### PR TITLE
Release v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.8.5] - 2026-02-16
+
 ### Features
 - **Force Episode Escape Hatch** - Admins can now force-play a specific episode immediately from the stream settings dashboard, bypassing the normal schedule. A search-by-show-name input finds episodes with audio, and a "FORCE PLAY" button pushes the episode directly to Liquidsoap via the webhook service. Adds a `force_play` telnet command to Liquidsoap, a `callWebhookWithPayload` function for sending JSON to webhooks, and a new `force-play-episode` webhook hook with NixOS and Docker scripts.
 - **Skip Track** - Admins can skip the currently playing scheduled track from the stream settings dashboard, immediately dropping to fallback audio. Adds a `skip_track` telnet command to Liquidsoap that clears the scheduled state and skips the source. New `POST /dashboard/stream-settings/skip-track` endpoint with confirmation dialog. "Container Management" section renamed to "Stream Controls" to reflect the broader scope.

--- a/nixos/monitoring.nix
+++ b/nixos/monitoring.nix
@@ -79,6 +79,18 @@ in
     };
 
     # ── Promtail — scrapes journald, ships to Loki ─────────────
+    #
+    # Disable namespace sandboxing — the NixOS module enables
+    # PrivateTmp / ProtectSystem by default, which requires
+    # user-namespace support.  Some VPS kernels block this,
+    # causing ExecStartPre to exit 226/NAMESPACE.
+    systemd.services.promtail.serviceConfig = {
+      PrivateTmp = lib.mkForce false;
+      ProtectSystem = lib.mkForce false;
+      ProtectHome = lib.mkForce false;
+      PrivateDevices = lib.mkForce false;
+    };
+
     services.promtail = {
       enable = true;
       configuration = {

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.8.4
+version:            0.8.5
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.8.5

This PR releases version 0.8.5

### What's Changed


### Features
- **Force Episode Escape Hatch** - Admins can now force-play a specific episode immediately from the stream settings dashboard, bypassing the normal schedule. A search-by-show-name input finds episodes with audio, and a "FORCE PLAY" button pushes the episode directly to Liquidsoap via the webhook service. Adds a `force_play` telnet command to Liquidsoap, a `callWebhookWithPayload` function for sending JSON to webhooks, and a new `force-play-episode` webhook hook with NixOS and Docker scripts.
- **Skip Track** - Admins can skip the currently playing scheduled track from the stream settings dashboard, immediately dropping to fallback audio. Adds a `skip_track` telnet command to Liquidsoap that clears the scheduled state and skips the source. New `POST /dashboard/stream-settings/skip-track` endpoint with confirmation dialog. "Container Management" section renamed to "Stream Controls" to reflect the broader scope.
- **Stop/Start Stream** - Admins can stop or start the entire stream from the dashboard. Stop shuts down Liquidsoap then Icecast; Start brings up Icecast then Liquidsoap. Danger-styled stop button and success-styled start button with confirmation dialogs. Adds `stop-stream` and `start-stream` webhook hooks with corresponding NixOS scripts and sudoers rules.
- **Google Group Host Sync** - The `sync-host-emails` batch job now syncs Google Group membership with hosts in the database. Queries users who have the Host role or are actively assigned to a show (via `show_hosts`), computes the set difference against the Google Group, and adds/removes members to match. Uses rel8 for the database query and a single OAuth2 token for all API calls. `--dry-run` prints the diff without making changes. The NixOS systemd service now reads `DATABASE_URL` from the existing `kpbj-web.env` and depends on PostgreSQL.

### Fixes
- **Twice-Daily Shows Skipped on Replay Airing** - Liquidsoap's `last_scheduled` deduplication state was never cleared between show airings, so when a show's replay airing came around (e.g. 8am → 8pm), it was rejected as a duplicate. The schedule API returned the correct episode, but Liquidsoap logged "Same show as before, not replaying" and continued playing fallback content. Now clears `last_scheduled` after 2 consecutive empty schedule polls, with a single-poll grace period to protect against transient API/DB errors mid-show.
- **Episode Soft Delete Test Assertion Mismatch** - `prop_deleteEpisode` was asserting that `getEpisodeById` returns a deleted episode, but `getEpisodeById` correctly filters on `deleted_at IS NULL`. Updated the test to verify that `getEpisodeById` returns `Nothing` after soft deletion, confirming the episode is properly hidden.

### Infrastructure
- **Grafana + Loki + Promtail Monitoring** - Added centralized log aggregation via a new `nixos/monitoring.nix` NixOS module. Promtail scrapes journald for all `kpbj-*`, `postgresql`, and `icecast` units and ships logs to Loki. Grafana is pre-configured with Loki as a datasource. All services bind to localhost only — access via SSH tunnel (`just staging-grafana` / `just prod-grafana`). Enabled on both staging and production.
- **NixOS VM for Local Streaming Dev** - Replaced Docker Compose streaming stack with a NixOS QEMU VM that runs the exact same `streaming.nix` configuration as staging/prod. Eliminates divergent codepaths (container name mismatches, missing tools in containers). The VM port-forwards Icecast (8000) and webhook (9000) to the host and uses the developer's existing age key for sops decryption. New Justfile recipes: `stream-dev-build`, `stream-dev-start`, `stream-dev-stop`, `stream-dev-ssh`, `stream-dev-logs`. Deleted `docker-compose.yml` and `force-play-docker.sh`.
- **CI Cache Improvements** - Overhauled GitHub Actions caching strategy for faster builds and deploys:
  - Updated `cachix/install-nix-action` from v20 to v31 and `cachix/cachix-action` from v12 to v15
  - Added `pushFilter` to Cachix so only project derivations are cached (stops pushing all of nixpkgs)
  - Added `nix-community/cache-nix-action` as a fast GitHub Actions cache layer on top of Cachix
  - Staging deploys now wait for CI build to complete (`workflow_run` trigger) so they pull `kpbj-api` from warm cache instead of rebuilding
  - CI now builds the full NixOS staging closure on main branch pushes, warming the cache for both staging and production deploys
  - Removed unused `extra-platforms = aarch64-linux` from deploy workflows

### Chores
- **Remove Docker/GHCR Artifacts** - Removed `packages.docker`, `packages.publish`, `apps.publish` from `flake.nix` and deleted `services/web/docker.nix`. Removed `flyctl` from devShell. These were leftovers from the Fly.io migration.

---

When merged, a git tag v0.8.5 will be automatically created, which triggers the production deployment.
