### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.4.2] - 2026-01-29
+
 ### Fixes
 - **Stream Player Now Playing** - Fixed stream player to show current track/DJ info from AzuraCast instead of hardcoded "KPBJ 95.9 FM". Now fetches from the AzuraCast Now Playing API and displays live DJ name or "Artist - Title" for playlist tracks
 - **Infinite Scroll Grid Layout** - Fixed blank spots appearing in grid layouts when infinite scroll loads new content. Sentinel and end-of-content elements now span full grid width

--- a/kpbj-api.cabal
+++ b/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.4.1
+version:            0.4.2
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.4.2

This PR releases version 0.4.2

### What's Changed


### Fixes
- **Stream Player Now Playing** - Fixed stream player to show current track/DJ info from AzuraCast instead of hardcoded "KPBJ 95.9 FM". Now fetches from the AzuraCast Now Playing API and displays live DJ name or "Artist - Title" for playlist tracks
- **Infinite Scroll Grid Layout** - Fixed blank spots appearing in grid layouts when infinite scroll loads new content. Sentinel and end-of-content elements now span full grid width

---

When merged, a git tag v0.4.2 will be automatically created, which triggers the production deployment.
