### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.5.0] - 2026-01-31
+
 ### Features
 - **Show Title on Schedule** - Schedule page now displays show title under the show image for better identification
 - **12 Hour Clock** - Render times with a 12 hour clock.

--- a/kpbj-api.cabal
+++ b/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.4.2
+version:            0.5.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.5.0

This PR releases version 0.5.0

### What's Changed


### Features
- **Show Title on Schedule** - Schedule page now displays show title under the show image for better identification
- **12 Hour Clock** - Render times with a 12 hour clock.
- **Simplified Event Details** - Removed back button and author section from event detail pages for cleaner presentation

### Fixes
- **Dark Mode Theme Colors** - Fixed ~30 files with hardcoded Tailwind colors (bg-gray-*, text-gray-*, border-gray-*) that caused white-on-white text and poor contrast in dark mode. All colors now use dynamic theme tokens from `Design.Tokens` that respect the user's theme preference.

### Chores
- **Weeder in CI** - Added dead code detection via Weeder to the CI pipeline
- **Design Tokens Cleanup** - Consolidated and cleaned up design token definitions across 64 files for better consistency
- **Factor out lucid-tailwind** - Extracted Tailwind CSS combinators (`cls`, `clsWhen`, breakpoint prefixes, state variants, grid utilities) into a standalone `lucid-tailwind` package for reuse across projects
- **Dead Code Cleanup** - Removed unused functions: `utcToPacificDay`, `EmailVerificationTokens.getByToken`, `EmailVerificationTokens.getLatestPendingForUser`, sync email functions (`sendEmail`, `sendVerificationEmail`, `sendPasswordResetEmail`, `sendHostAssignmentEmail`), `buildSimpleMail`, `claimStagedUploadMaybe`
- **Schedule Shows Filter** - Public schedule page now only displays shows that have assigned hosts
- **Remove OpenTelemetry** - Removed hs-opentelemetry dependency to simplify the codebase
- **Upstream Cookie Utils** - Migrated to upstream web-server-core cookie utilities, removing local implementations

### Fixes
- **Markdown Line Breaks** - Enabled hard line breaks in markdown rendering so single newlines render as `<br>` tags instead of being collapsed into spaces

---

When merged, a git tag v0.5.0 will be automatically created, which triggers the production deployment.
