### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.8.1] - 2026-02-11
+
 ### Features
 - **Featured Event on Homepage** - Staff/admins can promote a single event's flyer to the homepage, replacing the default range map image. The flyer links to the event detail page via HTMX navigation. When no event is featured (or the featured event has no poster), the default FCC range map is shown. A "Promote"/"Demote" action in the events dashboard dropdown toggles the featured status, automatically clearing any previously featured event. A partial unique index enforces that at most one event can be featured at a time.
 

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.8.0
+version:            0.8.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.8.1

This PR releases version 0.8.1

### What's Changed


### Features
- **Featured Event on Homepage** - Staff/admins can promote a single event's flyer to the homepage, replacing the default range map image. The flyer links to the event detail page via HTMX navigation. When no event is featured (or the featured event has no poster), the default FCC range map is shown. A "Promote"/"Demote" action in the events dashboard dropdown toggles the featured status, automatically clearing any previously featured event. A partial unique index enforces that at most one event can be featured at a time.

### Chores
  - **Add description to episode detail page** - Episode descriptions were missing from the template.
  - **Dashboard design tuneups** - Various small adjustments to the dashboard design and layouts.

---

When merged, a git tag v0.8.1 will be automatically created, which triggers the production deployment.
