### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.5.1] - 2026-02-01
+
 ### Features
 - **Stream Path Configuration** - Dashboard now allows setting the stream path for shows
 - **Pacific Time Show Storage** - Shows are now stored in Pacific time for consistent local scheduling

--- a/kpbj-api.cabal
+++ b/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.5.0
+version:            0.5.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.5.1

This PR releases version 0.5.1

### What's Changed


### Features
- **Stream Path Configuration** - Dashboard now allows setting the stream path for shows
- **Pacific Time Show Storage** - Shows are now stored in Pacific time for consistent local scheduling

### Fixes
- **Episode Form Time Localization** - Fixed time handling in episode forms to use correct timezone
- **Event DateTime UTC** - Event datetimes are now recorded in UTC for consistency
- **Episode Edit Cancel Redirect** - Fixed cancel button on episode edit form redirecting to wrong page

### Chores
- **Weeder Disabled** - Temporarily disabled Weeder dead code detection

---

When merged, a git tag v0.5.1 will be automatically created, which triggers the production deployment.
