### PR TITLE
Release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.8.3] - 2026-02-13
+
 ### Fixes
 - **Slot-Level Schedule Diffing** - Schedule updates now use set-difference logic instead of nuke-and-rebuild. When a staff member changes a show's schedule, only removed slots have their validity terminated and only added slots get new templates created — unchanged slots are left alone entirely. Previously, any schedule edit (e.g. adding a Monday slot to a show with an existing Friday slot) would destroy and recreate all templates, orphaning episodes that hosts had uploaded for upcoming airings. When the schedule hasn't changed at all, the update is skipped entirely to avoid unnecessary DB round-trips.
 - **New Schedule Templates Default to Airs Twice Daily** - Schedule templates created via the new show and edit show forms now set `airs_twice_daily = TRUE`, enabling automatic replay airings for all new schedule slots.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.8.2
+version:            0.8.3
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.8.3

This PR releases version 0.8.3

### What's Changed


### Fixes
- **Slot-Level Schedule Diffing** - Schedule updates now use set-difference logic instead of nuke-and-rebuild. When a staff member changes a show's schedule, only removed slots have their validity terminated and only added slots get new templates created — unchanged slots are left alone entirely. Previously, any schedule edit (e.g. adding a Monday slot to a show with an existing Friday slot) would destroy and recreate all templates, orphaning episodes that hosts had uploaded for upcoming airings. When the schedule hasn't changed at all, the update is skipped entirely to avoid unnecessary DB round-trips.
- **New Schedule Templates Default to Airs Twice Daily** - Schedule templates created via the new show and edit show forms now set `airs_twice_daily = TRUE`, enabling automatic replay airings for all new schedule slots.

### Chores
- **DayOfWeek Text Cleanup** - Renamed `dayOfWeekToText` to `dayOfWeekToPostgres` to clarify it's for PostgreSQL enum encoding. Added `Display DayOfWeek` instance for human-readable UI text. Removed duplicate `dayOfWeekToText` in `Form.hs` and `dayOfWeekName` in `Components.hs`, consolidating both into `OrphanInstances.DayOfWeek`.

### Infrastructure
- **Token Cleanup Batch Job** - Extracted background token cleanup from the web server process into a standalone `token-cleanup` executable run by a systemd timer (hourly). Deletes expired pending tokens and purges tokens older than 90 days from `email_verification_tokens` and `password_reset_tokens`. Supports `--dry-run` mode (enabled on staging). Reads `DATABASE_URL` from the existing `kpbj-web.env` SOPS template. Removed `Effects.BackgroundJobs` module, `CleanupInterval` config, and `Async.withAsync` wiring from the web server.
- **pgBackRest Automated Backups** - Added NixOS module (`nixos/pgbackrest.nix`) for automatic PostgreSQL backups using pgBackRest with WAL archiving for point-in-time recovery (PITR). Daily full backups with 14-day retention, zstd compression, local repository at `/var/lib/pgbackrest`. Stanza initialization runs as a oneshot service after PostgreSQL starts. Replaces the old `fly proxy` + `pg_dump` approach from Fly.io-managed database.
- **Object Storage Migration to DigitalOcean Spaces** - Migrated both staging and production object storage from Tigris (Fly.io) to DigitalOcean Spaces (SFO3). Terraform manages Spaces buckets with `public-read` ACL. Sync scripts now use per-environment endpoints (`PROD_ENDPOINT`/`STAGING_ENDPOINT`) instead of a single `TIGRIS_ENDPOINT`. Added one-time migration script (`scripts/migrate-tigris-to-spaces.sh`) and ACL fix script (`scripts/staging-fix-acls.sh`).
- **Production DNS Cutover to DigitalOcean** - Switched all production DNS records (`kpbj.fm`, `www`, `stream`, `uploads`) from Fly.io to the DigitalOcean VPS via Terraform-managed Cloudflare DNS. ACME/Let's Encrypt certificates issued via HTTP-01 challenge after DNS propagation.
- **PostgreSQL 17** - Upgraded from PostgreSQL 16 to 17 in the NixOS module.
- **Configurable SSL/ACME** - Added `enableSSL` option (default `true`) to both `nginx.nix` and `web.nix` NixOS modules, allowing SSL to be disabled for initial deploys before DNS cutover.
- **Per-Host PostgreSQL Version Pinning** - Replaced the hardcoded PostgreSQL package in the shared `postgresql.nix` module with a required `pgPackage` option that each host must set explicitly. Prevents accidental major-version upgrades (which destroy the data directory) from propagating silently across environments.
- **Pre-Deploy Database Backup in Production CI** - The production deploy workflow now runs a full pgBackRest backup via SSH before `nixos-rebuild switch`, ensuring a fresh restore point exists before every production deploy. If the backup fails, the deploy aborts.
- **SSH Tunnel + Dedicated DB Roles** - Replaced root SSH + `sudo -u postgres psql` with SSH tunnel connections using dedicated PostgreSQL roles. Added `kpbj_readonly` and `kpbj_readwrite` roles to the NixOS PostgreSQL module with appropriate grants (`SELECT`-only vs full DML). `just prod-psql` and `just staging-psql` now connect via SSH tunnel as `kpbj_readonly` by default; pass `--write` for `kpbj_readwrite`. Eliminates the need for root VPS access just to run queries.
- **Migrate Scripts from Fly.io to SSH Tunnels** - Replaced all `fly proxy` database connections with SSH tunnels to the VPS. Added `open_ssh_tunnel` helper to `scripts/lib/common.sh` that handles stale tunnel cleanup and PID management. Backup and sync scripts (`prod-to-staging-db`, `prod-to-local-db`, `prod-backup-pg`, and their wrappers) now use `kpbj_readonly` for production `pg_dump` operations. Removed `PROD_DB_APP` constant, added `PROD_VPS_TARGET` and `PROD_READONLY_USER`.

### Fixes
- **Bare Domain SSL Error** - Visiting `https://kpbj.fm` returned `ERR_CERT_COMMON_NAME_INVALID` because DNS pointed to the VPS but nginx had no vhost or certificate for the bare domain. Added an nginx vhost in `prod.nix` that obtains its own ACME cert for `kpbj.fm` and 301-redirects to `www.kpbj.fm`.
- **Uploads Subdomain Broken on Production** - The nginx vhost for uploads was constructed as `uploads.www.kpbj.fm` (from `uploads.${cfg.domain}` where domain is `www.kpbj.fm`) instead of the expected `uploads.kpbj.fm`. Requests never reached the app, causing CORS errors on audio uploads. Added an explicit `uploadsDomain` option to the web NixOS module with a sensible default, overridden in prod to `uploads.kpbj.fm`. Staging was unaffected because its domain has no `www.` prefix.
- **Stream Settings Resilience** - Stream settings dashboard and metadata proxy no longer crash when Icecast is down or returns non-JSON responses (e.g. 404 HTML). Switched from `httpJSON` (which throws uncaught `JSONException`) to `httpLBS` with manual JSON decoding. Added 5-second response timeout to both endpoints.
- **S3 Base URL Derived from Endpoint** - The public-facing media URL was hardcoded to `fly.storage.tigris.dev`, which broke file uploads after migrating staging off Fly.io. The base URL is now derived from the configured `AWS_ENDPOINT_URL_S3` endpoint. A new optional `S3_BASE_URL` env var allows explicit override for custom domains or CDNs.
- **S3 Public-Read ACL on Uploads** - Added `ObjectCannedACL_Public_read` to all S3 `PutObject` and `CopyObject` operations in `Effects/Storage/S3.hs`. DigitalOcean Spaces does not inherit bucket-level ACLs to objects (unlike Tigris), so each upload must explicitly set the ACL for files to be publicly accessible.

---

When merged, a git tag v0.8.3 will be automatically created, which triggers the production deployment.
