### PR TITLE
feat: pgBackRest S3 off-site backup (DigitalOcean Spaces)

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -45,7 +45,10 @@ jobs:
       - name: Pre-deploy database backup
         run: |
           ssh root@ssh.kpbj.fm \
-            'sudo -u postgres pgbackrest backup --stanza=kpbj --type=full'
+            'sudo -u postgres pgbackrest backup --stanza=kpbj --type=full --repo=1'
+          ssh root@ssh.kpbj.fm \
+            'sudo -u postgres bash -c "set -a; . /run/secrets-rendered/kpbj-pgbackrest-s3.env; pgbackrest backup --stanza=kpbj --type=full --repo=2"' \
+            || echo '::warning::S3 backup (repo2) failed — continuing with deploy'
 
       - name: Deploy NixOS configuration
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Added
+- **Off-Site S3 Backups for PostgreSQL** — pgBackRest now supports an optional second repository (repo2) on S3-compatible storage (DigitalOcean Spaces) for off-site disaster recovery. Local repo1 remains for fast restores. Credentials are wired through SOPS and read from disk on the server. S3 failures are treated as warnings — local backups always complete. Daily backups and WAL archiving target both repos when enabled. Setting `s3 = null` reverts to local-only backups.
 
 ---
 

--- a/nixos/pgbackrest.nix
+++ b/nixos/pgbackrest.nix
@@ -3,15 +3,18 @@
 # ──────────────────────────────────────────────────────────────
 #
 # Daily full backups + continuous WAL archiving for point-in-time
-# recovery. Backups stored locally on-VPS. A oneshot service
-# initialises the stanza after PostgreSQL starts, and a timer
-# triggers the daily full backup.
+# recovery. Backups stored locally on-VPS (repo1). An optional
+# S3-compatible second repository (repo2) provides off-site
+# disaster recovery. A oneshot service initialises the stanza
+# after PostgreSQL starts, and a timer triggers the daily full
+# backup.
 # ──────────────────────────────────────────────────────────────
 { config, lib, pkgs, ... }:
 
 let
   cfg = config.kpbj.pgbackrest;
   pgCfg = config.services.postgresql;
+  s3Enabled = cfg.s3 != null;
 in
 {
   options.kpbj.pgbackrest = {
@@ -40,6 +43,41 @@ in
       default = "daily";
       description = "Systemd calendar spec for backup frequency.";
     };
+
+    s3 = lib.mkOption {
+      type = lib.types.nullOr (lib.types.submodule {
+        options = {
+          bucket = lib.mkOption {
+            type = lib.types.str;
+            description = "S3 bucket name for off-site backups.";
+          };
+          endpoint = lib.mkOption {
+            type = lib.types.str;
+            description = "S3-compatible endpoint (e.g. sfo3.digitaloceanspaces.com).";
+          };
+          region = lib.mkOption {
+            type = lib.types.str;
+            description = "S3 region (e.g. sfo3).";
+          };
+          path = lib.mkOption {
+            type = lib.types.str;
+            default = "/pgbackrest";
+            description = "Path prefix within the S3 bucket.";
+          };
+          retentionFull = lib.mkOption {
+            type = lib.types.int;
+            default = 14;
+            description = "Number of full backups to retain in S3.";
+          };
+          secretsFile = lib.mkOption {
+            type = lib.types.path;
+            description = "Path to the SOPS-encrypted YAML containing aws_access_key_id and aws_secret_access_key.";
+          };
+        };
+      });
+      default = null;
+      description = "Optional S3-compatible remote repository (repo2) for off-site backups.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -59,10 +97,47 @@ in
       start-fast=y
       delta=y
       compress-type=zst
+    '' + lib.optionalString s3Enabled ''
+      repo2-type=s3
+      repo2-s3-bucket=${cfg.s3.bucket}
+      repo2-s3-endpoint=${cfg.s3.endpoint}
+      repo2-s3-region=${cfg.s3.region}
+      repo2-s3-uri-style=path
+      repo2-path=${cfg.s3.path}
+      repo2-retention-full=${toString cfg.s3.retentionFull}
+    '' + ''
 
       [global:archive-push]
       compress-level=3
     '';
+
+    # ── SOPS secrets for S3 credentials ────────────────────────
+    sops.secrets = lib.mkIf s3Enabled {
+      pgbackrest_s3_key = {
+        sopsFile = cfg.s3.secretsFile;
+        key = "aws_access_key_id";
+        owner = "postgres";
+        restartUnits = [ "kpbj-pgbackrest-init.service" ];
+      };
+      pgbackrest_s3_key_secret = {
+        sopsFile = cfg.s3.secretsFile;
+        key = "aws_secret_access_key";
+        owner = "postgres";
+        restartUnits = [ "kpbj-pgbackrest-init.service" ];
+      };
+    };
+
+    sops.templates = lib.mkIf s3Enabled {
+      "kpbj-pgbackrest-s3.env" = {
+        content = ''
+          PGBACKREST_REPO2_S3_KEY=${config.sops.placeholder.pgbackrest_s3_key}
+          PGBACKREST_REPO2_S3_KEY_SECRET=${config.sops.placeholder.pgbackrest_s3_key_secret}
+        '';
+        owner = "postgres";
+        group = "postgres";
+        restartUnits = [ "kpbj-pgbackrest-init.service" "kpbj-backup-full.service" ];
+      };
+    };
 
     # ── PostgreSQL WAL archiving ───────────────────────────────
     services.postgresql.settings = {
@@ -75,6 +150,10 @@ in
     # to the backup repo.  ProtectSystem=strict makes / read-only
     # for the service, so the repo path must be explicitly allowed.
     systemd.services.postgresql.serviceConfig.ReadWritePaths = [ cfg.repoPath ];
+
+    # S3 credentials for archive_command (runs as child of postgresql.service)
+    systemd.services.postgresql.serviceConfig.EnvironmentFile =
+      lib.mkIf s3Enabled [ config.sops.templates."kpbj-pgbackrest-s3.env".path ];
 
     # ── Repo + log directories ───────────────────────────────────
     systemd.tmpfiles.rules = [
@@ -95,11 +174,24 @@ in
         RemainAfterExit = true;
         User = "postgres";
         Group = "postgres";
-        ExecStart = pkgs.writeShellScript "kpbj-pgbackrest-init" ''
-          set -euo pipefail
-          ${pkgs.pgbackrest}/bin/pgbackrest stanza-create --stanza=${cfg.stanzaName} || \
-            ${pkgs.pgbackrest}/bin/pgbackrest stanza-upgrade --stanza=${cfg.stanzaName}
-        '';
+        ExecStart =
+          if s3Enabled then
+            pkgs.writeShellScript "kpbj-pgbackrest-init" ''
+              set -euo pipefail
+              ${pkgs.pgbackrest}/bin/pgbackrest stanza-create --stanza=${cfg.stanzaName} --repo=1 || \
+                ${pkgs.pgbackrest}/bin/pgbackrest stanza-upgrade --stanza=${cfg.stanzaName} --repo=1
+              ${pkgs.pgbackrest}/bin/pgbackrest stanza-create --stanza=${cfg.stanzaName} --repo=2 || \
+                ${pkgs.pgbackrest}/bin/pgbackrest stanza-upgrade --stanza=${cfg.stanzaName} --repo=2 || \
+                echo "WARNING: S3 stanza init (repo2) failed — local repo ready"
+            ''
+          else
+            pkgs.writeShellScript "kpbj-pgbackrest-init" ''
+              set -euo pipefail
+              ${pkgs.pgbackrest}/bin/pgbackrest stanza-create --stanza=${cfg.stanzaName} || \
+                ${pkgs.pgbackrest}/bin/pgbackrest stanza-upgrade --stanza=${cfg.stanzaName}
+            '';
+      } // lib.optionalAttrs s3Enabled {
+        EnvironmentFile = [ config.sops.templates."kpbj-pgbackrest-s3.env".path ];
       };
     };
 
@@ -113,7 +205,18 @@ in
         Type = "oneshot";
         User = "postgres";
         Group = "postgres";
-        ExecStart = "${pkgs.pgbackrest}/bin/pgbackrest backup --stanza=${cfg.stanzaName} --type=full";
+        ExecStart =
+          if s3Enabled then
+            pkgs.writeShellScript "kpbj-backup-full" ''
+              set -euo pipefail
+              ${pkgs.pgbackrest}/bin/pgbackrest backup --stanza=${cfg.stanzaName} --type=full --repo=1
+              ${pkgs.pgbackrest}/bin/pgbackrest backup --stanza=${cfg.stanzaName} --type=full --repo=2 \
+                || echo "WARNING: S3 backup (repo2) failed — local backup succeeded"
+            ''
+          else
+            "${pkgs.pgbackrest}/bin/pgbackrest backup --stanza=${cfg.stanzaName} --type=full";
+      } // lib.optionalAttrs s3Enabled {
+        EnvironmentFile = [ config.sops.templates."kpbj-pgbackrest-s3.env".path ];
       };
     };
 

--- a/nixos/prod.nix
+++ b/nixos/prod.nix
@@ -48,7 +48,16 @@
   kpbj.monitoring.enable = true;
 
   # ── pgBackRest (PG backups + WAL archiving) ──────────────────
-  kpbj.pgbackrest.enable = true;
+  kpbj.pgbackrest = {
+    enable = true;
+    s3 = {
+      bucket = "kpbj-pgbackrest";
+      endpoint = "sfo3.digitaloceanspaces.com";
+      region = "sfo3";
+      path = "/prod";
+      secretsFile = ../secrets/prod-web.yaml;
+    };
+  };
 
   # ── PostgreSQL ───────────────────────────────────────────────
   kpbj.postgresql = {

--- a/nixos/staging.nix
+++ b/nixos/staging.nix
@@ -13,6 +13,7 @@
     ./monitoring.nix
     ./nginx.nix
     ./sops.nix
+    ./pgbackrest.nix
     ./postgresql.nix
     ./web.nix
   ];
@@ -46,6 +47,18 @@
 
   # ── Monitoring (Grafana + Loki + Promtail) ───────────────────
   kpbj.monitoring.enable = true;
+
+  # ── pgBackRest (PG backups + WAL archiving) ──────────────────
+  kpbj.pgbackrest = {
+    enable = true;
+    s3 = {
+      bucket = "kpbj-pgbackrest";
+      endpoint = "sfo3.digitaloceanspaces.com";
+      region = "sfo3";
+      path = "/staging";
+      secretsFile = ../secrets/staging-web.yaml;
+    };
+  };
 
   # ── PostgreSQL ───────────────────────────────────────────────
   kpbj.postgresql = {

--- a/terraform/digitalocean.tf
+++ b/terraform/digitalocean.tf
@@ -83,6 +83,12 @@ resource "digitalocean_spaces_bucket" "staging_storage" {
   acl    = "public-read"
 }
 
+resource "digitalocean_spaces_bucket" "pgbackrest" {
+  name   = "kpbj-pgbackrest"
+  region = "sfo3"
+  acl    = "private"
+}
+
 # ──────────────────────────────────────────────────────────────
 # Firewalls
 # ──────────────────────────────────────────────────────────────

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -38,6 +38,11 @@ output "staging_spaces_endpoint" {
   value       = "https://${digitalocean_spaces_bucket.staging_storage.name}.${digitalocean_spaces_bucket.staging_storage.region}.digitaloceanspaces.com"
 }
 
+output "pgbackrest_spaces_bucket" {
+  description = "pgBackRest S3 backup bucket name"
+  value       = digitalocean_spaces_bucket.pgbackrest.name
+}
+
 output "google_groups_sa_email" {
   description = "Google Groups service account email"
   value       = google_service_account.google_groups.email


### PR DESCRIPTION
## Summary

- Adds DigitalOcean Spaces as a second pgBackRest repository (repo2) for off-site disaster recovery, keeping local repo1 for fast restores
- Provisions a private `kpbj-pgbackrest` Spaces bucket via Terraform
- Wires S3 credentials through SOPS → env file → systemd, reusing existing AWS keys from `prod-web.yaml`
- Setting `s3 = null` in `prod.nix` reverts to local-only backups (clean rollback)

## Deploy sequence

1. `terraform apply` to create the Spaces bucket
2. Deploy NixOS config — `kpbj-pgbackrest-init` creates the repo2 stanza on boot
3. CI pre-deploy backup already updated to target both repos

## Verification

```bash
# Check config
cat /etc/pgbackrest/pgbackrest.conf

# Check both repos initialized
sudo -u postgres pgbackrest info --stanza=kpbj

# Manual S3 backup
sudo -u postgres pgbackrest backup --stanza=kpbj --type=full --repo=2

# Verify WAL archiving to S3
sudo -u postgres psql -c "SELECT pg_switch_wal();"
sudo -u postgres pgbackrest info --stanza=kpbj --repo=2
```

## Test plan

- [x] `terraform plan` shows only the new bucket resource
- [x] `terraform apply` creates the bucket successfully

## Followup
- NixOS deploy succeeds and `kpbj-pgbackrest-init` initializes both repos
- Manual full backup to repo2 completes
- WAL archiving reaches S3 after `pg_switch_wal()`
