### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.9.0] - 2026-02-26
+
 ### Added
 - **Styled 404 Page for Unmatched Routes** — Visiting a URL that doesn't match any route (e.g. `/nonexistent`) now renders a full HTML 404 page with the site frame (header, nav, footer, music player) instead of an empty response. Implemented as WAI middleware that intercepts non-HTML 404 responses from Servant's router and replaces them with a pre-rendered page. Handler-level 404s (e.g. `/shows/bad-slug`) are unchanged.
 - **Source URL in Playback History** — Liquidsoap now records the original audio URL (instead of a temp file path) in playback history via a `source_url` annotation on all track types (episodes, fallbacks, force-play). The stream settings dashboard displays the source URL beneath each track title for easier debugging.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.8.5
+version:            0.9.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.9.0

This PR releases version 0.9.0

### What's Changed


### Added
- **Styled 404 Page for Unmatched Routes** — Visiting a URL that doesn't match any route (e.g. `/nonexistent`) now renders a full HTML 404 page with the site frame (header, nav, footer, music player) instead of an empty response. Implemented as WAI middleware that intercepts non-HTML 404 responses from Servant's router and replaces them with a pre-rendered page. Handler-level 404s (e.g. `/shows/bad-slug`) are unchanged.
- **Source URL in Playback History** — Liquidsoap now records the original audio URL (instead of a temp file path) in playback history via a `source_url` annotation on all track types (episodes, fallbacks, force-play). The stream settings dashboard displays the source URL beneath each track title for easier debugging.

### Changed
- **Remove Redundant Dashboard Page Title** — Removed the `h1` page title from the dashboard top bar since the sidebar already highlights the active page. Cleaned up the unused `navTitle` function.

### Fixed
- **Correct HTTP Status Codes for Public Error Pages** — `handlePublicErrors` now returns proper HTTP status codes (404 for not found, 500 for server errors, etc.) instead of always returning 200. HTMX requests still receive 200 so content swaps proceed normally. This ensures search engines and browsers see correct error semantics for public-facing pages like show detail, episode detail, and show blog.
- **HTML Entities Rendered Literally in Audio Player** — Icecast metadata containing HTML entities (e.g. `&#8217;`) now gets decoded before display in the persistent music player. Previously, `x-text` bindings rendered entities as literal text instead of the intended characters.

### Security
- **XSS in Redirect Banner** — The `bannerFromUrlScript` now HTML-escapes `_title` and `_msg` query parameters before injecting them via `innerHTML`. Previously, crafted URLs could execute arbitrary HTML/JS through these parameters.
- **Stop Logging Plaintext Passwords (C1)** — Registration handler log calls no longer serialize the full request body (which included the password). Logs now emit only email and display name. The upstream root cause (`Password` `ToJSON`/`Display` instances in `web-server-core`) is also fixed in the updated pin.
- **MIME Validation Fail Closed (C2)** — When libmagic throws an exception during file upload validation, the upload is now rejected (`Left`) instead of silently accepted (`Right`). Previously, a libmagic failure would bypass content-type verification entirely.
- **Session IDs Use CSPRNG (H2)** — New migration switches `server_sessions.id` default from `uuid_generate_v1mc()` (time-based, leaks server MAC and creation timestamp) to `gen_random_uuid()` (v4, CSPRNG-backed). All existing sessions are truncated to force re-login with secure IDs.
- **Session Fixation Prevention (H3)** — Login now always expires the user's existing session before creating a new one. Previously, if a session already existed, the old session ID was reused, enabling session fixation attacks.
- **Login Rate Limiting (H4)** — Added nginx `limit_req_zone` (5 requests/minute per IP, burst of 3) for `/user/login` and `/user/register` endpoints. Returns 429 Too Many Requests when exceeded.
- **Private ACL for S3 Staging Uploads (H5)** — Staged file uploads now use `ObjectCannedACL_Private` instead of `ObjectCannedACL_Public_read`. Files are only made public when moved from staging to their final location via `claimAndRelocateUpload`.
- **Stored XSS via Show Title (M2)** — Applied `escapeJsString` to show title and audio URL interpolations in Alpine `x-data` attributes on the dashboard episode templates. Applied `sanitizeTitle` to show title in the show edit handler to strip dangerous content at write time.
- **Logout Clears Browser Cookie (L3)** — Logout handlers (GET and POST) now send a `Set-Cookie` header with `Max-Age=0` via `mkCookieSessionExpired` to clear the session cookie from the browser. Previously, only the server-side session was expired, leaving a stale cookie in the browser.
- **Upstream web-server-core Security Fixes** — Updated `web-server-core` pin to include: `Password` type no longer has `ToJSON`/`Display` instances (prevents accidental password logging), session idle timeout tracking (`last_activity_at`), and multi-session cap (max 5 active sessions per user, replacing the single-session trigger).

### Removed
- **Old Session Cookie Backward-Compatibility Code** — Removed `mkExpireOldSessionCookie` and the second `Set-Cookie` header it powered in the login and verify-email handlers. This code expired pre-2026-01-28 cookies that lacked a `Domain` attribute. With all sessions long since rotated, the compat shim is no longer needed. Deletes `App.Cookie` module and its tests.

### Developer Experience
- **E2E Tests Auto-Reload Mock Data** - `just e2e`, `just e2e-ui`, and `just e2e-headed` now run `dev-mock-data` as a dependency before launching Playwright, ensuring a clean database slate for every test run.

### Infrastructure
- **Dedicated SSH Deploy DNS Records** - Added `ssh.kpbj.fm` and `ssh.staging.kpbj.fm` DNS-only A records in Cloudflare for CI/CD SSH access, separating deploy targets from proxied web hostnames. Deploy workflows now use these instead of `stream.kpbj.fm` / `staging.kpbj.fm`.
- **Pinned SSH Host Keys** - Replaced runtime `ssh-keyscan` in deploy workflows with pinned known host keys stored in GitHub Actions secrets. Eliminates MITM risk from trusting first-connect keys and removes the network call that was failing when Cloudflare-proxied hostnames couldn't be reached on port 22.
- **GitHub Terraform Provider** - Added `integrations/github` provider to manage GitHub Actions secrets (`PRODUCTION_KNOWN_HOST`, `STAGING_KNOWN_HOST`) from SOPS-encrypted values, keeping host key management in the same Terraform workflow as DNS and infrastructure.

### Tests
- **Multi-Timeslot Currently Airing Tests** — Added 5 tests to `CurrentlyAiringSpec` verifying that `getCurrentlyAiringEpisode` returns the correct episode when a show has multiple timeslots (e.g., 9–11 AM and 2–4 PM). Tests assert the right episode and audio file are returned for each slot, and Nothing between/before/after all slots.
- **Playwright E2E Test Suite (Public Site)** - Added ~280 end-to-end tests across 11 spec files using Playwright, covering all public-facing pages: homepage (featured event, newsletter signup, stream player), shows (filter panel, search, tag/status/sort filters, infinite scroll, empty state), show detail, episode detail, blog, events, schedule, navigation, 404 pages, and smoke tests. Tests run against mock data with a live dev server.
- **Playwright E2E Test Suite (Dashboard)** - Added 11 dashboard spec files covering authentication, role-based access control, and CRUD operations. Tests pre-authenticate as admin, staff, host, and user roles via a setup phase that saves session state. Role tests verify sidebar visibility, show selector rendering (multi-show `<select>` vs single-show `<span>`), and URL-based access denial (hosts redirected from admin routes, users blocked from all dashboard routes). CRUD specs cover events, station blog, show blog, users, profile settings, and site pages — including create/edit/delete flows with confirm dialogs, inline role changes, suspend/unsuspend, site page revision history, and revision restore.
- **Mobile E2E Tests** - Added mobile-specific test suite (`mobile.spec.ts`) covering hamburger menu navigation, collapsible shows filter panel, and mobile player controls. Desktop-only tests (nav links, volume slider, filter panel) are automatically skipped on mobile projects.
- **Multi-Browser Testing** - Playwright config updated with separate project groups: public site tests run across Chromium, Firefox, iPhone 13, and Pixel 5 viewports; dashboard tests run in a dedicated `authenticated` project that depends on the auth setup phase. WebKit disabled on NixOS due to WPE EGL display incompatibility.
- **Site Pages Mock Data** - Added `20_site_pages.sql` seeding About KPBJ, Privacy Policy, and Terms of Service pages for dashboard e2e tests.
- **Playwright Station ID Upload Tests** - Added `station-ids-crud.spec.ts` with e2e tests covering station ID audio upload, edit, and delete flows from the dashboard.
- **Playwright Ephemeral Upload Tests** - Added `ephemeral-uploads-crud.spec.ts` with e2e tests covering list empty state, upload form fields and editorial guidelines, client/server validation, and a serial create/verify/delete flow with staged audio upload.
- **Playwright Episode Upload Tests** - Added `episodes-crud.spec.ts` with e2e tests covering episode list with mock data, upload form fields and scheduled date select, client/server validation, and a serial create/verify-detail/verify-list/archive flow. Uses HOST_AUTH for create (host is assigned to the show) and ADMIN_AUTH for archive (staff+ only).
- **Logout Cookie Clearing E2E Test** - Strengthened the logout e2e test to assert that the `session-id-development` cookie is removed from the browser after logout, validating the new `Set-Cookie` clearing header.

### Infrastructure
- **Nix GC Retention Reduced** - Reduced automatic Nix garbage collection retention from 30 days to 7 days (`common.nix`). Staging VPS ran out of disk space due to stale store paths accumulating between weekly GC runs. Applies to both staging and production.
- **Cloudflare Proxy Enabled** - Switched production (root + www) and staging DNS records from DNS-only to proxied through Cloudflare for DDoS protection and edge caching. Upload subdomains remain DNS-only to avoid Cloudflare request size limits on large audio uploads. Added ACME challenge TXT records for DNS-01 SSL certificate validation, required now that proxied mode blocks HTTP-01 challenges.

### Fixes
- **Test WarpConfig Missing Field** - Fixed `testWarpConfig` in test harness missing the `warpConfigRequestTimeout` field added upstream, which blocked the test suite from compiling.
- **Mock Data Schema Sync** - Fixed mock data SQL files that broke against the current schema: removed dropped `is_primary` column from `show_hosts` inserts, removed dropped `status` column from `episodes` inserts, added `featured_on_homepage` column to events with one featured upcoming event, updated events to include future 2026 dates so "upcoming events" queries return results, and fixed blog tag assignment query that could only assign one tag per post (CASE inside IN only returns one value) by rewriting as a VALUES join.
- **Shows Filter Form Duplicate Listeners** - The shows page filter form (`renderFilters`) was rendered twice (mobile + desktop) with the same `id="show-filters"`. The inline `<script>` used `getElementById`, which always returns the first (mobile) form — so the mobile form got two submit listeners and the desktop form got none. Desktop filtering only worked by accident (falling back to default HTML form submission). Fixed by switching to `querySelectorAll` with a guard flag so each form gets exactly one listener, and replaced the non-functional `pushUrl` option in `htmx.ajax()` with explicit `history.pushState()`.

### Refactoring
- **ExceptT Error Handling** - Migrated all ~90 handlers from exception-based error handling (`MonadThrow`/`MonadCatch`) to explicit `ExceptT HandlerError AppM`. Errors are now visible in types and can't be accidentally dropped. The `HandlerError` type is no longer an `Exception` instance — throw helpers use `throwE` instead of `throwM`, and handler wrappers use `runExceptT` instead of `catch`.
- **Handler/Action Split** - Extracted business logic from every handler into a standalone `action` function that runs in `ExceptT HandlerError AppM` and returns a typed view-data record. Handlers are now thin glue that composes `action` with HTTP response formatting (redirects, banners, headers). This separation makes business logic independently testable without constructing HTTP requests.
- **Centralized Public Error Pages** - Removed per-template `notFoundTemplate` and `errorTemplate` functions from ~6 public page template modules. Error content is now rendered by `notFoundContent` and `errorContent` in `App.Handler.Error`, giving all public pages consistent error presentation.
- **Inline Error Rendering for Public Pages** - Added `handlePublicErrors` error handler that renders not-found and other content errors inline at the same URL instead of redirecting visitors to the homepage. Auth errors still redirect to login. Previously, a missing show or blog post would redirect to `/` with a banner — now visitors see a contextual "not found" page at the URL they requested.
- **Combinators Use ExceptT** - Authorization combinators (`requireAuth`, `requireHostNotSuspended`, `requireStaffNotSuspended`, `requireAdminNotSuspended`, `requireShowHostOrStaff`, `requireJust`, `requireRight`) now operate in `ExceptT HandlerError AppM` instead of requiring `MonadThrow` constraints.
- **Error Response Consolidation** - Extracted `errorRedirectParams :: Link -> HandlerError -> (Text, BannerParams)` as a single source of truth for error-to-redirect mapping, used by both `handleHtmlErrors` (client-side redirect) and `handleRedirectErrors` (HX-Redirect header). Removed the duplicated `mkErrorRedirect` and `mkHtmlErrorRedirect` functions.

### Tests
- **Handler Integration Tests** - Added ~70 new test files covering handler `action` functions against a real test database. Tests verify auth checks (role hierarchy, suspension), not-found paths, happy-path CRUD, and business logic edge cases. Every dashboard section (blogs, shows, episodes, events, users, ephemeral uploads, site pages, station blog, station IDs, stream settings) and public page (home, shows, blog, events, schedule) has test coverage.
- **Combinator Tests** - Added `CombinatorsSpec` with 18 test cases covering `requireHostNotSuspended`, `requireStaffNotSuspended`, `requireAdminNotSuspended`, `requireShowHostOrStaff`, `requireJust`, and `requireRight` against real database state including suspended users and cross-show host checks.
- **Test Infrastructure** - Added `Test.Handler.Monad` (`bracketAppM`) to bridge the existing `TestDBConfig` to a full `AppContext`, enabling `AppM` actions in tests. Added `Test.Handler.Fixtures` with shared helpers: `mkUserInsert`, `setupUserModels`, `expectSetupRight`, `defaultScheduleInsert`, `nonExistentId`. Shared `noOpLoggerEnv` between database and handler test suites. Added `runDBTransaction` method to `MonadDB` test instance. New database helpers: `insertTestBlogPost`, `insertTestShowBlogPost`, `insertTestEvent`, `insertTestEpisode`, `insertTestEphemeralUpload`, `insertTestStationId`, `addTestShowHost`, `verifyTestUserEmail`.
- **`-Werror` on Test Suite** - Test suite GHC options now include `-Werror` to catch unused imports and incomplete patterns at compile time.
- **Upload Type Generator Coverage** - `StagedUploadsSpec` generator now covers `StationIdAudio` and `EphemeralAudio` in addition to `EpisodeAudio`.

### Additions
- **`getBlogPostBySlug`** - New database query in `Effects.Database.Tables.BlogPosts` for fetching blog posts by slug.
- **`fromMaybeM`** - New utility in `Utils` for monadic `Maybe` unwrapping, complementing the existing `fromRightM`.

### Fixes
- **Promtail/Loki Port Conflict** - Promtail failed to start because Loki's default gRPC server was already bound to port 9095. Disabled Promtail's unused gRPC server (`grpc_listen_port = 0`) and explicitly bound Loki's gRPC to localhost.
- **Loki Query Frontend Unreachable** - Loki queries hung indefinitely because the internal query frontend worker tried to deliver results via the server's public IP, which was unreachable after binding gRPC to localhost. Added `frontend_worker.frontend_address = "127.0.0.1:9095"` so all internal gRPC traffic routes through localhost.
- **Liquidsoap False "Playout POST Failed" Logs** - The `POST /api/playout/played` endpoint returns 204 No Content, but Liquidsoap only accepted 200 as success, logging false failures on every track change. Updated the status check to accept any 2xx response.
- **Test Database Teardown Error Message** - Fixed misleading "Failed to create test database" error message during test teardown — now correctly says "Failed to drop test database".
- **Audio Upload Timeout on Slow Connections** - The uploads nginx vhost was missing proxy and client body timeouts, defaulting to 60 seconds. Large audio files on slower connections would exceed this limit, causing nginx to kill the connection and trigger a "Network error during upload" in the browser. Added `proxy_read_timeout`, `proxy_send_timeout`, and `client_body_timeout` (600s each) to the uploads vhost.
- **Warp Request Timeout for Large Uploads** - Extended the Warp application-level request timeout to 600 seconds (`APP_WARP_REQUEST_TIMEOUT`), matching the nginx proxy timeout. Without this, the Haskell web server would terminate long-running upload requests before nginx did, producing confusing partial-upload failures.
- **File Upload Memory Exhaustion** - Switched the staged upload pipeline from reading entire files into memory (`Mem` backend) to streaming through temp files (`Tmp` backend). Large audio uploads (up to 500MB) could spike server memory and trigger OOM kills. The pipeline now reads the Servant temp file directly, validates MIME type and size on disk, and streams to storage without buffering the full file in memory. Added structured `StagedUploadError` type with `ExceptT`-based error handling for the upload pipeline.

---

When merged, a git tag v0.9.0 will be automatically created, which triggers the production deployment.
