### PR TITLE
Release v0.3.2

### DIFF
--- a/kpbj-api.cabal
+++ b/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.3.1
+version:            0.3.2
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.3.2

This PR bumps the version to 0.3.2

When merged, a git tag v0.3.2 will be automatically created, which triggers the production deployment