### PR TITLE
Release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.8.4] - 2026-02-13
+
 ### Infrastructure
 - **Terraform State Migration to DigitalOcean Spaces** - Migrated Terraform remote state backend from Tigris S3 to DigitalOcean Spaces (SFO3), completing the full migration off Tigris.
 

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.8.3
+version:            0.8.4
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.8.4

This PR releases version 0.8.4

### What's Changed


### Infrastructure
- **Terraform State Migration to DigitalOcean Spaces** - Migrated Terraform remote state backend from Tigris S3 to DigitalOcean Spaces (SFO3), completing the full migration off Tigris.

### Fixes
- **pgBackRest WAL Archiving Broken by Systemd Sandbox** - PostgreSQL's `ProtectSystem=strict` sandbox made `/var/lib/pgbackrest` read-only for the `archive_command`, preventing WAL archiving and blocking pre-deploy backups in CI. Added `ReadWritePaths` for the pgBackRest repo path to the PostgreSQL service configuration.

---

When merged, a git tag v0.8.4 will be automatically created, which triggers the production deployment.
