### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.8.0] - 2026-02-11
+
 ### Features
 - **Episode Card Scrub Bar** - Added a progress/seek bar to episode card artwork. A thin bar at the bottom of the artwork image shows playback progress and supports click-to-seek and drag-to-scrub (mouse and touch). Clicking the bar while not playing starts playback at that position. Progress syncs with the persistent navbar player via `requestAnimationFrame`.
 - **Missing Episodes Dashboard** - Added admin page at `/dashboard/missing-episodes` showing shows scheduled within the next 7 days that are missing episode uploads (no episode or episode without audio). Table displays show title, hosts, scheduled date, day of week, and time slot, sorted by soonest deadline first. Accessible to staff and admin roles via the sidebar.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.7.0
+version:            0.8.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.8.0

This PR releases version 0.8.0

### What's Changed


### Features
- **Episode Card Scrub Bar** - Added a progress/seek bar to episode card artwork. A thin bar at the bottom of the artwork image shows playback progress and supports click-to-seek and drag-to-scrub (mouse and touch). Clicking the bar while not playing starts playback at that position. Progress syncs with the persistent navbar player via `requestAnimationFrame`.
- **Missing Episodes Dashboard** - Added admin page at `/dashboard/missing-episodes` showing shows scheduled within the next 7 days that are missing episode uploads (no episode or episode without audio). Table displays show title, hosts, scheduled date, day of week, and time slot, sorted by soonest deadline first. Accessible to staff and admin roles via the sidebar.
- **Liquidsoap Audio Processing** - Added normalization, compression, and limiting to the Liquidsoap broadcast chain. Normalizes volume across tracks (±6 dB range), compresses dynamic range (3:1 ratio, -10 dB threshold), and hard-limits at -1 dB to prevent clipping.

### Improvements
- **Scrollable Playback History** - Playback history table on the stream settings dashboard is now capped at ~15 visible rows with a scrollable container and sticky column headers.

### Fixes
- **Dashboard Nav Links Disabled on Non-Show Pages** - Fixed EPISODES and SHOW SETTINGS sidebar links being disabled when viewing STREAM or SITE PAGES. These handlers now fall back to the first available show so show-scoped nav links remain clickable.
- **Icecast Stream Choppy Audio on Refresh** - Fixed audio jumping between two buffers when refreshing the page during live stream playback. Added `beforeunload` handler to tear down the audio element before page unload, cache-busting on the stream URL to prevent stale connection reuse, and halved Icecast `burst-size` from 65536 to 32768 to reduce audio overlap on reconnect.

### Chores
- **SOPS-Managed Backup & Sync Credentials** - All backup and data sync scripts (`prod-backup-pg`, `prod-backup-s3`, `prod-to-staging-*`, `prod-to-local-*`) now load credentials from SOPS-encrypted `secrets/backup.yaml` instead of requiring env vars in `.envrc.local`. Added `load_secret` helper to `scripts/lib/common.sh`, new `just sops-edit-backup` command, and `prod-backup-s3.sh` falls back to env vars for TrueNAS cron contexts. Renamed `prod-backup` to `prod-backup-pg`.
- **SOPS-Managed Terraform State Backend Credentials** - `just tf-init` now loads state backend S3 keys from SOPS-encrypted `secrets/terraform.yaml` instead of requiring `TERRAFORM_ACCESS_KEY_ID` / `TERRAFORM_SECRET_ACCESS_KEY` env vars. Renamed `tf-edit-secrets` to `sops-edit-terraform` and grouped all `sops-edit-*` commands under a unified "SOPS Secrets" section.
- **Remove Deprecated Stream Deploy Commands** - Removed `just stream-staging-deploy` and `just stream-prod-deploy` Justfile recipes, replaced by NixOS deployment (`just nixos-deploy-staging` / `just nixos-deploy-prod`).

### Infrastructure
- **Terraform + SOPS Infrastructure** - Codified DigitalOcean streaming VPS (separate prod + staging droplets, firewalls, SSH keys) and Cloudflare DNS + proxy settings as Terraform. Secrets managed via SOPS + age encryption. Remote state in Tigris S3.
- **NixOS Streaming VPS** - Replaced Ubuntu/Docker Compose/manual nginx+certbot setup with fully declarative NixOS configuration. Droplets are provisioned via nixos-infect in Terraform user_data and configured with NixOS-managed nginx with automatic ACME/Let's Encrypt TLS and systemd service management. Deploy with `just nixos-deploy-staging` / `just nixos-deploy-prod` via `nixos-rebuild --target-host`.
- **Native Systemd Streaming Services** - Replaced Podman OCI containers with native systemd services for Icecast, Liquidsoap, and Webhook. Removes the container build/push/pull pipeline entirely — packages come directly from nixpkgs. Icecast and Liquidsoap run as `DynamicUser` with systemd hardening; Webhook runs as a static `kpbj-webhook` user with narrow NOPASSWD sudoers rules for restarting the other two services. Per-service sops-nix env files replace the single shared env template. Removed `stream-images.yml` CI workflow, `stream-dev-build`/`stream-dev-rebuild`/`stream-publish` Justfile recipes, and `icecast-docker`/`liquidsoap-docker`/`webhook-docker` Nix packages.
- **sops-nix for Streaming Secrets** - Streaming secrets (Icecast passwords, `PLAYOUT_SECRET`, `WEBHOOK_SECRET`) are now SOPS-encrypted in the repo under `secrets/` and decrypted on VPS at deploy time via sops-nix using the host's SSH key. Replaces per-VPS random secret generation. New Justfile commands (`just fly-sync-secrets-prod`, `just fly-sync-secrets-staging`) sync the same secrets to Fly.io. Consolidated all SOPS files into `secrets/` directory.
- **Consolidate Icecast source password** - Icecast entrypoint now reads `ICECAST_PASSWORD` for `<source-password>` (matching Liquidsoap), eliminating the separate `ICECAST_SOURCE_PASSWORD` variable.
- **Per-environment networking configs** - `nixos-setup` now captures nixos-infect's static IP networking config as `networking-staging.nix` / `networking-prod.nix`, imported by each environment's NixOS config. Replaces DHCP (which doesn't work reliably on DigitalOcean after nixos-infect).
- **Safe NixOS deploys** - `nixos-rebuild boot` + reboot instead of `nixos-rebuild switch` to avoid hangs on first deploy to freshly-infected hosts.

---

When merged, a git tag v0.8.0 will be automatically created, which triggers the production deployment.
