### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.4.1] - 2026-01-29
+
 ### Features
 - **Schedule Page Note** - Added informational note explaining that outside scheduled programming, KPBJ plays curated ephemeral content from hosts and DJs
 - **Schedule Page Dates** - Schedule page now shows the date (e.g., "Wednesday, Jan 28") in addition to the day of week

--- a/kpbj-api.cabal
+++ b/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.4.0
+version:            0.4.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.4.1

This PR releases version 0.4.1

### What's Changed


### Features
- **Schedule Page Note** - Added informational note explaining that outside scheduled programming, KPBJ plays curated ephemeral content from hosts and DJs
- **Schedule Page Dates** - Schedule page now shows the date (e.g., "Wednesday, Jan 28") in addition to the day of week

### Chores
- **Prod to Local Sync** - Added `just prod-to-local`, `just prod-to-local-db`, and `just prod-to-local-files` commands to copy production data to local development with PII sanitization

### Fixes
- **Episode Date Display Timezone** - Fixed episode scheduled dates displaying one day ahead (e.g., Feb 4th instead of Feb 3rd) for evening shows. The `scheduledAt` UTC timestamp is now properly converted to Pacific time before formatting. Added `tz` library dependency for DST-aware `America/Los_Angeles` timezone handling
- **Schedule Timezone Bug** - Fixed schedule template creation/editing using UTC instead of Pacific time, which caused an ~8 hour window where old and new templates could overlap incorrectly after editing
- **Staging Login Cookie Collision** - Fixed issue where production cookies (Domain=.kpbj.fm) were sent to staging (staging.kpbj.fm) causing login failures. Each environment now uses a unique cookie name: `session-id-staging` and `session-id-production`
- **File Upload MIME Types** - Fixed file uploads being rejected due to MIME type charset suffixes (e.g., `audio/mpeg; charset=binary` was not matching `audio/mpeg`)
- **Station ID Playback on S3** - Fixed station ID audio files not playing on staging/production. The template was hardcoding `/media/` URLs instead of using `buildMediaUrl` which generates proper S3 URLs in production

---

When merged, a git tag v0.4.1 will be automatically created, which triggers the production deployment.
