### PR TITLE
feat: make episode schedule optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ### Added
 - **Off-Site S3 Backups for PostgreSQL** — pgBackRest now supports an optional second repository (repo2) on S3-compatible storage (DigitalOcean Spaces) for off-site disaster recovery. Local repo1 remains for fast restores. Credentials are wired through SOPS and read from disk on the server. S3 failures are treated as warnings — local backups always complete. Daily backups and WAL archiving target both repos when enabled. Setting `s3 = null` reverts to local-only backups.
+- **Optional Episode Schedule** — Episodes can now exist without a schedule slot. This supports episodes created before a show has a schedule, or episodes detached when a schedule template is invalidated.
+  - `UNSCHEDULED` badge shown in the dashboard episode list
+  - "Scheduled: Unscheduled" displayed on the episode detail page
+  - Edit form allows assigning a schedule slot to unscheduled episodes
+  - Unscheduled episodes sort last in the dashboard list
+  - Unscheduled episodes are excluded from public published episodes
+  - E2E tests for schedule state transitions and property tests for unscheduled episode behavior
+
+### Changed
+- **Episode Schedule Columns Now Nullable** — `schedule_template_id` and `scheduled_at` columns on `episodes` are no longer `NOT NULL`. A `CHECK` constraint ensures both fields are either `NULL` or both `NOT NULL`.
 
 ---
 

--- a/e2e/tests/dashboard/episode-schedule.spec.ts
+++ b/e2e/tests/dashboard/episode-schedule.spec.ts
@@ -1,0 +1,271 @@
+import { test, expect } from "@playwright/test";
+import { ADMIN_AUTH, HOST_AUTH } from "../../playwright.config";
+
+// ---------------------------------------------------------------------------
+// Episode Schedule State Transition tests
+//
+// Covers the schedule section behaviour on the episode edit form:
+// - Unscheduled episodes (NULL schedule_template_id / scheduled_at)
+// - Scheduled episodes (has a schedule slot)
+// - State transitions: keep unscheduled, assign slot, keep slot, reschedule
+// - Host visibility: past episodes hide the schedule section
+//
+// Depends on mock-data/10a_unscheduled_episodes.sql inserting one unscheduled
+// episode for sunday-morning-jazz with description
+// "Unscheduled jazz episode for e2e testing".
+//
+// Form builder note: the select field always renders a disabled "Select..."
+// placeholder as the first <option>. Template options added via addOption are
+// NOT pre-selected, so the placeholder is the default selected option.
+// ---------------------------------------------------------------------------
+
+const SHOW_SLUG = "sunday-morning-jazz";
+const LIST_URL = `/dashboard/episodes/${SHOW_SLUG}`;
+const UNSCHEDULED_DESC = "Unscheduled jazz episode for e2e testing";
+
+// ---------------------------------------------------------------------------
+// Helper: find a row by description text and navigate to its edit page.
+// ---------------------------------------------------------------------------
+async function navigateToEditByDescription(
+  page: import("@playwright/test").Page,
+  description: string,
+) {
+  await page.goto(LIST_URL);
+  const row = page.locator("#episodes-table-body tr", {
+    hasText: description,
+  });
+  await expect(row).toBeVisible();
+  // Use the actions dropdown to navigate to edit
+  await row.locator("select").selectOption("edit");
+  await page.waitForURL(/\/dashboard\/episodes\/sunday-morning-jazz\/\d+\/edit/);
+}
+
+// Helper: submit the edit form and wait for redirect back to the episode list.
+// The HTMX form POSTs and returns HX-Redirect to the list page.
+async function submitAndWaitForList(
+  page: import("@playwright/test").Page,
+) {
+  await page.getByRole("button", { name: "SAVE CHANGES" }).click();
+  // Wait until we leave the /edit page — HTMX redirects to the list URL.
+  await page.waitForURL((url) => !url.pathname.includes("/edit"));
+  await expect(page.locator("#banner-container")).toContainText(/updated/i);
+}
+
+// ---------------------------------------------------------------------------
+// Unscheduled episode display (ADMIN)
+// ---------------------------------------------------------------------------
+
+test.describe("Unscheduled episode display", () => {
+  test.use({ storageState: ADMIN_AUTH });
+
+  test("unscheduled episode shows UNSCHEDULED badge in list", async ({
+    page,
+  }) => {
+    await page.goto(LIST_URL);
+    const row = page.locator("#episodes-table-body tr", {
+      hasText: UNSCHEDULED_DESC,
+    });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("UNSCHEDULED");
+  });
+
+  test("unscheduled episode detail shows Scheduled: Unscheduled", async ({
+    page,
+  }) => {
+    await page.goto(LIST_URL);
+    const row = page.locator("#episodes-table-body tr", {
+      hasText: UNSCHEDULED_DESC,
+    });
+    await expect(row).toBeVisible();
+    // Click the row to navigate to detail page
+    await row.locator("td").first().click();
+    await page.waitForURL(
+      /\/dashboard\/episodes\/sunday-morning-jazz\/\d+/,
+    );
+    // Use locator scoped to the metadata grid to avoid matching the description
+    await expect(
+      page.locator("text=Scheduled: Unscheduled"),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Past episode schedule visibility (HOST)
+// ---------------------------------------------------------------------------
+
+test.describe("Past episode schedule visibility", () => {
+  test.use({ storageState: HOST_AUTH });
+
+  test("host cannot see schedule section for past episodes", async ({
+    page,
+  }) => {
+    await page.goto(LIST_URL);
+    // All mock episodes from 10_episodes.sql are in the past (past 3 weeks).
+    // Find a row that is NOT the unscheduled one (those are the scheduled past episodes).
+    const rows = page.locator("#episodes-table-body tr");
+    await expect(rows.first()).toBeVisible();
+
+    // Pick a past scheduled episode (any row not containing the unscheduled description)
+    const pastRow = page
+      .locator("#episodes-table-body tr")
+      .filter({ hasNotText: UNSCHEDULED_DESC })
+      .first();
+    await expect(pastRow).toBeVisible();
+
+    // Navigate to its edit page via actions dropdown
+    await pastRow.locator("select").selectOption("edit");
+    await page.waitForURL(
+      /\/dashboard\/episodes\/sunday-morning-jazz\/\d+\/edit/,
+    );
+
+    // The schedule slot section should NOT be visible for a past episode
+    // when the user is a host (not staff).
+    // The section title "SCHEDULE SLOT" should not appear.
+    await expect(page.getByText("SCHEDULE SLOT")).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schedule state transitions (ADMIN, serial)
+//
+// These tests are serial because T3 changes the episode from
+// unscheduled → scheduled, which T4 and T5 depend on.
+//
+// The form builder's select field has a disabled "Select..." placeholder
+// that is selected by default. The template's addOption calls are NOT
+// pre-selected, so we must explicitly select the desired option.
+// ---------------------------------------------------------------------------
+
+test.describe("Schedule state transitions", () => {
+  test.use({ storageState: ADMIN_AUTH });
+
+  test.describe.serial("schedule transitions", () => {
+    // T2: Keep unscheduled episode unscheduled on edit
+    test("keep unscheduled episode unscheduled on edit", async ({ page }) => {
+      await navigateToEditByDescription(page, UNSCHEDULED_DESC);
+
+      // The schedule select should be visible
+      const select = page.locator('select[name="scheduled_date"]');
+      await expect(select).toBeVisible();
+
+      // The "Unscheduled (Current)" option should exist
+      const unschedOption = select.locator("option", {
+        hasText: "Unscheduled (Current)",
+      });
+      await expect(unschedOption).toBeAttached();
+
+      // Explicitly select the "Unscheduled" option (value "") to keep it unscheduled
+      await select.selectOption({ label: "Unscheduled (Current)" });
+
+      // Submit and wait for redirect
+      await submitAndWaitForList(page);
+
+      // Verify episode is still unscheduled in the list
+      const row = page.locator("#episodes-table-body tr", {
+        hasText: UNSCHEDULED_DESC,
+      });
+      await expect(row).toContainText("UNSCHEDULED");
+    });
+
+    // T3: Assign schedule slot to unscheduled episode
+    test("assign schedule slot to unscheduled episode", async ({ page }) => {
+      await navigateToEditByDescription(page, UNSCHEDULED_DESC);
+
+      const select = page.locator('select[name="scheduled_date"]');
+      await expect(select).toBeVisible();
+
+      // Pick the first available (non-empty, non-disabled) schedule slot
+      const firstOption = select.locator(
+        "option:not([value='']):not([disabled])",
+      ).first();
+      await expect(firstOption).toBeAttached();
+      const slotValue = await firstOption.getAttribute("value");
+      expect(slotValue).toBeTruthy();
+      await select.selectOption(slotValue!);
+
+      // Submit and wait for redirect
+      await submitAndWaitForList(page);
+
+      // Verify episode is no longer unscheduled in the list
+      const row = page.locator("#episodes-table-body tr", {
+        hasText: UNSCHEDULED_DESC,
+      });
+      await expect(row).toBeVisible();
+      await expect(row).not.toContainText("UNSCHEDULED");
+    });
+
+    // T4: Keep current slot on scheduled episode
+    test("keep current slot on scheduled episode", async ({ page }) => {
+      await navigateToEditByDescription(page, UNSCHEDULED_DESC);
+
+      const select = page.locator('select[name="scheduled_date"]');
+      await expect(select).toBeVisible();
+
+      // Find the "(Current)" option — it's the current schedule slot
+      const currentOption = select.locator("option", {
+        hasText: "(Current)",
+      });
+      await expect(currentOption).toBeAttached();
+      const currentValue = await currentOption.getAttribute("value");
+      expect(currentValue).toBeTruthy();
+
+      // Explicitly select the current slot (form defaults to "Select..." placeholder)
+      await select.selectOption(currentValue!);
+
+      // Submit and wait for redirect
+      await submitAndWaitForList(page);
+
+      // Verify episode is still scheduled (no UNSCHEDULED badge)
+      const row = page.locator("#episodes-table-body tr", {
+        hasText: UNSCHEDULED_DESC,
+      });
+      await expect(row).toBeVisible();
+      await expect(row).not.toContainText("UNSCHEDULED");
+    });
+
+    // T5: Reschedule episode to different slot
+    test("reschedule episode to different slot", async ({ page }) => {
+      await navigateToEditByDescription(page, UNSCHEDULED_DESC);
+
+      const select = page.locator('select[name="scheduled_date"]');
+      await expect(select).toBeVisible();
+
+      // Find the current slot value
+      const currentOption = select.locator("option", {
+        hasText: "(Current)",
+      });
+      await expect(currentOption).toBeAttached();
+      const currentValue = await currentOption.getAttribute("value");
+
+      // Find a different slot (non-empty, non-disabled, not the current one)
+      const allSlotOptions = select.locator(
+        "option:not([value='']):not([disabled])",
+      );
+      const optionCount = await allSlotOptions.count();
+      // Need at least 2 options (current + at least one alternative)
+      expect(optionCount).toBeGreaterThanOrEqual(2);
+
+      // Pick the first option whose value differs from the current slot
+      let altValue: string | null = null;
+      for (let i = 0; i < optionCount; i++) {
+        const val = await allSlotOptions.nth(i).getAttribute("value");
+        if (val && val !== currentValue) {
+          altValue = val;
+          break;
+        }
+      }
+      expect(altValue).toBeTruthy();
+      await select.selectOption(altValue!);
+
+      // Submit and wait for redirect
+      await submitAndWaitForList(page);
+
+      // Verify episode is still scheduled (no UNSCHEDULED badge)
+      const row = page.locator("#episodes-table-body tr", {
+        hasText: UNSCHEDULED_DESC,
+      });
+      await expect(row).toBeVisible();
+      await expect(row).not.toContainText("UNSCHEDULED");
+    });
+  });
+});

--- a/services/web/migrations/20260227010050_make_episode_schedule_template_optional.sql
+++ b/services/web/migrations/20260227010050_make_episode_schedule_template_optional.sql
@@ -1,0 +1,8 @@
+ALTER TABLE episodes ALTER COLUMN schedule_template_id DROP NOT NULL;
+ALTER TABLE episodes ALTER COLUMN scheduled_at DROP NOT NULL;
+
+ALTER TABLE episodes ADD CONSTRAINT episodes_schedule_consistency
+  CHECK (
+    (schedule_template_id IS NULL AND scheduled_at IS NULL) OR
+    (schedule_template_id IS NOT NULL AND scheduled_at IS NOT NULL)
+  );

--- a/services/web/mock-data/10a_unscheduled_episodes.sql
+++ b/services/web/mock-data/10a_unscheduled_episodes.sql
@@ -1,0 +1,8 @@
+-- Unscheduled Episodes
+-- One unscheduled episode for sunday-morning-jazz (used by e2e schedule tests)
+
+INSERT INTO episodes (show_id, schedule_template_id, description, scheduled_at, published_at, created_by)
+SELECT s.id, NULL, 'Unscheduled jazz episode for e2e testing', NULL, NOW(), u.id
+FROM shows s
+JOIN users u ON u.email = 'host-sunday-morning-jazz@kpbj.fm'
+WHERE s.slug = 'sunday-morning-jazz';

--- a/services/web/mock-data/load-all.sql
+++ b/services/web/mock-data/load-all.sql
@@ -51,6 +51,10 @@
 \i 10_episodes.sql
 
 \echo ''
+\echo '10a. Creating unscheduled episodes...'
+\i 10a_unscheduled_episodes.sql
+
+\echo ''
 \echo '11. Creating staff and regular users...'
 \i 11_staff_and_users.sql
 

--- a/services/web/src/API/Dashboard/Episodes/Get/Templates/EpisodeRow.hs
+++ b/services/web/src/API/Dashboard/Episodes/Get/Templates/EpisodeRow.hs
@@ -10,7 +10,7 @@ where
 
 import API.Links (dashboardEpisodesLinks)
 import API.Types (DashboardEpisodesRoutes (..))
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, isNothing)
 import Data.String.Interpolate (i)
 import Data.Text qualified as Text
 import Design (base, class_)
@@ -70,14 +70,18 @@ renderEpisodeTableRow userMeta showModel episode = do
 
     -- Scheduled date (converted to Pacific time)
     Lucid.td_ cellLinkAttrs $
-      Lucid.toHtml $
-        formatPacificDate episode.scheduledAt
+      case episode.scheduledAt of
+        Nothing -> mempty
+        Just sa -> Lucid.toHtml $ formatPacificDate sa
 
-    -- Status column - only show badge if archived
+    -- Status column
     Lucid.td_ cellLinkAttrs $
       if isArchived
         then Lucid.span_ [class_ $ base ["inline-block", Tokens.errorBg, Tokens.errorText, "px-2", "py-1", "rounded", Tokens.textXs, Tokens.fontBold]] "ARCHIVED"
-        else mempty
+        else
+          if isNothing episode.scheduleTemplateId
+            then Lucid.span_ [class_ $ base ["inline-block", Tokens.warningBg, Tokens.warningText, "px-2", "py-1", "rounded", Tokens.textXs, Tokens.fontBold]] "UNSCHEDULED"
+            else mempty
 
     -- Actions dropdown
     Lucid.td_ [class_ $ base [Tokens.p4, "text-center"]] $

--- a/services/web/src/API/Dashboard/Episodes/Slug/Edit/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Episodes/Slug/Edit/Get/Handler.hs
@@ -28,7 +28,6 @@ import Data.Text.Display (display)
 import Data.Time (getCurrentTime)
 import Domain.Types.Cookie (Cookie (..))
 import Domain.Types.HxRequest (HxRequest (..), foldHxReq)
-import Domain.Types.Limit (Limit (..))
 import Domain.Types.Slug (Slug)
 import Effects.Database.Execute (execQuery, execTransaction)
 import Effects.Database.Tables.EpisodeTags qualified as EpisodeTags
@@ -179,20 +178,23 @@ fetchEpisodeTags episodeId =
 fetchCurrentSlot ::
   Episodes.Model ->
   AppM (Maybe ShowSchedule.UpcomingShowDate)
-fetchCurrentSlot episode =
-  execQuery (ShowSchedule.getScheduleTemplateById episode.scheduleTemplateId) >>= \case
-    Left err -> do
-      Log.logAttention "Failed to fetch schedule template" (show err)
-      pure Nothing
-    Right Nothing -> pure Nothing
-    Right (Just scheduleTemplate) ->
-      pure $ Just $ ShowSchedule.makeUpcomingShowDateFromTemplate scheduleTemplate episode.scheduledAt
+fetchCurrentSlot episode = case (episode.scheduleTemplateId, episode.scheduledAt) of
+  (Nothing, _) -> pure Nothing
+  (_, Nothing) -> pure Nothing
+  (Just templateId, Just sa) ->
+    execQuery (ShowSchedule.getScheduleTemplateById templateId) >>= \case
+      Left err -> do
+        Log.logAttention "Failed to fetch schedule template" (show err)
+        pure Nothing
+      Right Nothing -> pure Nothing
+      Right (Just scheduleTemplate) ->
+        pure $ Just $ ShowSchedule.makeUpcomingShowDateFromTemplate scheduleTemplate sa
 
 fetchUpcomingDates ::
   Shows.Id ->
   AppM [ShowSchedule.UpcomingShowDate]
 fetchUpcomingDates showId =
-  execQuery (ShowSchedule.getUpcomingUnscheduledShowDates showId (Limit 52)) >>= \case
+  execQuery (ShowSchedule.getUpcomingUnscheduledShowDates showId 4) >>= \case
     Left err -> do
       Log.logAttention "Failed to fetch upcoming dates" (show err)
       pure []

--- a/services/web/src/API/Dashboard/Episodes/Slug/Edit/Get/Templates/Form.hs
+++ b/services/web/src/API/Dashboard/Episodes/Slug/Edit/Get/Templates/Form.hs
@@ -25,7 +25,7 @@ import Domain.Types.Slug (Slug)
 import Domain.Types.StorageBackend (StorageBackend, buildMediaUrl)
 import Effects.Database.Tables.EpisodeTags qualified as EpisodeTags
 import Effects.Database.Tables.EpisodeTrack qualified as EpisodeTrack
-import Effects.Database.Tables.Episodes qualified as Episodes (Model, artworkUrl, audioFilePath, description, episodeNumber, scheduledAt)
+import Effects.Database.Tables.Episodes qualified as Episodes (Model, artworkUrl, audioFilePath, description, episodeNumber, isUnaired)
 import Effects.Database.Tables.ShowSchedule qualified as ShowSchedule
 import Effects.Database.Tables.Shows qualified as Shows
 import Lucid qualified
@@ -67,9 +67,6 @@ episodeIndexUrl showSlug = rootLink $ dashboardEpisodesLinks.list showSlug Nothi
 
 --------------------------------------------------------------------------------
 
--- | Check if the episode's scheduled date is in the future (allowing file uploads)
-isScheduledInFuture :: UTCTime -> Episodes.Model -> Bool
-isScheduledInFuture now episode = episode.scheduledAt > now
 
 -- | Episode edit template.
 --
@@ -104,7 +101,7 @@ template ctx = do
     episodeBackUrl = episodeIndexUrl showModel.slug
     descriptionValue = fromMaybe "" episode.description
     -- File uploads allowed if scheduled date is in the future OR user is staff/admin
-    allowFileUpload = isScheduledInFuture currentTime episode || isStaff
+    allowFileUpload = Episodes.isUnaired currentTime episode || isStaff
     audioUrl = maybe "" (buildMediaUrl backend) episode.audioFilePath
     artworkUrl = maybe "" (buildMediaUrl backend) episode.artworkUrl
 
@@ -137,36 +134,32 @@ template ctx = do
         -- Schedule slot section (only shown if episode is in future or user is staff)
         when (allowFileUpload || isStaff) $ do
           section "SCHEDULE SLOT" $ do
-            case mCurrentSlot of
-              Nothing ->
-                -- No template found, show raw scheduled date
+            case (mCurrentSlot, upcomingDates) of
+              (Nothing, []) ->
+                -- Unscheduled with no available slots — read-only display
                 plain $
                   Lucid.div_ $ do
                     Lucid.label_ [class_ $ base ["block", Tokens.fontBold, Tokens.mb2]] "Scheduled Date"
                     Lucid.div_
                       [class_ $ base [Tokens.fullWidth, Tokens.p3, Tokens.border2, Tokens.borderDefault, Tokens.bgAlt, "font-mono", Tokens.textSm]]
-                      (Lucid.toHtml $ "Current: " <> display episode.scheduledAt)
+                      "Unscheduled"
                     Lucid.p_
                       [class_ $ base [Tokens.textSm, Tokens.fgMuted, "mt-2", "italic"]]
-                      "Schedule template not found. To change, cancel and create a new episode."
-              Just currentSlot ->
-                if null upcomingDates
-                  then plain $
-                    Lucid.div_ $ do
-                      Lucid.label_ [class_ $ base ["block", Tokens.fontBold, Tokens.mb2]] "Scheduled Date"
-                      Lucid.div_
-                        [class_ $ base [Tokens.fullWidth, Tokens.p3, Tokens.border2, Tokens.borderDefault, Tokens.bgAlt, "font-mono", Tokens.textSm]]
-                        (Lucid.toHtml $ display currentSlot <> " (Current)")
-                      Lucid.p_
-                        [class_ $ base [Tokens.textSm, Tokens.fgMuted, "mt-2", "italic"]]
-                        "No other available time slots. To change, cancel and create a new episode."
-                  else selectField "scheduled_date" $ do
-                    label "Scheduled Date"
-                    hint "Choose when this episode will air"
-                    -- Current slot as first option (preselected), rendered same as upcoming dates
-                    addOption (encodeScheduleValue currentSlot) (display currentSlot <> " (Current)")
-                    -- Other available slots
-                    mapM_ (\usd -> addOption (encodeScheduleValue usd) (display usd)) upcomingDates
+                      "No available time slots."
+              (Nothing, _) ->
+                -- Unscheduled with available slots — allow assigning
+                selectField "scheduled_date" $ do
+                  label "Scheduled Date"
+                  hint "Choose when this episode will air"
+                  addOption "" "Unscheduled (Current)"
+                  mapM_ (\usd -> addOption (encodeScheduleValue usd) (display usd)) upcomingDates
+              (Just currentSlot, _) ->
+                -- Scheduled — allow rescheduling
+                selectField "scheduled_date" $ do
+                  label "Scheduled Date"
+                  hint "Choose when this episode will air"
+                  addOption (encodeScheduleValue currentSlot) (display currentSlot <> " (Current)")
+                  mapM_ (\usd -> addOption (encodeScheduleValue usd) (display usd)) upcomingDates
 
         textareaField "description" 6 $ do
           label "Description"

--- a/services/web/src/API/Dashboard/Episodes/Slug/Edit/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Episodes/Slug/Edit/Post/Handler.hs
@@ -144,14 +144,6 @@ parseScheduleValue txt =
       Right (tid, time)
     _ -> Left $ "Invalid schedule format: " <> txt
 
--- | Check if the episode's scheduled date is in the future (allowing file uploads)
-isScheduledInFuture :: UTCTime -> Episodes.Model -> Bool
-isScheduledInFuture now episode = episode.scheduledAt > now
-
--- | Check if the episode's scheduled date has passed
-isScheduledInPast :: UTCTime -> Episodes.Model -> Bool
-isScheduledInPast now episode = episode.scheduledAt <= now
-
 --------------------------------------------------------------------------------
 
 updateEpisode ::
@@ -166,7 +158,7 @@ updateEpisode ::
 updateEpisode _showSlug _episodeNumber _user userMetadata episode showModel editForm = do
   currentTime <- currentSystemTime
   let isStaffOrAdmin = UserMetadata.isStaffOrHigher userMetadata.mUserRole
-      isPast = isScheduledInPast currentTime episode
+      isPast = Episodes.isAired currentTime episode
 
   -- 1. Validation phase (throws on error)
   validDescription <- validateDescription (eefDescription editForm)
@@ -211,7 +203,7 @@ execOptionalUpdates ::
   EpisodeEditForm ->
   AppM [Text] -- Returns list of warning messages
 execOptionalUpdates userId currentTime isStaffOrAdmin isPast episode showModel editForm = do
-  let allowFileUpload = isScheduledInFuture currentTime episode || isStaffOrAdmin
+  let allowFileUpload = Episodes.isUnaired currentTime episode || isStaffOrAdmin
 
   -- File uploads
   fileWarning <- processFileUploadsWithWarning userId allowFileUpload showModel episode editForm
@@ -284,14 +276,15 @@ processScheduleUpdate ::
   AppM [Text]
 processScheduleUpdate isPast isStaffOrAdmin episode editForm =
   case eefScheduledDate editForm of
-    Nothing -> pure []
+    Nothing -> pure [] -- Field absent, no change
+    Just "" -> pure [] -- "Unscheduled" selected, stay unscheduled
     Just scheduleDateValue -> do
       case parseScheduleValue scheduleDateValue of
         Left parseErr -> do
           Log.logInfo "Failed to parse schedule value" parseErr
           pure ["Schedule update failed: " <> parseErr]
         Right (newTemplateId, newScheduledAt) -> do
-          let scheduleChanged = newTemplateId /= episode.scheduleTemplateId || newScheduledAt /= episode.scheduledAt
+          let scheduleChanged = Just newTemplateId /= episode.scheduleTemplateId || Just newScheduledAt /= episode.scheduledAt
           if not scheduleChanged
             then pure []
             else
@@ -354,6 +347,12 @@ processFileUploads userId showModel episode editForm = do
   storageBackend <- asks getter
   mAwsEnv <- asks getter
 
+  -- Get the air date for file organization (use current time as fallback).
+  -- NOTE: File paths are set at upload time and never relocated on reschedule.
+  -- If downloads are added later, generate user-facing filenames from episode
+  -- metadata (scheduled_at, slug, etc.) rather than relying on storage paths.
+  airDate <- maybe currentSystemTime pure episode.scheduledAt
+
   -- Process audio: staged upload, then move to final location with air date
   audioResult <- case eefAudioToken editForm of
     Just token -> do
@@ -365,7 +364,7 @@ processFileUploads userId showModel episode editForm = do
           StagedUploads.EpisodeAudio
           AudioBucket
           EpisodeAudio
-          episode.scheduledAt
+          airDate
           (display showModel.slug)
       pure $ case result of
         Left err -> Left err
@@ -378,7 +377,7 @@ processFileUploads userId showModel episode editForm = do
     Just artworkFile
       | isEmptyUpload artworkFile -> pure $ Right Nothing
       | otherwise -> do
-          result <- FileUpload.uploadEpisodeArtwork storageBackend mAwsEnv showModel.slug (Just episode.scheduledAt) artworkFile
+          result <- FileUpload.uploadEpisodeArtwork storageBackend mAwsEnv showModel.slug (Just airDate) artworkFile
           case result of
             Left err -> do
               Log.logInfo "Failed to upload artwork file" (Text.pack $ show err)

--- a/services/web/src/API/Dashboard/Episodes/Slug/Get/Templates/Page.hs
+++ b/services/web/src/API/Dashboard/Episodes/Slug/Get/Templates/Page.hs
@@ -67,9 +67,15 @@ template backend _userMeta showModel episode tracks tags = do
               else mempty
 
             -- Aired/Scheduled date (converted to Pacific time)
-            Lucid.div_ $ do
-              Lucid.span_ [class_ $ base [Tokens.fontBold, Tokens.fgMuted]] "Scheduled: "
-              Lucid.toHtml (formatPacificDateLong episode.scheduledAt)
+            case episode.scheduledAt of
+              Nothing ->
+                Lucid.div_ $ do
+                  Lucid.span_ [class_ $ base [Tokens.fontBold, Tokens.fgMuted]] "Scheduled: "
+                  "Unscheduled"
+              Just sa ->
+                Lucid.div_ $ do
+                  Lucid.span_ [class_ $ base [Tokens.fontBold, Tokens.fgMuted]] "Scheduled: "
+                  Lucid.toHtml (formatPacificDateLong sa)
 
             -- Published date
             case episode.publishedAt of

--- a/services/web/src/API/Dashboard/Shows/New/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/New/Post/Handler.hs
@@ -326,8 +326,8 @@ checkScheduleConflicts showId = go
           let weeks = map fromIntegral (weeksOfMonth slot)
           execQuery (ShowSchedule.checkTimeSlotConflict showId dow weeks start end) >>= \case
             Left err -> do
-              Log.logInfo "Failed to check schedule conflict" (Text.pack $ show err)
-              pure (Right ()) -- Don't block on DB errors, let it through
+              Log.logAttention "Failed to check schedule conflict" (Text.pack $ show err)
+              pure (Left "Unable to verify schedule availability. Please try again.")
             Right (Just conflictingShow) ->
               pure (Left $ "Schedule conflict: " <> dayOfWeek slot <> " " <> startTime slot <> "-" <> endTime slot <> " overlaps with \"" <> conflictingShow <> "\"")
             Right Nothing -> go rest

--- a/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Handler.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 
@@ -47,6 +48,7 @@ import Domain.Types.Timezone (LocalTime (..), utcToPacific)
 import Effects.Clock (currentSystemTime)
 import Effects.ContentSanitization (sanitizeTitle)
 import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Episodes qualified as Episodes
 import Effects.Database.Tables.ShowHost qualified as ShowHost
 import Effects.Database.Tables.ShowSchedule qualified as ShowSchedule
 import Effects.Database.Tables.ShowTags qualified as ShowTags
@@ -381,8 +383,8 @@ checkScheduleConflicts showId = go
       let weeks = map fromIntegral (pssWeeks slot)
       execQuery (ShowSchedule.checkTimeSlotConflict showId (pssDay slot) weeks (pssStart slot) (pssEnd slot)) >>= \case
         Left err -> do
-          Log.logInfo "Failed to check schedule conflict" (Text.pack $ show err)
-          pure (Right ()) -- Don't block on DB errors, let it through
+          Log.logAttention "Failed to check schedule conflict" (Text.pack $ show err)
+          pure (Left "Unable to verify schedule availability. Please try again.")
         Right (Just conflictingShow) ->
           pure (Left $ "Schedule conflict: " <> Text.pack (show (pssDay slot)) <> " " <> formatTimeHHMM (pssStart slot) <> "-" <> formatTimeHHMM (pssEnd slot) <> " overlaps with \"" <> conflictingShow <> "\"")
         Right Nothing -> go rest
@@ -472,6 +474,11 @@ updateScheduleTemplates showId activeTemplates parsedSlots today = do
       forM_ activeValidities $ \validity -> do
         _ <- execQuery (ShowSchedule.endValidity validity.stvId today)
         Log.logInfo "Closed out schedule validity" (show template.stId, show validity.stvId)
+
+      -- Detach upcoming episodes from this expired template
+      execQuery (Episodes.clearTemplateForUpcomingEpisodes template.stId) >>= \case
+        Left err -> Log.logAttention "Failed to clear template from episodes" (show err)
+        Right ids -> Log.logInfo "Detached episodes from expired template" (show template.stId, length ids)
 
   -- For each added slot, create a fresh template and an open-ended validity
   -- period starting from today.

--- a/services/web/src/API/Dashboard/Shows/Slug/Episode/New/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Episode/New/Post/Handler.hs
@@ -172,8 +172,8 @@ processEpisodeUpload _userMetadata user showModel form = do
                             Episodes.eiAudioMimeType = Nothing, -- TODO: Get from upload
                             Episodes.eiDurationSeconds = episodeData.durationSeconds,
                             Episodes.eiArtworkUrl = artworkPath,
-                            Episodes.eiScheduleTemplateId = episodeData.scheduleTemplateId,
-                            Episodes.eiScheduledAt = episodeData.scheduledAt,
+                            Episodes.eiScheduleTemplateId = Just episodeData.scheduleTemplateId,
+                            Episodes.eiScheduledAt = Just episodeData.scheduledAt,
                             Episodes.eiCreatedBy = User.mId user
                           }
 
@@ -296,7 +296,10 @@ processFileUploads ::
   -- | (audioPath, artworkPath)
   AppM (Either Text (Maybe Text, Maybe Text))
 processFileUploads backend mAwsEnv userId showSlug mScheduledDate mArtworkFile mAudioToken = do
-  -- Get the air date for file organization (use current time as fallback)
+  -- Get the air date for file organization (use current time as fallback).
+  -- NOTE: File paths are set at upload time and never relocated on reschedule.
+  -- If downloads are added later, generate user-facing filenames from episode
+  -- metadata (scheduled_at, slug, etc.) rather than relying on storage paths.
   airDate <- maybe currentSystemTime pure mScheduledDate
 
   -- Process main audio file (always required)

--- a/services/web/src/API/Dashboard/Shows/Slug/Get/Templates/Episode.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Get/Templates/Episode.hs
@@ -60,7 +60,9 @@ renderLatestEpisode backend showModel episode tracks = do
             ]
             $ Lucid.toHtml (show epNum)
         Lucid.div_ [class_ $ base [Tokens.textSm, Tokens.fgMuted, Tokens.mb2]] $ do
-          "Aired: " <> Lucid.toHtml (formatPacificDateLong episode.scheduledAt)
+          case episode.scheduledAt of
+            Just sa -> "Aired: " <> Lucid.toHtml (formatPacificDateLong sa)
+            Nothing -> "Unscheduled"
 
           case episode.durationSeconds of
             Just duration ->
@@ -206,7 +208,9 @@ renderEpisodeCard backend showModel episode = do
           $ Lucid.toHtml (show epNum)
 
       Lucid.div_ [class_ $ base [Tokens.textSm, Tokens.fgMuted, Tokens.mb2]] $ do
-        "Aired: " <> Lucid.toHtml (formatPacificDateLong episode.scheduledAt)
+        case episode.scheduledAt of
+          Just sa -> "Aired: " <> Lucid.toHtml (formatPacificDateLong sa)
+          Nothing -> "Unscheduled"
 
         case episode.durationSeconds of
           Just duration -> " • Duration: " <> Lucid.toHtml (show (duration `div` 60)) <> "min"

--- a/services/web/src/API/Dashboard/StreamSettings/Episodes/Search/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/StreamSettings/Episodes/Search/Get/Handler.hs
@@ -97,7 +97,9 @@ renderResultRow sr = do
         Lucid.toHtml sr.srShowTitle
       Lucid.div_ [class_ $ base [Tokens.fgMuted, Tokens.textXs, "flex", "gap-3"]] $ do
         Lucid.span_ [] $ Lucid.toHtml ([i|Ep. #{epNum}|] :: Text)
-        Lucid.span_ [] $ Lucid.toHtml $ formatDate sr.srScheduledAt
+        case sr.srScheduledAt of
+          Just sa -> Lucid.span_ [] $ Lucid.toHtml $ formatDate sa
+          Nothing -> mempty
         case sr.srDurationSeconds of
           Just dur -> Lucid.span_ [] $ Lucid.toHtml $ formatDuration dur
           Nothing -> mempty

--- a/services/web/src/Component/Card/Episode.hs
+++ b/services/web/src/Component/Card/Episode.hs
@@ -65,7 +65,9 @@ renderEpisodeCard backend showModel episode = do
       renderArtworkWithPlayer backend epUrl mArtworkUrl
 
       -- Episode date
-      renderEpisodeDate episode.scheduledAt
+      case episode.scheduledAt of
+        Just sa -> renderEpisodeDate sa
+        Nothing -> mempty
 
 --------------------------------------------------------------------------------
 -- Component Functions

--- a/services/web/src/Effects/Database/Tables/Episodes.hs
+++ b/services/web/src/Effects/Database/Tables/Episodes.hs
@@ -21,6 +21,8 @@ module Effects.Database.Tables.Episodes
 
     -- * Model (Result alias)
     Model,
+    isUnaired,
+    isAired,
 
     -- * Insert Type
     Insert (..),
@@ -42,6 +44,7 @@ module Effects.Database.Tables.Episodes
     updateEpisodeFiles,
     updateScheduledSlot,
     deleteEpisode,
+    clearTemplateForUpcomingEpisodes,
 
     -- * Result Types
     EpisodeWithShow (..),
@@ -128,8 +131,8 @@ data Episode f = Episode
     audioMimeType :: Column f (Maybe Text),
     durationSeconds :: Column f (Maybe Int64),
     artworkUrl :: Column f (Maybe Text),
-    scheduleTemplateId :: Column f ShowSchedule.TemplateId,
-    scheduledAt :: Column f UTCTime,
+    scheduleTemplateId :: Column f (Maybe ShowSchedule.TemplateId),
+    scheduledAt :: Column f (Maybe UTCTime),
     publishedAt :: Column f (Maybe UTCTime),
     deletedAt :: Column f (Maybe UTCTime),
     createdBy :: Column f User.Id,
@@ -159,6 +162,16 @@ instance Display (Episode Result) where
 --
 -- @Model@ is the same as @Episode Result@.
 type Model = Episode Result
+
+-- | An episode is unaired if it has no scheduled date or its date is in the future.
+isUnaired :: UTCTime -> Model -> Bool
+isUnaired currentTime episode = case episode.scheduledAt of
+  Nothing -> True
+  Just sa -> sa > currentTime
+
+-- | An episode has aired if it has a scheduled date that has passed.
+isAired :: UTCTime -> Model -> Bool
+isAired currentTime = not . isUnaired currentTime
 
 -- | Table schema connecting the Haskell type to the database table.
 episodeSchema :: TableSchema (Episode Name)
@@ -223,8 +236,8 @@ data Insert = Insert
     eiAudioMimeType :: Maybe Text,
     eiDurationSeconds :: Maybe Int64,
     eiArtworkUrl :: Maybe Text,
-    eiScheduleTemplateId :: ShowSchedule.TemplateId,
-    eiScheduledAt :: UTCTime,
+    eiScheduleTemplateId :: Maybe ShowSchedule.TemplateId,
+    eiScheduledAt :: Maybe UTCTime,
     eiCreatedBy :: User.Id
   }
   deriving stock (Generic, Show, Eq)
@@ -282,8 +295,8 @@ data EpisodeWithShow = EpisodeWithShow
     ewsAudioMimeType :: Maybe Text,
     ewsDurationSeconds :: Maybe Int64,
     ewsArtworkUrl :: Maybe Text,
-    ewsScheduleTemplateId :: ShowSchedule.TemplateId,
-    ewsScheduledAt :: UTCTime,
+    ewsScheduleTemplateId :: Maybe ShowSchedule.TemplateId,
+    ewsScheduledAt :: Maybe UTCTime,
     ewsPublishedAt :: Maybe UTCTime,
     ewsDeletedAt :: Maybe UTCTime,
     ewsCreatedBy :: User.Id,
@@ -302,7 +315,7 @@ data SearchResult = SearchResult
   { srId :: Id,
     srShowTitle :: Text,
     srEpisodeNumber :: EpisodeNumber,
-    srScheduledAt :: UTCTime,
+    srScheduledAt :: Maybe UTCTime,
     srDurationSeconds :: Maybe Int64
   }
   deriving stock (Generic, Show, Eq)
@@ -323,7 +336,8 @@ getPublishedEpisodesForShow currentTime showId' (Limit lim) (Offset off) =
             ep <- each episodeSchema
             where_ $ ep.showId ==. lit showId'
             where_ $ isNull ep.deletedAt
-            where_ $ ep.scheduledAt <=. lit currentTime
+            where_ $ isNonNull ep.scheduledAt
+            where_ $ ep.scheduledAt <=. nullify (lit currentTime)
             pure ep
 
 -- | Get episodes for a show (for hosts viewing their own show).
@@ -335,7 +349,7 @@ getEpisodesForShow showId' (Limit lim) (Offset off) =
     select $
       Rel8.limit (fromIntegral lim) $
         Rel8.offset (fromIntegral off) $
-          orderBy ((.scheduledAt) >$< desc) do
+          orderBy ((.scheduledAt) >$< nullsLast desc) do
             ep <- each episodeSchema
             where_ $ ep.showId ==. lit showId'
             where_ $ isNull ep.deletedAt
@@ -633,8 +647,8 @@ updateScheduledSlot ScheduleSlotUpdate {..} =
             from = pure (),
             set = \_ ep ->
               ep
-                { scheduleTemplateId = lit essuScheduleTemplateId,
-                  scheduledAt = lit essuScheduledAt,
+                { scheduleTemplateId = nullify (lit essuScheduleTemplateId),
+                  scheduledAt = nullify (lit essuScheduledAt),
                   updatedAt = now
                 },
             updateWhere = \_ ep -> ep.id ==. lit essuId,
@@ -659,6 +673,24 @@ deleteEpisode episodeId =
             returning = Returning (.id)
           }
 
+-- | Clear schedule_template_id for upcoming episodes tied to a given template.
+--
+-- Used when a schedule template is invalidated (e.g., timeslot changed) to
+-- explicitly detach future episodes rather than leaving them with a stale FK.
+-- Returns the IDs of affected episodes for logging.
+clearTemplateForUpcomingEpisodes :: ShowSchedule.TemplateId -> Hasql.Statement () [Id]
+clearTemplateForUpcomingEpisodes templateId =
+  interp
+    False
+    [sql|
+    UPDATE episodes
+    SET schedule_template_id = NULL, scheduled_at = NULL, updated_at = NOW()
+    WHERE schedule_template_id = #{templateId}
+      AND scheduled_at > NOW()
+      AND deleted_at IS NULL
+    RETURNING id
+  |]
+
 --------------------------------------------------------------------------------
 -- Search Queries
 
@@ -679,7 +711,7 @@ searchEpisodesWithAudio query =
       AND e.deleted_at IS NULL
       AND s.deleted_at IS NULL
       AND s.title ILIKE #{pattern}
-    ORDER BY e.scheduled_at DESC
+    ORDER BY e.scheduled_at DESC NULLS LAST
     LIMIT 20
   |]
 

--- a/services/web/test/API/Dashboard/Episodes/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Get/HandlerSpec.hs
@@ -95,8 +95,8 @@ test_insertedEpisodeAppears cfg = do
                   eiAudioMimeType = Nothing,
                   eiDurationSeconds = Nothing,
                   eiArtworkUrl = Nothing,
-                  eiScheduleTemplateId = templateId,
-                  eiScheduledAt = read "2020-01-01 10:00:00 UTC",
+                  eiScheduleTemplateId = Just templateId,
+                  eiScheduledAt = Just (read "2020-01-01 10:00:00 UTC"),
                   eiCreatedBy = userModel.mId
                 }
         episodeId <- insertTestEpisode episodeInsert

--- a/services/web/test/API/Dashboard/Episodes/Slug/Delete/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Delete/HandlerSpec.hs
@@ -101,8 +101,8 @@ test_archivesEpisode cfg = do
                 Episodes.eiAudioMimeType = Nothing,
                 Episodes.eiDurationSeconds = Nothing,
                 Episodes.eiArtworkUrl = Nothing,
-                Episodes.eiScheduleTemplateId = templateId,
-                Episodes.eiScheduledAt = read "2026-03-01 10:00:00 UTC",
+                Episodes.eiScheduleTemplateId = Just templateId,
+                Episodes.eiScheduledAt = Just (read "2026-03-01 10:00:00 UTC"),
                 Episodes.eiCreatedBy = userId
               }
       episodeId <- insertTestEpisode episodeInsert

--- a/services/web/test/API/Dashboard/Episodes/Slug/Edit/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Edit/Get/HandlerSpec.hs
@@ -66,8 +66,8 @@ setupFixture showInsert userInsert = do
             eiAudioMimeType = Nothing,
             eiDurationSeconds = Nothing,
             eiArtworkUrl = Nothing,
-            eiScheduleTemplateId = templateId,
-            eiScheduledAt = read "2026-03-01 10:00:00 UTC",
+            eiScheduleTemplateId = Just templateId,
+            eiScheduledAt = Just (read "2026-03-01 10:00:00 UTC"),
             eiCreatedBy = userModel.mId
           }
   -- Note: 'error' is used here because Transaction does not have MonadIO,

--- a/services/web/test/API/Dashboard/Episodes/Slug/Edit/Post/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Edit/Post/HandlerSpec.hs
@@ -108,8 +108,8 @@ test_updatesDescription cfg = do
                 Episodes.eiAudioMimeType = Nothing,
                 Episodes.eiDurationSeconds = Nothing,
                 Episodes.eiArtworkUrl = Nothing,
-                Episodes.eiScheduleTemplateId = templateId,
-                Episodes.eiScheduledAt = read "2026-03-01 10:00:00 UTC",
+                Episodes.eiScheduleTemplateId = Just templateId,
+                Episodes.eiScheduledAt = Just (read "2026-03-01 10:00:00 UTC"),
                 Episodes.eiCreatedBy = userModel.mId
               }
       episodeId <- insertTestEpisode episodeInsert
@@ -178,8 +178,8 @@ test_notAuthorizedForUnrelatedUser cfg = do
                 Episodes.eiAudioMimeType = Nothing,
                 Episodes.eiDurationSeconds = Nothing,
                 Episodes.eiArtworkUrl = Nothing,
-                Episodes.eiScheduleTemplateId = templateId,
-                Episodes.eiScheduledAt = read "2026-03-01 10:00:00 UTC",
+                Episodes.eiScheduleTemplateId = Just templateId,
+                Episodes.eiScheduledAt = Just (read "2026-03-01 10:00:00 UTC"),
                 Episodes.eiCreatedBy = creatorId
               }
       episodeId <- insertTestEpisode episodeInsert

--- a/services/web/test/API/Dashboard/Episodes/Slug/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Get/HandlerSpec.hs
@@ -64,8 +64,8 @@ setupFixture showInsert userInsert = do
             eiAudioMimeType = Nothing,
             eiDurationSeconds = Nothing,
             eiArtworkUrl = Nothing,
-            eiScheduleTemplateId = templateId,
-            eiScheduledAt = read "2020-01-01 10:00:00 UTC",
+            eiScheduleTemplateId = Just templateId,
+            eiScheduledAt = Just (read "2020-01-01 10:00:00 UTC"),
             eiCreatedBy = userModel.mId
           }
   episodeId <- insertTestEpisode episodeInsert

--- a/services/web/test/API/Shows/Slug/Episode/Get/HandlerSpec.hs
+++ b/services/web/test/API/Shows/Slug/Episode/Get/HandlerSpec.hs
@@ -51,8 +51,8 @@ mkEpisodeInsert showId templateId userId =
       eiAudioMimeType = Nothing,
       eiDurationSeconds = Nothing,
       eiArtworkUrl = Nothing,
-      eiScheduleTemplateId = templateId,
-      eiScheduledAt = read "2020-01-01 10:00:00 UTC",
+      eiScheduleTemplateId = Just templateId,
+      eiScheduledAt = Just (read "2020-01-01 10:00:00 UTC"),
       eiCreatedBy = userId
     }
 

--- a/services/web/test/API/Shows/Slug/Get/HandlerSpec.hs
+++ b/services/web/test/API/Shows/Slug/Get/HandlerSpec.hs
@@ -92,8 +92,8 @@ test_includesEpisodes cfg = do
                   eiAudioMimeType = Nothing,
                   eiDurationSeconds = Nothing,
                   eiArtworkUrl = Nothing,
-                  eiScheduleTemplateId = templateId,
-                  eiScheduledAt = read "2020-01-01 10:00:00 UTC",
+                  eiScheduleTemplateId = Just templateId,
+                  eiScheduledAt = Just (read "2020-01-01 10:00:00 UTC"),
                   eiCreatedBy = userId
                 }
         insertTestEpisode episodeInsert

--- a/services/web/test/Effects/Database/Tables/CurrentlyAiringSpec.hs
+++ b/services/web/test/Effects/Database/Tables/CurrentlyAiringSpec.hs
@@ -268,8 +268,8 @@ setupTestDataFull passHash startTime endTime airsTwiceDaily scheduledAt mAudioPa
             eiAudioMimeType = if isJust mAudioPath then Just "audio/mpeg" else Nothing,
             eiDurationSeconds = fromIntegral <$> mDuration,
             eiArtworkUrl = Nothing,
-            eiScheduleTemplateId = templateId,
-            eiScheduledAt = scheduledAt,
+            eiScheduleTemplateId = Just templateId,
+            eiScheduledAt = Just scheduledAt,
             eiCreatedBy = userId
           }
 
@@ -351,8 +351,8 @@ addTimeslot showId userId startTime endTime airsTwiceDaily scheduledAt mAudioPat
           eiAudioMimeType = if isJust mAudioPath then Just "audio/mpeg" else Nothing,
           eiDurationSeconds = Just (fromIntegral slotDuration),
           eiArtworkUrl = Nothing,
-          eiScheduleTemplateId = templateId,
-          eiScheduledAt = scheduledAt,
+          eiScheduleTemplateId = Just templateId,
+          eiScheduledAt = Just scheduledAt,
           eiCreatedBy = userId
         }
 
@@ -1065,8 +1065,8 @@ transitionReplacedSlot cfg = bracketConn cfg $ do
               eiAudioMimeType = Just "audio/mpeg",
               eiDurationSeconds = Just slotDuration,
               eiArtworkUrl = Nothing,
-              eiScheduleTemplateId = templateId1,
-              eiScheduledAt = scheduledAt,
+              eiScheduleTemplateId = Just templateId1,
+              eiScheduledAt = Just scheduledAt,
               eiCreatedBy = userId
             }
 
@@ -1157,8 +1157,8 @@ transitionRemovedSlot cfg = bracketConn cfg $ do
               eiAudioMimeType = Just "audio/mpeg",
               eiDurationSeconds = Just slotDuration,
               eiArtworkUrl = Nothing,
-              eiScheduleTemplateId = templateId1,
-              eiScheduledAt = scheduledAt,
+              eiScheduleTemplateId = Just templateId1,
+              eiScheduledAt = Just scheduledAt,
               eiCreatedBy = userId
             }
 
@@ -1192,7 +1192,6 @@ multiSlotFirstSlot cfg = bracketConn cfg $ do
       scheduledAt1 = mkTestTime slot1Start
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 10 0 0) -- 10 AM (during first slot)
-
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     (ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
     _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
@@ -1220,7 +1219,6 @@ multiSlotSecondSlot cfg = bracketConn cfg $ do
       scheduledAt1 = mkTestTime slot1Start
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 15 0 0) -- 3 PM (during second slot)
-
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
     ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
@@ -1248,7 +1246,6 @@ multiSlotBetween cfg = bracketConn cfg $ do
       scheduledAt1 = mkTestTime slot1Start
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 12 0 0) -- Noon (between slots)
-
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
     _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
@@ -1272,7 +1269,6 @@ multiSlotBeforeAll cfg = bracketConn cfg $ do
       scheduledAt1 = mkTestTime slot1Start
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 8 0 0) -- 8 AM (before both)
-
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
     _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
@@ -1296,7 +1292,6 @@ multiSlotAfterAll cfg = bracketConn cfg $ do
       scheduledAt1 = mkTestTime slot1Start
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 17 0 0) -- 5 PM (after both)
-
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
     _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing

--- a/services/web/test/Effects/Database/Tables/EpisodeTrackSpec.hs
+++ b/services/web/test/Effects/Database/Tables/EpisodeTrackSpec.hs
@@ -62,7 +62,7 @@ prop_insertSelect cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = templateId, Episodes.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = Just templateId, Episodes.eiCreatedBy = userId}
         episodeId <- unwrapInsert (Episodes.insertEpisode episodeInsert)
 
         let trackInsert = trackTemplate {UUT.etiEpisodeId = episodeId, UUT.etiTrackNumber = 1}
@@ -100,7 +100,7 @@ prop_getTracksForEpisode cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = templateId, Episodes.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = Just templateId, Episodes.eiCreatedBy = userId}
         episodeId <- unwrapInsert (Episodes.insertEpisode episodeInsert)
 
         -- Insert track 2 first, then track 1, to verify ordering
@@ -141,7 +141,7 @@ prop_deleteAllTracksForEpisode cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = templateId, Episodes.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {Episodes.eiId = showId, Episodes.eiScheduleTemplateId = Just templateId, Episodes.eiCreatedBy = userId}
         episodeId <- unwrapInsert (Episodes.insertEpisode episodeInsert)
 
         let track1 = track1Template {UUT.etiEpisodeId = episodeId, UUT.etiTrackNumber = 1}

--- a/services/web/test/Effects/Database/Tables/EpisodesSpec.hs
+++ b/services/web/test/Effects/Database/Tables/EpisodesSpec.hs
@@ -67,6 +67,14 @@ spec =
         runs 10 . it "updateScheduledSlot: changes template and scheduled_at" $
           hedgehog . prop_updateScheduledSlot
 
+      describe "Unscheduled Episodes" $ do
+        runs 10 . it "clearTemplateForUpcomingEpisodes: nulls schedule fields for future episodes" $
+          hedgehog . prop_clearTemplateForUpcomingEpisodes
+        runs 10 . it "getEpisodesForShow: unscheduled episodes sort last" $
+          hedgehog . prop_unscheduledEpisodesSortLast
+        runs 10 . it "getPublishedEpisodesForShow: excludes unscheduled episodes" $
+          hedgehog . prop_publishedExcludesUnscheduled
+
       describe "Tag Operations" $ do
         runs 10 . it "getTagsForEpisode: returns tags for episode" $
           hedgehog . prop_getTagsForEpisode
@@ -107,7 +115,7 @@ prop_insertSelect cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
 
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
         selected <- TRX.statement () (UUT.getEpisodeById episodeId)
@@ -135,7 +143,7 @@ prop_updateSelect cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         let update = UUT.Update {UUT.euId = episodeId, UUT.euDescription = UUT.eiDescription updateEpisodeTemplate}
@@ -171,7 +179,7 @@ prop_updateUpdate cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         let updateA = UUT.Update {UUT.euId = episodeId, UUT.euDescription = UUT.eiDescription updateATemplate}
@@ -210,8 +218,8 @@ prop_getEpisodesForShow cfg = do
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
         -- Offset scheduledAt to avoid unique constraint on (show_id, scheduled_at)
-        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
-        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = addUTCTime (3600 :: NominalDiffTime) (UUT.eiScheduledAt ep2Template)}
+        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
+        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = fmap (addUTCTime (3600 :: NominalDiffTime)) (UUT.eiScheduledAt ep2Template)}
 
         id1 <- unwrapInsert (UUT.insertEpisode ep1)
         id2 <- unwrapInsert (UUT.insertEpisode ep2)
@@ -247,8 +255,8 @@ prop_getPublishedEpisodesForShow cfg = do
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
         -- Offset scheduledAt to avoid unique constraint on (show_id, scheduled_at)
-        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
-        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = addUTCTime (3600 :: NominalDiffTime) (UUT.eiScheduledAt ep2Template)}
+        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
+        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = fmap (addUTCTime (3600 :: NominalDiffTime)) (UUT.eiScheduledAt ep2Template)}
 
         id1 <- unwrapInsert (UUT.insertEpisode ep1)
         id2 <- unwrapInsert (UUT.insertEpisode ep2)
@@ -287,7 +295,7 @@ prop_getEpisodeByShowAndNumber cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         -- Get the episode to find its number
@@ -327,7 +335,7 @@ prop_deleteEpisode cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         deleteResult <- TRX.statement () (UUT.deleteEpisode episodeId)
@@ -367,7 +375,7 @@ prop_deleteEpisode_idempotent cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         firstDelete <- TRX.statement () (UUT.deleteEpisode episodeId)
@@ -403,7 +411,7 @@ prop_updateEpisodeFiles cfg = do
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
         -- Insert with no audio/artwork
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId, UUT.eiAudioFilePath = Nothing, UUT.eiArtworkUrl = Nothing}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId, UUT.eiAudioFilePath = Nothing, UUT.eiArtworkUrl = Nothing}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         -- Update with audio file
@@ -470,8 +478,8 @@ prop_getEpisodesByUser cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
-        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = addUTCTime (3600 :: NominalDiffTime) (UUT.eiScheduledAt ep2Template)}
+        let ep1 = ep1Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
+        let ep2 = ep2Template {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId, UUT.eiScheduledAt = fmap (addUTCTime (3600 :: NominalDiffTime)) (UUT.eiScheduledAt ep2Template)}
 
         id1 <- unwrapInsert (UUT.insertEpisode ep1)
         id2 <- unwrapInsert (UUT.insertEpisode ep2)
@@ -519,7 +527,7 @@ prop_updateScheduledSlot cfg = do
         let template2WithShowId = scheduleTemplate2 {ShowSchedule.stiShowId = showId}
         templateId2 <- TRX.statement () (ShowSchedule.insertScheduleTemplate template2WithShowId)
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId1, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId1, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         -- Use a clean timestamp without sub-microsecond precision (PostgreSQL truncates to microseconds)
@@ -538,8 +546,8 @@ prop_updateScheduledSlot cfg = do
         updatedId === episodeId
 
         afterUpdate <- assertJust mAfterUpdate
-        UUT.scheduleTemplateId afterUpdate === expectedTemplateId
-        UUT.scheduledAt afterUpdate === expectedScheduledAt
+        UUT.scheduleTemplateId afterUpdate === Just expectedTemplateId
+        UUT.scheduledAt afterUpdate === Just expectedScheduledAt
         pure ()
 
 --------------------------------------------------------------------------------
@@ -559,7 +567,7 @@ prop_getTagsForEpisode cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         -- Add tags
@@ -592,7 +600,7 @@ prop_replaceEpisodeTags cfg = do
         userId <- insertTestUser userWithMetadata
         (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
 
-        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = templateId, UUT.eiCreatedBy = userId}
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiCreatedBy = userId}
         episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
 
         -- First set of tags
@@ -624,4 +632,119 @@ prop_replaceEpisodeTags cfg = do
         elem "rock" secondNames === False
         -- Empty list removes all tags
         length tagsAfterEmpty === 0
+        pure ()
+
+--------------------------------------------------------------------------------
+-- Unscheduled Episode tests
+
+-- | clearTemplateForUpcomingEpisodes: nulls both schedule fields for future episodes.
+prop_clearTemplateForUpcomingEpisodes :: TestDBConfig -> PropertyT IO ()
+prop_clearTemplateForUpcomingEpisodes cfg = do
+  arrange (bracketConn cfg) $ do
+    userWithMetadata <- forAllT userWithMetadataInsertGen
+    showInsert <- forAllT showInsertGen
+    scheduleTemplate <- forAllT $ scheduleTemplateInsertGen (Shows.Id 1)
+    episodeTemplate <- forAllT $ episodeInsertGen (Shows.Id 1) (ShowSchedule.TemplateId 1) (User.Id 1)
+
+    act $ do
+      now <- liftIO getCurrentTime
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        userId <- insertTestUser userWithMetadata
+        (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
+
+        -- Insert an episode scheduled in the future
+        let futureTime = addUTCTime (86400 :: NominalDiffTime) now
+        let episodeInsert = episodeTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiScheduledAt = Just futureTime, UUT.eiCreatedBy = userId}
+        episodeId <- unwrapInsert (UUT.insertEpisode episodeInsert)
+
+        -- Clear template for upcoming episodes
+        clearedIds <- TRX.statement () (UUT.clearTemplateForUpcomingEpisodes templateId)
+
+        -- Re-fetch the episode
+        afterClear <- TRX.statement () (UUT.getEpisodeById episodeId)
+
+        TRX.condemn
+        pure (episodeId, clearedIds, afterClear)
+
+      assert $ do
+        (episodeId, clearedIds, mAfterClear) <- assertRight result
+        -- The episode should have been cleared
+        clearedIds === [episodeId]
+        afterClear <- assertJust mAfterClear
+        UUT.scheduleTemplateId afterClear === Nothing
+        UUT.scheduledAt afterClear === Nothing
+        pure ()
+
+-- | getEpisodesForShow: unscheduled episodes (NULL scheduledAt) sort after scheduled ones.
+prop_unscheduledEpisodesSortLast :: TestDBConfig -> PropertyT IO ()
+prop_unscheduledEpisodesSortLast cfg = do
+  arrange (bracketConn cfg) $ do
+    userWithMetadata <- forAllT userWithMetadataInsertGen
+    showInsert <- forAllT showInsertGen
+    scheduleTemplate <- forAllT $ scheduleTemplateInsertGen (Shows.Id 1)
+    epTemplate <- forAllT $ episodeInsertGen (Shows.Id 1) (ShowSchedule.TemplateId 1) (User.Id 1)
+
+    act $ do
+      now <- liftIO getCurrentTime
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        userId <- insertTestUser userWithMetadata
+        (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
+
+        -- Insert a scheduled episode
+        let scheduledInsert = epTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiScheduledAt = Just now, UUT.eiCreatedBy = userId}
+        scheduledId <- unwrapInsert (UUT.insertEpisode scheduledInsert)
+
+        -- Insert an unscheduled episode
+        let unscheduledInsert = epTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Nothing, UUT.eiScheduledAt = Nothing, UUT.eiCreatedBy = userId}
+        unscheduledId <- unwrapInsert (UUT.insertEpisode unscheduledInsert)
+
+        episodes <- TRX.statement () (UUT.getEpisodesForShow showId (Limit 10) (Offset 0))
+
+        TRX.condemn
+        pure (scheduledId, unscheduledId, episodes)
+
+      assert $ do
+        (scheduledId, unscheduledId, episodes) <- assertRight result
+        -- Both episodes returned, scheduled first (desc order, nulls last)
+        case episodes of
+          [first, second] -> do
+            UUT.id first === scheduledId
+            UUT.id second === unscheduledId
+          _ -> length episodes === 2
+        pure ()
+
+-- | getPublishedEpisodesForShow: excludes episodes with NULL scheduledAt.
+prop_publishedExcludesUnscheduled :: TestDBConfig -> PropertyT IO ()
+prop_publishedExcludesUnscheduled cfg = do
+  arrange (bracketConn cfg) $ do
+    userWithMetadata <- forAllT userWithMetadataInsertGen
+    showInsert <- forAllT showInsertGen
+    scheduleTemplate <- forAllT $ scheduleTemplateInsertGen (Shows.Id 1)
+    epTemplate <- forAllT $ episodeInsertGen (Shows.Id 1) (ShowSchedule.TemplateId 1) (User.Id 1)
+
+    act $ do
+      now <- liftIO getCurrentTime
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        userId <- insertTestUser userWithMetadata
+        (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleTemplate
+
+        -- Insert a scheduled episode in the past (should appear in published)
+        let pastTime = addUTCTime (-86400 :: NominalDiffTime) now
+        let scheduledInsert = epTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Just templateId, UUT.eiScheduledAt = Just pastTime, UUT.eiCreatedBy = userId}
+        scheduledId <- unwrapInsert (UUT.insertEpisode scheduledInsert)
+
+        -- Insert an unscheduled episode (should NOT appear in published)
+        let unscheduledInsert = epTemplate {UUT.eiId = showId, UUT.eiScheduleTemplateId = Nothing, UUT.eiScheduledAt = Nothing, UUT.eiCreatedBy = userId}
+        _unscheduledId <- unwrapInsert (UUT.insertEpisode unscheduledInsert)
+
+        published <- TRX.statement () (UUT.getPublishedEpisodesForShow now showId (Limit 10) (Offset 0))
+
+        TRX.condemn
+        pure (scheduledId, published)
+
+      assert $ do
+        (scheduledId, published) <- assertRight result
+        -- Only the scheduled past episode should appear
+        ep <- assertSingleton published
+        UUT.id ep === scheduledId
         pure ()

--- a/services/web/test/Effects/Database/Tables/ShowScheduleMissingEpisodesSpec.hs
+++ b/services/web/test/Effects/Database/Tables/ShowScheduleMissingEpisodesSpec.hs
@@ -105,8 +105,8 @@ prop_episodeWithAudioNotMissing cfg = do
                   eiAudioMimeType = Just "audio/mpeg",
                   eiDurationSeconds = Just 3600,
                   eiArtworkUrl = Nothing,
-                  eiScheduleTemplateId = templateId,
-                  eiScheduledAt = read (show today ++ " 10:00:00 UTC"),
+                  eiScheduleTemplateId = Just templateId,
+                  eiScheduledAt = Just (read (show today ++ " 10:00:00 UTC")),
                   eiCreatedBy = userId
                 }
         _ <- unwrapInsert (Episodes.insertEpisode episodeInsert)
@@ -153,8 +153,8 @@ prop_episodeWithoutAudioIsMissing cfg = do
                   eiAudioMimeType = Nothing,
                   eiDurationSeconds = Nothing,
                   eiArtworkUrl = Nothing,
-                  eiScheduleTemplateId = templateId,
-                  eiScheduledAt = read (show today ++ " 10:00:00 UTC"),
+                  eiScheduleTemplateId = Just templateId,
+                  eiScheduledAt = Just (read (show today ++ " 10:00:00 UTC")),
                   eiCreatedBy = userId
                 }
         _ <- unwrapInsert (Episodes.insertEpisode episodeInsert)

--- a/services/web/test/Test/Gen/Tables/Episodes.hs
+++ b/services/web/test/Test/Gen/Tables/Episodes.hs
@@ -17,13 +17,13 @@ import Test.Gen.Time (genUTCTime)
 episodeInsertGen :: (MonadGen m) => Shows.Id -> ShowSchedule.TemplateId -> User.Id -> m Episodes.Insert
 episodeInsertGen showId templateId userId = do
   let eiId = showId
-  let eiScheduleTemplateId = templateId
+  let eiScheduleTemplateId = Just templateId
   eiDescription <- Gen.maybe genText
   eiAudioFilePath <- Gen.maybe genUrl
   eiAudioFileSize <- Gen.maybe $ Gen.integral (Range.linear 1000 100000000)
   eiAudioMimeType <- Gen.maybe $ Gen.element ["audio/mpeg", "audio/mp3", "audio/wav"]
   eiDurationSeconds <- Gen.maybe $ Gen.integral (Range.linear 60 7200)
   eiArtworkUrl <- Gen.maybe genUrl
-  eiScheduledAt <- genUTCTime
+  eiScheduledAt <- Just <$> genUTCTime
   let eiCreatedBy = userId
   pure Episodes.Insert {..}


### PR DESCRIPTION
## Summary

- Episodes can now exist without a schedule slot (`NULL` for both `schedule_template_id` and `scheduled_at`)
- Supports episodes created before a show has a schedule, or detached when a schedule template is invalidated
- Dashboard displays UNSCHEDULED badge and allows assigning slots to unscheduled episodes
- CHECK constraint ensures `schedule_template_id` and `scheduled_at` are always both NULL or both NOT NULL

## Changes

- **Migration**: Drop NOT NULL on `schedule_template_id`/`scheduled_at`, add consistency CHECK constraint
- **Dashboard list**: UNSCHEDULED badge for episodes without a schedule slot
- **Episode detail**: Shows "Scheduled: Unscheduled" for unscheduled episodes
- **Edit form**: Schedule section allows assigning a slot to unscheduled episodes; three states handled (no interaction → no change, "Unscheduled" selected → no change, slot selected → update)
- **Queries**: Unscheduled episodes sort last in dashboard, excluded from public published list
- **Tests**: Property tests for sort ordering, published exclusion, and schedule clearing; e2e tests for schedule state transitions (keep unscheduled → assign slot → keep slot → reschedule)

## Test plan

- [x] `just test` passes (property tests cover unscheduled episode behavior)
- [x] e2e schedule state transition tests pass
- [x] Verify UNSCHEDULED badge renders in dashboard episode list
- [x] Verify unscheduled episodes don't appear on public show pages