### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.6.0] - 2026-02-01
+
 ### Features
 - **Liquidsoap Playout API** - Added two JSON API endpoints for Liquidsoap integration:
   - `GET /api/playout/now` - Returns the currently scheduled episode's audio URL based on schedule templates

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.5.1
+version:            0.6.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.6.0

This PR releases version 0.6.0

### What's Changed


### Features
- **Liquidsoap Playout API** - Added two JSON API endpoints for Liquidsoap integration:
  - `GET /api/playout/now` - Returns the currently scheduled episode's audio URL based on schedule templates
  - `GET /api/playout/fallback` - Returns a random ephemeral track URL for fallback playback
  - Both endpoints are public (no auth) and return `{"url": "..."}` or `null` with graceful error handling
- **Ephemeral Upload Edit Form** - Staff and admins can now edit ephemeral uploads (title and audio file) via the dashboard
- **Ephemeral Upload Download Button** - Added download button to ephemeral uploads table for easy file retrieval
- **Ephemeral Upload Filenames** - Ephemeral audio files now use the slugified title in the filename (e.g., `weather-report_2026-02-01_abc123.mp3`) instead of generic `ephemeral_` prefix

### Fixes
- **Episode Image Filepath Date Format** - Fixed date format in episode image file paths for consistent organization

### Chores
- **Monorepo Restructure** - Reorganized project into `services/` directory structure to support multiple services. Web application moved to `services/web/`, with placeholder for upcoming LiquidSoap streaming service at `services/liquidsoap/`. Root `cabal.project` now references all packages. Updated `flake.nix`, `Justfile`, CI workflows, and scripts with new paths.

---

When merged, a git tag v0.6.0 will be automatically created, which triggers the production deployment.
