### PR TITLE
feat: LLM watchdog + fix S3 MIME type on upload relocation

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -41,5 +41,5 @@ jobs:
         run: |
           nix shell nixpkgs#nixos-rebuild -c \
             nixos-rebuild switch \
-            --flake .#kpbj-stream-staging \
+            --flake .#kpbj-staging \
             --target-host root@ssh.staging.kpbj.fm

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build NixOS closure for staging 🏗️
       if: github.ref == 'refs/heads/main'
-      run: nix build .#nixosConfigurations.kpbj-stream-staging.config.system.build.toplevel
+      run: nix build .#nixosConfigurations.kpbj-staging.config.system.build.toplevel
 
     # - name: Check for dead code 🧹
     #   run: |

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,7 +3,7 @@ keys:
   - &pc_lorean age1h9eclrfude5fkzvt0v7sjyhfsu5f839xw0wwh29lrptq70mfvgescqng6a
   - &pc_voice-of-evening age1esadyxrm9kjt25jlg9y0mmp8u75mh05pncxxd8csl7z6dsycy3pszhrh35
   - &vps_stream_prod age1smawm633jsv5qn2aye465j85rac2cu3h7fez3jpl2qu49fh56ejqdjusvg
-  - &vps_stream_staging age1kvwcm2txc4knu5wqm34g307u7gazv3svs4vnm7z2p92xvd9tv3eqhy9smg
+  - &vps_staging age1kvwcm2txc4knu5wqm34g307u7gazv3svs4vnm7z2p92xvd9tv3eqhy9smg
 
 creation_rules:
   - path_regex: secrets/terraform\.yaml$
@@ -35,7 +35,7 @@ creation_rules:
           - *pc_lorean
           - *pc_voice-of-evening
           - *vps_stream_prod
-          - *vps_stream_staging
+          - *vps_staging
 
   - path_regex: secrets/dev-streaming\.yaml$
     key_groups:
@@ -50,7 +50,7 @@ creation_rules:
           - *pc_nightshade
           - *pc_lorean
           - *pc_voice-of-evening
-          - *vps_stream_staging
+          - *vps_staging
 
   - path_regex: secrets/prod-web\.yaml$
     key_groups:
@@ -66,4 +66,4 @@ creation_rules:
           - *pc_nightshade
           - *pc_lorean
           - *pc_voice-of-evening
-          - *vps_stream_staging
+          - *vps_staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- **LLM-Powered Log Watchdog** — A systemd timer runs every 15 minutes (configurable) on prod and staging, collecting journal logs, service statuses, and system stats. Sends them to the Gemini 2.0 Flash API for anomaly detection and emails the operator if anything looks wrong. Covers service outages, error spikes, resource pressure, security anomalies, and streaming issues. Observe-only — no corrective actions. Cost: ~$1/month.
 - **Off-Site S3 Backups for PostgreSQL** — pgBackRest now supports an optional second repository (repo2) on S3-compatible storage (DigitalOcean Spaces) for off-site disaster recovery. Local repo1 remains for fast restores. Credentials are wired through SOPS and read from disk on the server. S3 failures are treated as warnings — local backups always complete. Daily backups and WAL archiving target both repos when enabled. Setting `s3 = null` reverts to local-only backups.
 - **Optional Episode Schedule** — Episodes can now exist without a schedule slot. This supports episodes created before a show has a schedule, or episodes detached when a schedule template is invalidated.
   - `UNSCHEDULED` badge shown in the dashboard episode list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ### Fixed
 - **Episode Card Aspect Ratio Mismatch** — Episode artwork is cropped to 1:1 on upload but was rendered in a 4:3 container, cutting off the top and bottom. Now renders as square to match the crop.
+- **S3 MIME Type Lost on Staged Upload Relocation** — When staged audio uploads were moved from the staging area to their final archive location via `claimAndRelocateUpload`, the S3 `CopyObject` operation did not set `Content-Type`, causing DigitalOcean Spaces to default to `binary/octet-stream`. Liquidsoap then failed to detect the file type and fell back to the FFmpeg decoder with errors. The MIME type stored in the database is now threaded through and set on the copy request.
 
 ### Changed
 - **Rename Staging Droplet** — Renamed the staging DigitalOcean droplet from `kpbj-stream-staging` to `kpbj-staging` to reflect that the VPS now hosts more than just the stream. Updated Terraform resources (with `moved` blocks), NixOS hostname and flake config, CI/CD workflows, Justfile, `.sops.yaml`, and docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 - **Episode Card Aspect Ratio Mismatch** — Episode artwork is cropped to 1:1 on upload but was rendered in a 4:3 container, cutting off the top and bottom. Now renders as square to match the crop.
 
 ### Changed
+- **Rename Staging Droplet** — Renamed the staging DigitalOcean droplet from `kpbj-stream-staging` to `kpbj-staging` to reflect that the VPS now hosts more than just the stream. Updated Terraform resources (with `moved` blocks), NixOS hostname and flake config, CI/CD workflows, Justfile, `.sops.yaml`, and docs.
 - **Episode Schedule Columns Now Nullable** — `schedule_template_id` and `scheduled_at` columns on `episodes` are no longer `NOT NULL`. A `CHECK` constraint ensures both fields are either `NULL` or both `NOT NULL`.
 
 ---

--- a/Justfile
+++ b/Justfile
@@ -665,7 +665,7 @@ nixos-deploy-prod:
 
 # Deploy NixOS config to staging streaming VPS
 nixos-deploy-staging:
-  nixos-rebuild switch --flake .#kpbj-stream-staging --target-host {{STAGING_STREAM_TARGET}}
+  nixos-rebuild switch --flake .#kpbj-staging --target-host {{STAGING_STREAM_TARGET}}
 
 # Preview NixOS changes for production (dry-activate)
 nixos-deploy-prod-dry:
@@ -673,7 +673,7 @@ nixos-deploy-prod-dry:
 
 # Preview NixOS changes for staging (dry-activate)
 nixos-deploy-staging-dry:
-  nixos-rebuild dry-activate --flake .#kpbj-stream-staging --target-host {{STAGING_STREAM_TARGET}}
+  nixos-rebuild dry-activate --flake .#kpbj-staging --target-host {{STAGING_STREAM_TARGET}}
 
 # Build production NixOS config locally (verify it evaluates)
 nixos-build-prod:
@@ -681,7 +681,7 @@ nixos-build-prod:
 
 # Build staging NixOS config locally (verify it evaluates)
 nixos-build-staging:
-  nix build .#nixosConfigurations.kpbj-stream-staging.config.system.build.toplevel
+  nix build .#nixosConfigurations.kpbj-staging.config.system.build.toplevel
 
 # =============================================================================
 # pgBackRest (Database Backup & Recovery)

--- a/PROVISIONING.md
+++ b/PROVISIONING.md
@@ -57,7 +57,7 @@ Note the droplet IPs from the output:
 
 ```
 stream_prod_droplet_ip = "x.x.x.x"
-stream_staging_droplet_ip = "y.y.y.y"
+staging_droplet_ip = "y.y.y.y"
 ```
 
 Clean up the one-time import file:
@@ -92,7 +92,7 @@ Output will include:
 
 ```
    Host age key: age1abc123...
-   Add this key to .sops.yaml under &vps_stream_staging
+   Add this key to .sops.yaml under &vps_staging
 ```
 
 Save the key. Then do the same for prod:
@@ -117,7 +117,7 @@ Edit `.sops.yaml` and replace the placeholder keys with the real ones from Phase
 
 ```yaml
 - &vps_stream_prod age1<REPLACE_WITH_REAL_PROD_KEY>
-- &vps_stream_staging age1<REPLACE_WITH_REAL_STAGING_KEY>
+- &vps_staging age1<REPLACE_WITH_REAL_STAGING_KEY>
 ```
 
 ## Phase 5: Create Streaming Secrets

--- a/flake.nix
+++ b/flake.nix
@@ -174,7 +174,7 @@
               ./nixos/prod.nix
             ];
           };
-          kpbj-stream-staging = nixpkgs.lib.nixosSystem {
+          kpbj-staging = nixpkgs.lib.nixosSystem {
             system = "x86_64-linux";
             specialArgs = { inherit sync-host-emails token-cleanup kpbj-api; };
             modules = [

--- a/nixos/prod.nix
+++ b/nixos/prod.nix
@@ -16,6 +16,7 @@
     ./pgbackrest.nix
     ./postgresql.nix
     ./web.nix
+    ./watchdog.nix
   ];
 
   networking.hostName = "kpbj-stream-prod";
@@ -46,6 +47,18 @@
 
   # ── Monitoring (Grafana + Loki + Promtail) ───────────────────
   kpbj.monitoring.enable = true;
+
+  # ── Watchdog (LLM log anomaly detection) ────────────────────
+  kpbj.watchdog = {
+    enable = true;
+    secretsFile = ../secrets/prod-web.yaml;
+    recipientEmail = "ssbothwell@gmail.com";
+    environment = "prod";
+    knownIssues = [
+      "androxgh0st and similar bots scanning for .env files — normal internet noise, ignore unless volume spikes dramatically"
+      "Node.js command injection probes (child_process.execSync, process.mainModule, etc.) — irrelevant to Haskell/Servant, ignore"
+    ];
+  };
 
   # ── pgBackRest (PG backups + WAL archiving) ──────────────────
   kpbj.pgbackrest = {

--- a/nixos/scripts/watchdog.sh
+++ b/nixos/scripts/watchdog.sh
@@ -1,0 +1,249 @@
+# shellcheck shell=bash
+# ──────────────────────────────────────────────────────────────
+# KPBJ Watchdog — LLM-powered log anomaly detection
+# ──────────────────────────────────────────────────────────────
+#
+# Collects journal logs, service statuses, and system stats from
+# a NixOS droplet, sends them to the Gemini 2.5 Flash API for
+# anomaly detection, and emails the operator via msmtp if
+# anything looks wrong.
+#
+# Expected to be wrapped by pkgs.writeShellApplication which
+# adds the shebang and set -euo pipefail. Do NOT add a shebang.
+# ──────────────────────────────────────────────────────────────
+
+# ── 1. Validate required environment variables ───────────────
+
+required_vars=(
+  GEMINI_API_KEY
+  WATCHDOG_ENV
+  WATCHDOG_RECIPIENT
+  WATCHDOG_INTERVAL
+  MSMTP_CONFIG
+)
+
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "ERROR: Required environment variable ${var} is not set." >&2
+    exit 1
+  fi
+done
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+echo "[${TIMESTAMP}] Watchdog starting (env=${WATCHDOG_ENV}, interval=${WATCHDOG_INTERVAL}m)"
+
+# ── 2. Collect data ──────────────────────────────────────────
+
+# Journal logs from KPBJ services and PostgreSQL.
+# journalctl may return non-zero if no entries match the time window.
+journal_logs=$(journalctl \
+  --since "${WATCHDOG_INTERVAL} minutes ago" \
+  -u 'kpbj-*' \
+  -u postgresql \
+  --no-pager \
+  --no-hostname \
+  -n 500 2>&1) || true
+
+# Service statuses. systemctl status returns non-zero for
+# failed/inactive services, which is expected.
+service_status=$(systemctl status \
+  kpbj-web \
+  kpbj-icecast \
+  kpbj-liquidsoap \
+  kpbj-webhook \
+  postgresql 2>&1) || true
+
+# System resource stats.
+disk_usage=$(df -h /)
+memory_usage=$(free -h)
+system_uptime=$(uptime)
+
+# ── 3. Build the Gemini system prompt ────────────────────────
+
+read -r -d '' SYSTEM_PROMPT << 'SYSPROMPT' || true
+You are a watchdog for KPBJ 95.9FM community radio infrastructure running on a NixOS server. Your job is to analyze system logs, service statuses, and resource metrics to detect anomalies that need operator attention.
+
+## KPBJ Services
+
+- **kpbj-web.service** — Haskell/Servant web application. Serves the website, dashboard, and playout API. Should be active and running. Logs HTTP requests and application events.
+- **kpbj-icecast.service** — Icecast streaming server. Serves audio to listeners. Should be active and running. Listener connects/disconnects are normal.
+- **kpbj-liquidsoap.service** — Liquidsoap audio automation. Polls the web API for the playlist schedule, fetches audio files, and streams to Icecast. Should be active and running. Routine polling and track changes are normal.
+- **kpbj-webhook.service** — Webhook listener for service restarts triggered by deployments. Should be active and running. Occasional restart commands are normal during deploys.
+- **postgresql.service** — PostgreSQL database. Should be active and running. Routine autovacuum, checkpoints, and connection handling are normal.
+- **kpbj-token-cleanup.service** — Oneshot timer job. Deletes expired auth tokens. Runs hourly. It is normal for this to be inactive (dead) between runs.
+- **kpbj-sync-host-emails.service** — Oneshot timer job. Syncs host emails from Google Workspace. Runs hourly. It is normal for this to be inactive (dead) between runs.
+- **kpbj-backup-full.service** — Oneshot timer job. Runs pgBackRest full PostgreSQL backup. Runs daily. It is normal for this to be inactive (dead) between runs.
+
+## What to FLAG (anomalies requiring attention)
+
+- Any long-running service (kpbj-web, kpbj-icecast, kpbj-liquidsoap, kpbj-webhook, postgresql) in failed, inactive, or activating state
+- Repeated crash loops or rapid restart patterns
+- Error spikes: many ERROR or FATAL log lines in a short period
+- Out-of-memory (OOM) kills or memory pressure warnings
+- Disk usage above 85%
+- Unusual SSH login patterns (failed auth from unexpected IPs, brute force)
+- Liquidsoap failing to fetch audio or losing connection to Icecast
+- Icecast mount point going down or source disconnecting unexpectedly
+- Database errors: connection refused, too many connections, replication lag, corruption
+- Backup failures in kpbj-backup-full
+- TLS/certificate errors
+- Systemd dependency failures (service failed because a required unit failed)
+
+## What is NORMAL and should NOT be flagged
+
+- Listener connects and disconnects in Icecast (these are routine)
+- Liquidsoap polling the API and fetching tracks (routine operation)
+- PostgreSQL autovacuum, checkpoint, and WAL archiving activity
+- Oneshot timer services (kpbj-token-cleanup, kpbj-sync-host-emails, kpbj-backup-full) showing as inactive/dead — they only run on their timer schedule
+- Empty or sparse journal logs during quiet periods
+- Normal HTTP request logs (200/301/302 responses)
+- Routine service startup messages after a deploy
+- pgBackRest info-level backup logs
+
+## Response Format
+
+If everything looks normal, respond with exactly:
+NO_ISSUES
+
+If you detect an anomaly, respond with:
+SUBJECT: <one-line summary of the most important finding>
+<detailed analysis in plain text, explaining what you found, why it matters, and suggested next steps>
+
+Important rules:
+- Be concise. Operators are busy.
+- Only flag genuine problems, not routine operations.
+- If in doubt, do NOT flag it. False alarms erode trust.
+- The SUBJECT line must be short enough for an email subject (under 80 chars).
+- Never include markdown formatting — this goes into a plain-text email.
+SYSPROMPT
+
+# Append known issues to the system prompt if the file is non-empty.
+if [[ -s "${WATCHDOG_KNOWN_ISSUES_FILE:-}" ]]; then
+  known_issues=$(cat "${WATCHDOG_KNOWN_ISSUES_FILE}")
+  SYSTEM_PROMPT="${SYSTEM_PROMPT}
+
+## Known Issues — Do NOT Flag
+
+The following are known, acknowledged issues. Do NOT flag them unless the pattern changes significantly (e.g. volume spikes, new IPs, or different behavior).
+
+${known_issues}"
+fi
+
+# ── 4. Build JSON payload with jq (safe escaping) ───────────
+
+user_message=$(jq -n \
+  --arg env "${WATCHDOG_ENV}" \
+  --arg interval "${WATCHDOG_INTERVAL}" \
+  --arg timestamp "${TIMESTAMP}" \
+  --arg journal "${journal_logs}" \
+  --arg services "${service_status}" \
+  --arg disk "${disk_usage}" \
+  --arg memory "${memory_usage}" \
+  --arg uptime_info "${system_uptime}" \
+  '{
+    text: ("Analyze these logs and metrics from the KPBJ " + $env + " server.\nCollection time: " + $timestamp + "\nLookback window: " + $interval + " minutes\n\n--- JOURNAL LOGS (last " + $interval + " minutes) ---\n" + $journal + "\n\n--- SERVICE STATUSES ---\n" + $services + "\n\n--- DISK USAGE ---\n" + $disk + "\n\n--- MEMORY ---\n" + $memory + "\n\n--- UPTIME ---\n" + $uptime_info)
+  }' | jq -r '.text')
+
+payload=$(jq -n \
+  --arg system_prompt "${SYSTEM_PROMPT}" \
+  --arg user_message "${user_message}" \
+  '{
+    system_instruction: {
+      parts: [{ text: $system_prompt }]
+    },
+    contents: [{
+      parts: [{ text: $user_message }]
+    }],
+    generationConfig: {
+      temperature: 0.1,
+      maxOutputTokens: 4096
+    }
+  }')
+
+# ── 5. Call the Gemini API ───────────────────────────────────
+
+api_url="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+
+http_response=$(curl -s -w "\n%{http_code}" \
+  --max-time 60 \
+  --retry 2 \
+  --retry-delay 5 \
+  -H "Content-Type: application/json" \
+  -H "x-goog-api-key: ${GEMINI_API_KEY}" \
+  -d @<(printf '%s' "${payload}") \
+  "${api_url}") || true
+
+# Split response body and HTTP status code.
+http_code=$(echo "${http_response}" | tail -n1)
+response_body=$(echo "${http_response}" | sed '$d')
+
+# ── 6. Parse Gemini response ────────────────────────────────
+
+if [[ -z "${http_code}" || "${http_code}" -ne 200 ]]; then
+  echo "[${TIMESTAMP}] Gemini API returned HTTP ${http_code}" >&2
+  analysis="SUBJECT: Watchdog API error (HTTP ${http_code}) on ${WATCHDOG_ENV}
+The watchdog script failed to reach the Gemini API.
+
+HTTP status: ${http_code}
+Response body (truncated):
+$(echo "${response_body}" | head -c 2000)
+
+This means log analysis did not run. Check the API key and network connectivity."
+else
+  analysis=$(echo "${response_body}" | jq -r '.candidates[0].content.parts[0].text // empty') || true
+
+  if [[ -z "${analysis}" ]]; then
+    echo "[${TIMESTAMP}] Failed to extract text from Gemini response" >&2
+    analysis="SUBJECT: Watchdog failed to parse Gemini response on ${WATCHDOG_ENV}
+The Gemini API returned HTTP 200 but the response could not be parsed.
+
+Raw response (truncated):
+$(echo "${response_body}" | head -c 2000)
+
+This may indicate an API schema change or an unexpected error format."
+  fi
+fi
+
+# ── 7. Check result and notify ───────────────────────────────
+
+# Trim whitespace for comparison.
+analysis_trimmed=$(echo "${analysis}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+if [[ "${analysis_trimmed}" == "NO_ISSUES" ]]; then
+  echo "[${TIMESTAMP}] Watchdog complete: no issues detected."
+  exit 0
+fi
+
+echo "[${TIMESTAMP}] Watchdog detected issues, sending alert."
+
+# Parse the SUBJECT line from the first line of the response.
+subject_line=$(echo "${analysis}" | head -n1)
+if [[ "${subject_line}" == SUBJECT:* ]]; then
+  raw_subject=$(echo "${subject_line#SUBJECT: }" | tr -d '\n\r')
+  email_subject=$(echo "${raw_subject}" | head -c 78)
+  email_body=$(echo "${analysis}" | tail -n +2)
+  # If the subject was truncated, prepend the full line to the body.
+  if [[ "${#raw_subject}" -gt 78 ]]; then
+    email_body=$(printf '%s\n\n%s' "${raw_subject}" "${email_body}")
+  fi
+else
+  # No SUBJECT prefix — use a generic subject and include full text as body.
+  email_subject="Watchdog alert on ${WATCHDOG_ENV}"
+  email_body="${analysis}"
+fi
+
+# Compose and send the email.
+{
+  echo "From: KPBJ Watchdog <noreply@kpbj.fm>"
+  echo "To: ${WATCHDOG_RECIPIENT}"
+  echo "Subject: [KPBJ ${WATCHDOG_ENV}] ${email_subject}"
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo ""
+  echo "${email_body}"
+  echo ""
+  echo "---"
+  echo "KPBJ Watchdog | ${WATCHDOG_ENV} | ${TIMESTAMP}"
+} | msmtp -C "${MSMTP_CONFIG}" "${WATCHDOG_RECIPIENT}"
+
+echo "[${TIMESTAMP}] Alert sent to ${WATCHDOG_RECIPIENT}."

--- a/nixos/staging.nix
+++ b/nixos/staging.nix
@@ -16,6 +16,7 @@
     ./pgbackrest.nix
     ./postgresql.nix
     ./web.nix
+    ./watchdog.nix
   ];
 
   networking.hostName = "kpbj-staging";
@@ -47,6 +48,21 @@
 
   # ── Monitoring (Grafana + Loki + Promtail) ───────────────────
   kpbj.monitoring.enable = true;
+
+  # ── Watchdog (LLM log anomaly detection) ────────────────────
+  kpbj.watchdog = {
+    enable = true;
+    secretsFile = ../secrets/staging-web.yaml;
+    recipientEmail = "ssbothwell@gmail.com";
+    environment = "staging";
+    timerInterval = "*:0/30";
+    lookbackMinutes = 30;
+    knownIssues = [
+      "androxgh0st and similar bots scanning for .env files — normal internet noise, ignore unless volume spikes dramatically"
+      "Node.js command injection probes (child_process.execSync, process.mainModule, etc.) — irrelevant to Haskell/Servant, ignore"
+      "sync-host-emails running in dry-run mode on staging with out-of-sync membership — intentional, staging uses dry-run by design"
+    ];
+  };
 
   # ── pgBackRest (PG backups + WAL archiving) ──────────────────
   kpbj.pgbackrest = {

--- a/nixos/staging.nix
+++ b/nixos/staging.nix
@@ -18,7 +18,7 @@
     ./web.nix
   ];
 
-  networking.hostName = "kpbj-stream-staging";
+  networking.hostName = "kpbj-staging";
 
   kpbj.sops.secretsFile = ../secrets/staging-streaming.yaml;
 

--- a/nixos/watchdog.nix
+++ b/nixos/watchdog.nix
@@ -1,0 +1,137 @@
+# ──────────────────────────────────────────────────────────────
+# Watchdog — LLM-powered log anomaly detection timer
+# ──────────────────────────────────────────────────────────────
+#
+# Runs the watchdog bash script as a oneshot systemd service on
+# a timer. Collects recent journald logs, sends them to Gemini
+# for anomaly analysis, and emails alerts via msmtp when issues
+# are detected. Reads GEMINI_API_KEY from its own SOPS secret
+# and SMTP password from the shared web secrets.
+# ──────────────────────────────────────────────────────────────
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.kpbj.watchdog;
+
+  knownIssuesFile = pkgs.writeText "kpbj-watchdog-known-issues"
+    (lib.concatStringsSep "\n" cfg.knownIssues);
+
+  watchdogScript = pkgs.writeShellApplication {
+    name = "kpbj-watchdog";
+    runtimeInputs = [ pkgs.curl pkgs.jq pkgs.msmtp pkgs.systemd pkgs.procps ];
+    text = builtins.readFile ./scripts/watchdog.sh;
+  };
+in
+{
+  options.kpbj.watchdog = {
+    enable = lib.mkEnableOption "KPBJ watchdog log monitor";
+
+    secretsFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to the SOPS-encrypted YAML file containing gemini_api_key and smtp_password.";
+    };
+
+    timerInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "*:0/15";
+      description = "Systemd OnCalendar spec for how often to run the watchdog.";
+    };
+
+    lookbackMinutes = lib.mkOption {
+      type = lib.types.int;
+      default = 15;
+      description = "How many minutes of logs to look back each run. Should match timerInterval.";
+    };
+
+    recipientEmail = lib.mkOption {
+      type = lib.types.str;
+      description = "Email address to send alerts to.";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.str;
+      description = "Environment name shown in alerts (e.g. 'prod', 'staging').";
+    };
+
+    knownIssues = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "Known issues the watchdog should ignore unless the pattern changes significantly.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # ── SOPS secrets ──────────────────────────────────────────
+    sops.secrets.gemini_api_key = {
+      sopsFile = cfg.secretsFile;
+    };
+
+    # Declare smtp_password here too so watchdog.nix is
+    # self-contained. SOPS-nix deduplicates declarations for
+    # the same secret name, so this is safe alongside web.nix.
+    sops.secrets.smtp_password = {
+      sopsFile = cfg.secretsFile;
+    };
+
+    # ── SOPS templates ────────────────────────────────────────
+    sops.templates."kpbj-watchdog.env" = {
+      content = ''
+        GEMINI_API_KEY=${config.sops.placeholder.gemini_api_key}
+        WATCHDOG_ENV=${cfg.environment}
+        WATCHDOG_RECIPIENT=${cfg.recipientEmail}
+        WATCHDOG_INTERVAL=${toString cfg.lookbackMinutes}
+        MSMTP_CONFIG=${config.sops.templates."kpbj-watchdog-msmtprc".path}
+      '';
+    };
+
+    sops.templates."kpbj-watchdog-msmtprc" = {
+      content = ''
+        account default
+        host smtp.gmail.com
+        port 587
+        tls on
+        tls_trust_file /etc/ssl/certs/ca-certificates.crt
+        auth on
+        user noreply@kpbj.fm
+        password ${config.sops.placeholder.smtp_password}
+        from noreply@kpbj.fm
+      '';
+    };
+
+    # ── Systemd service ─────────────────────────────────────────
+    systemd.services.kpbj-watchdog = {
+      description = "KPBJ watchdog — LLM log anomaly detection";
+
+      serviceConfig = {
+        Type = "oneshot";
+
+        EnvironmentFile = [ config.sops.templates."kpbj-watchdog.env".path ];
+        Environment = [ "WATCHDOG_KNOWN_ISSUES_FILE=${knownIssuesFile}" ];
+
+        ExecStart = "${watchdogScript}/bin/kpbj-watchdog";
+
+        # Hardening
+        NoNewPrivileges = true;
+        ProtectHome = true;
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictRealtime = true;
+      };
+    };
+
+    # ── Systemd timer ───────────────────────────────────────────
+    systemd.timers.kpbj-watchdog = {
+      description = "Run KPBJ watchdog on a schedule";
+      wantedBy = [ "timers.target" ];
+
+      timerConfig = {
+        OnCalendar = cfg.timerInterval;
+        RandomizedDelaySec = "60";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/scripts/nixos-setup.sh
+++ b/scripts/nixos-setup.sh
@@ -121,7 +121,7 @@ echo "════════════════════════�
 echo ""
 echo "Next steps:"
 echo "  1. Review nixos/hardware-digitalocean.nix"
-echo "  2. Add host age key to .sops.yaml (vps_stream_${ENV})"
+echo "  2. Add host age key to .sops.yaml (check anchor name for ${ENV})"
 echo "  3. Create secrets: sops secrets/${ENV}-streaming.yaml"
 echo "  4. Update keys:    sops updatekeys secrets/${ENV}-streaming.yaml"
 echo "  5. Deploy:         just nixos-deploy-${ENV}"

--- a/scripts/tf-import.sh
+++ b/scripts/tf-import.sh
@@ -173,7 +173,7 @@ HEADER
 # }
 #
 # import {
-#   to = digitalocean_droplet.stream_staging
+#   to = digitalocean_droplet.staging
 #   id = "<droplet-id>"    # doctl compute droplet list
 # }
 #
@@ -183,7 +183,7 @@ HEADER
 # }
 #
 # import {
-#   to = digitalocean_firewall.stream_staging
+#   to = digitalocean_firewall.staging
 #   id = "<firewall-id>"   # doctl compute firewall list
 # }
 #

--- a/secrets/prod-web.yaml
+++ b/secrets/prod-web.yaml
@@ -7,6 +7,7 @@ aws_secret_access_key_pgbackrest: ENC[AES256_GCM,data:3es+Jrdx6qhwNyy9mIjSliQuQN
 google_analytics_gtag: ENC[AES256_GCM,data:3moz29qnL2rUydxk,iv:qnAsnElTqQaKwYv7gbQuK8hy4Qjjf+/2/o9DsnI6CV8=,tag:dXxOVs4IUrJmy36E2T0a/A==,type:str]
 db_readonly_password: ENC[AES256_GCM,data:ufMpG8hVN/0byy/F8FmsaTvN4/2OuC7K5o8f3tdm,iv:06YoYBs855D/3UM4f38MyefUm+mbciNsP3MAXos311k=,tag:UblVJFyeXk+LHDuTV2w5Gw==,type:str]
 db_readwrite_password: ENC[AES256_GCM,data:jR9/AYvMtqc0iu8ygS0YGDnBINam2yhYBD8jFvFe,iv:r69XZ74DEiAEXgl7bgv9Ht2SykqpheY9M2OsGcLPueE=,tag:SWK2xX945j1AE0EriWBuHw==,type:str]
+gemini_api_key: ENC[AES256_GCM,data:JWBzt5K2BmvnxWErOR8YijIXVrnvlTf168STm+AjQ72MczW/eQTA,iv:OvLRsP23EnOdrDbvfSYmiBVfZmca6QcmjeubqGbrBs8=,tag:/x7H/Qt/l3bP7VCx5YS/cw==,type:str]
 sops:
     age:
         - recipient: age1hm87e69thh5c4glk9w2gn2dn3mhexe7cen3c57upfg9zech9qe9sz0ha4j
@@ -45,7 +46,7 @@ sops:
             d2FUZG9pSm1QQ1BMcWpCaWdXU3NvdzQKwBnHGMTeCoHE1PqGWkcEtKspHprVfSFW
             RrHBRYyk0Etdc56sQUMcOoV47Wrf6l9D1D0UBvheHFCtrgcXJoXbkw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-28T03:42:02Z"
-    mac: ENC[AES256_GCM,data:nprSUTZSpfHQQabY4lyYS0TUhLLXKPY/5KlCZQ/yjlkP9TGkBs+381KNhu3uFgpl+e+wN+FTJSydHJ5gN6lsZ2NCb0GZA4yI6XL6ACD7RrIF5pPHl2fkE1JZNhgGgvHyt9bPFhxQeHawc6FlaQgEP0dhHGsanpLt5w1JBAVjC1s=,iv:dKJffxMrqak4hw+dtoGEUJAFEoorDqLTu9IsOOW8SQI=,tag:7BRfYSsirsTRPzNFm2jmmg==,type:str]
+    lastmodified: "2026-02-28T21:10:37Z"
+    mac: ENC[AES256_GCM,data:LJ3GEONKAYnbt9Cl3NUwYorxYYN52ZDJXHtISzestA/VMcgqr/0OF8Mfgu440ZyEr/mdjoV/1V2DMpJFlAkyl0OVeFNJhme9hPf5WaA3aAqkZZ7eeuo3oVKi1TQEzE9HPWbsvllJ3XC+KMZ/hsyCMHdm0Q1YL3mep8e0kXIZ7WE=,iv:1547NV/ITraKSrEmqtCZ64MtI8BGLZqrOUjXI/ZNSZA=,tag:TcgRrmlv84NevhG8F2+l8w==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/secrets/staging-web.yaml
+++ b/secrets/staging-web.yaml
@@ -8,6 +8,7 @@ aws_secret_access_key_pgbackrest: ENC[AES256_GCM,data:oGbJJFn0nYuQXbKWu9Sj9PPxtM
 google_analytics_gtag: ""
 db_readonly_password: ENC[AES256_GCM,data:Ev3p3PQgu7EM4y1ABp/CbVVTXNuVtqvcweFmBEMp,iv:Nm/Qg2M06iVWuO4tTTpD4c5LkIrW5nn+kf1mMdfwh80=,tag:8BVdsg+ftEaHKBUsNYcbSw==,type:str]
 db_readwrite_password: ENC[AES256_GCM,data:7X1C+Br3o0iMhPiDcH4WE9BU/RODgCpeUzLYqTiq,iv:X97H0pgSb+hEJSTvubUX56Je+YQ6djTTafZjKljcG0E=,tag:BBTKUE6XVF42m0SRVVoeeA==,type:str]
+gemini_api_key: ENC[AES256_GCM,data:FEYi69BvvwQ5yqYdqHU6XbZPKhH3BVbSjKMmM4b6JWmo4Ffz8VOT,iv:yg4zjPu2ewoSxf3arDnxV0kV+82ZCTypLFG4QCbmmeY=,tag:NHGnM+mCsOLzauTx25Q4jg==,type:str]
 sops:
     age:
         - recipient: age1hm87e69thh5c4glk9w2gn2dn3mhexe7cen3c57upfg9zech9qe9sz0ha4j
@@ -46,7 +47,7 @@ sops:
             QkhkUVN1Q1IvWnZSMmo3WEJ0TFJFdVEKxqsfOLS4Ya5n7xrVEZd6xYLvrg8Ji6Ei
             L585J+cX70tj77DUDDxH/0EecE63uMAZMuAyo60cECuDMWV4h5DenQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-28T03:41:09Z"
-    mac: ENC[AES256_GCM,data:J5xt39uXDrGcDCDdV2z+nCw8Tr+8H0OWLJmAIuSmhdMmZbQAGSSQPiFd+9OUVJ/2b2gaRxjL+26Et7051sjRao9ocON3dr7rHd47YT202PhPOSMxD42CgV9lLi5nmeGdbkxx/C4kw105vxFsnRc2dIaT7lwLq5i0OyTmdidRT/I=,iv:U3nVrO4kdvn1JmnsJMowDtaeRcM/VRB8oiPfoadz7Qc=,tag:YSi5D31srz7lPE//npgNKw==,type:str]
+    lastmodified: "2026-02-28T21:10:28Z"
+    mac: ENC[AES256_GCM,data:4hzEBvye4Jde5mKAWWwx4tami2347v5i5mV0IP+YDT+Kg7SrJZIX0q5+GJpCexbniZZgW5gLkuN7W95LOAgnAmRfdwzxoiTDo/We5UhJDD+N///+sn2l+cUWpREAFsak1Ql1vCx3TtsY4WvbCsjf/pySqVo+TbKL47EiUgKYUiQ=,iv:PgkCyWmW/oMW+HQqpTTb2TO0OdX9MFdZVo8oY655bfA=,tag:V2BjaJFL39HAWTbI1Q1KjA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/services/web/src/Effects/StagedUploads.hs
+++ b/services/web/src/Effects/StagedUploads.hs
@@ -79,7 +79,8 @@ claimStagedUpload ::
   User.Id ->
   Text ->
   StagedUploads.UploadType ->
-  AppM (Either ClaimError Text)
+  -- | Returns (storagePath, mimeType) on success
+  AppM (Either ClaimError (Text, Text))
 claimStagedUpload userId tokenText expectedType = do
   let token = StagedUploads.Token tokenText
   result <- execQuery (StagedUploads.claimUpload token userId)
@@ -99,7 +100,7 @@ claimStagedUpload userId tokenText expectedType = do
           pure $ Left $ ClaimTypeMismatch actualType expectedType
         else do
           Log.logInfo "Claimed staged upload" (StagedUploads.storagePath stagedUpload)
-          pure $ Right $ StagedUploads.storagePath stagedUpload
+          pure $ Right (StagedUploads.storagePath stagedUpload, StagedUploads.mimeType stagedUpload)
 
 -- | Convert a ClaimError to user-friendly text.
 claimErrorToText :: ClaimError -> Text
@@ -139,7 +140,7 @@ claimAndRelocateUpload userId tokenText expectedType destBucket destResource air
   claimResult <- claimStagedUpload userId tokenText expectedType
   case claimResult of
     Left err -> pure $ Left $ claimErrorToText err
-    Right stagingPath -> do
+    Right (stagingPath, mimeType) -> do
       -- Move to final location
       backend <- asks (Has.getter @StorageBackend)
       mAwsEnv <- asks (Has.getter @(Maybe AWS.Env))
@@ -155,7 +156,7 @@ claimAndRelocateUpload userId tokenText expectedType destBucket destResource air
       let uuidText = Text.filter (/= '-') $ UUID.toText uuid
           destFilename = filenamePrefix <> "_" <> dateStr <> "_" <> uuidText <> "." <> extension
 
-      moveResult <- moveFile backend mAwsEnv stagingPath destBucket destResource dateHier destFilename
+      moveResult <- moveFile backend mAwsEnv stagingPath destBucket destResource dateHier destFilename mimeType
 
       case moveResult of
         Left err -> do
@@ -184,12 +185,14 @@ moveFile ::
   DateHierarchy ->
   -- | Destination filename
   Text ->
+  -- | MIME type (used for S3 Content-Type on the destination object)
+  Text ->
   m (Either Text Text)
-moveFile backend mAwsEnv sourcePath destBucket destResource destDateHier destFilename =
+moveFile backend mAwsEnv sourcePath destBucket destResource destDateHier destFilename mimeType =
   case backend of
     LocalStorage config ->
       Local.moveFileLocal config sourcePath destBucket destResource destDateHier destFilename
     S3Storage config -> case mAwsEnv of
       Nothing -> pure $ Left "S3 storage requires AWS environment"
       Just awsEnv ->
-        S3.moveFileS3 awsEnv config sourcePath destBucket destResource destDateHier destFilename
+        S3.moveFileS3 awsEnv config sourcePath destBucket destResource destDateHier destFilename mimeType

--- a/services/web/src/Effects/Storage/S3.hs
+++ b/services/web/src/Effects/Storage/S3.hs
@@ -16,7 +16,7 @@ where
 
 import Amazonka qualified as AWS
 import Amazonka.S3 qualified as S3
-import Amazonka.S3.CopyObject (copyObject_acl)
+import Amazonka.S3.CopyObject (copyObject_acl, copyObject_contentType)
 import Amazonka.S3.PutObject (putObject_acl, putObject_contentType)
 import Amazonka.S3.Types (ObjectCannedACL (..))
 import Control.Exception (IOException, SomeException)
@@ -204,8 +204,10 @@ moveFileS3 ::
   DateHierarchy ->
   -- | Destination filename
   Text ->
+  -- | MIME type to set on the destination object
+  Text ->
   m (Either Text Text)
-moveFileS3 awsEnv config sourceKey destBucketType destResourceType destDateHier destFilename = liftIO $ do
+moveFileS3 awsEnv config sourceKey destBucketType destResourceType destDateHier destFilename mimeType = liftIO $ do
   let destKey = buildStorageKey destBucketType destResourceType destDateHier destFilename
       bucket = S3.BucketName (s3BucketName config)
       srcKeyObj = S3.ObjectKey sourceKey
@@ -218,6 +220,7 @@ moveFileS3 awsEnv config sourceKey destBucketType destResourceType destDateHier 
     let req =
           S3.newCopyObject bucket copySource destKeyObj
             & copyObject_acl ?~ ObjectCannedACL_Public_read
+            & copyObject_contentType ?~ mimeType
     AWS.send awsEnv req
 
   case copyResult of

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -52,7 +52,7 @@ resource "cloudflare_dns_record" "ssh_staging" {
   zone_id = local.cloudflare_zone_id
   name    = "ssh.staging"
   type    = "A"
-  content = digitalocean_droplet.stream_staging.ipv4_address
+  content = digitalocean_droplet.staging.ipv4_address
   proxied = false
   ttl     = 1
   comment = "Staging SSH deploy (DO VPS, DNS-only)"
@@ -67,7 +67,7 @@ resource "cloudflare_dns_record" "staging_a" {
   zone_id = local.cloudflare_zone_id
   name    = "staging"
   type    = "A"
-  content = digitalocean_droplet.stream_staging.ipv4_address
+  content = digitalocean_droplet.staging.ipv4_address
   proxied = true
   ttl     = 1
   comment = "Staging web (DO VPS)"
@@ -93,7 +93,7 @@ resource "cloudflare_dns_record" "stream_staging" {
   zone_id = local.cloudflare_zone_id
   name    = "stream.staging"
   type    = "A"
-  content = digitalocean_droplet.stream_staging.ipv4_address
+  content = digitalocean_droplet.staging.ipv4_address
   proxied = false
   ttl     = 1
   comment = "Staging audio stream (DO)"
@@ -141,7 +141,7 @@ resource "cloudflare_dns_record" "uploads_staging" {
   zone_id = local.cloudflare_zone_id
   name    = "uploads.staging"
   type    = "A"
-  content = digitalocean_droplet.stream_staging.ipv4_address
+  content = digitalocean_droplet.staging.ipv4_address
   proxied = false
   ttl     = 1
   comment = "Staging file uploads (DO VPS, DNS-only for large uploads)"

--- a/terraform/digitalocean.tf
+++ b/terraform/digitalocean.tf
@@ -46,8 +46,8 @@ resource "digitalocean_droplet" "stream_prod" {
 # Staging Droplet
 # ──────────────────────────────────────────────────────────────
 
-resource "digitalocean_droplet" "stream_staging" {
-  name     = "kpbj-stream-staging"
+resource "digitalocean_droplet" "staging" {
+  name     = "kpbj-staging"
   region   = var.droplet_region
   size     = var.droplet_size_staging
   image    = var.droplet_image
@@ -143,9 +143,9 @@ resource "digitalocean_firewall" "stream_prod" {
   }
 }
 
-resource "digitalocean_firewall" "stream_staging" {
-  name        = "kpbj-stream-staging-fw"
-  droplet_ids = [digitalocean_droplet.stream_staging.id]
+resource "digitalocean_firewall" "staging" {
+  name        = "kpbj-staging-fw"
+  droplet_ids = [digitalocean_droplet.staging.id]
 
   # SSH
   inbound_rule {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,9 +17,9 @@ output "stream_prod_droplet_ip" {
   value       = digitalocean_droplet.stream_prod.ipv4_address
 }
 
-output "stream_staging_droplet_ip" {
-  description = "Public IPv4 address of the staging streaming VPS"
-  value       = digitalocean_droplet.stream_staging.ipv4_address
+output "staging_droplet_ip" {
+  description = "Public IPv4 address of the staging VPS"
+  value       = digitalocean_droplet.staging.ipv4_address
 }
 
 output "cloudflare_zone_id" {


### PR DESCRIPTION
## Summary
- **LLM Watchdog** — New NixOS module (`watchdog.nix`) that runs a systemd timer to collect journald logs, service statuses, and system metrics, sends them to Gemini 2.5 Flash for anomaly detection, and emails alerts via msmtp. Enabled on both prod (15min) and staging (30min) with configurable known-issues suppression.
- **S3 MIME Type Fix** — When staged audio uploads were relocated from staging to their final S3 path via `CopyObject`, the `Content-Type` header was not set, causing DigitalOcean Spaces to default to `binary/octet-stream`. Liquidsoap then failed to detect the file type. The MIME type from the database is now threaded through the claim/relocate/copy pipeline and set on the destination object.
- **Review fixups** — Removed a staging-specific known issue from prod watchdog config, increased Gemini API timeout to 60s, increased error email truncation limit to 2000 chars.

## Test plan
- [x] Verify watchdog timer runs on staging and sends `NO_ISSUES` (or a valid alert) email
- [x] Upload an episode audio file and verify the S3 object has the correct `Content-Type` header after relocation
- [x] Confirm Liquidsoap can fetch and play relocated audio without FFmpeg fallback errors
