### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.9.1] - 2026-02-28
+
 ### Added
 - **LLM-Powered Log Watchdog** — A systemd timer runs every 15 minutes (configurable) on prod and staging, collecting journal logs, service statuses, and system stats. Sends them to the Gemini 2.0 Flash API for anomaly detection and emails the operator if anything looks wrong. Covers service outages, error spikes, resource pressure, security anomalies, and streaming issues. Observe-only — no corrective actions. Cost: ~$1/month.
 - **Off-Site S3 Backups for PostgreSQL** — pgBackRest now supports an optional second repository (repo2) on S3-compatible storage (DigitalOcean Spaces) for off-site disaster recovery. Local repo1 remains for fast restores. Credentials are wired through SOPS and read from disk on the server. S3 failures are treated as warnings — local backups always complete. Daily backups and WAL archiving target both repos when enabled. Setting `s3 = null` reverts to local-only backups.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.9.0
+version:            0.9.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.9.1

This PR releases version 0.9.1

### What's Changed


### Added
- **LLM-Powered Log Watchdog** — A systemd timer runs every 15 minutes (configurable) on prod and staging, collecting journal logs, service statuses, and system stats. Sends them to the Gemini 2.0 Flash API for anomaly detection and emails the operator if anything looks wrong. Covers service outages, error spikes, resource pressure, security anomalies, and streaming issues. Observe-only — no corrective actions. Cost: ~$1/month.
- **Off-Site S3 Backups for PostgreSQL** — pgBackRest now supports an optional second repository (repo2) on S3-compatible storage (DigitalOcean Spaces) for off-site disaster recovery. Local repo1 remains for fast restores. Credentials are wired through SOPS and read from disk on the server. S3 failures are treated as warnings — local backups always complete. Daily backups and WAL archiving target both repos when enabled. Setting `s3 = null` reverts to local-only backups.
- **Optional Episode Schedule** — Episodes can now exist without a schedule slot. This supports episodes created before a show has a schedule, or episodes detached when a schedule template is invalidated.
  - `UNSCHEDULED` badge shown in the dashboard episode list
  - "Scheduled: Unscheduled" displayed on the episode detail page
  - Edit form allows assigning a schedule slot to unscheduled episodes
  - Unscheduled episodes sort last in the dashboard list
  - Unscheduled episodes are excluded from public published episodes
  - E2E tests for schedule state transitions and property tests for unscheduled episode behavior

### Fixed
- **Episode Card Aspect Ratio Mismatch** — Episode artwork is cropped to 1:1 on upload but was rendered in a 4:3 container, cutting off the top and bottom. Now renders as square to match the crop.
- **S3 MIME Type Lost on Staged Upload Relocation** — When staged audio uploads were moved from the staging area to their final archive location via `claimAndRelocateUpload`, the S3 `CopyObject` operation did not set `Content-Type`, causing DigitalOcean Spaces to default to `binary/octet-stream`. Liquidsoap then failed to detect the file type and fell back to the FFmpeg decoder with errors. The MIME type stored in the database is now threaded through and set on the copy request.

### Changed
- **Rename Staging Droplet** — Renamed the staging DigitalOcean droplet from `kpbj-stream-staging` to `kpbj-staging` to reflect that the VPS now hosts more than just the stream. Updated Terraform resources (with `moved` blocks), NixOS hostname and flake config, CI/CD workflows, Justfile, `.sops.yaml`, and docs.
- **Episode Schedule Columns Now Nullable** — `schedule_template_id` and `scheduled_at` columns on `episodes` are no longer `NOT NULL`. A `CHECK` constraint ensures both fields are either `NULL` or both `NOT NULL`.

---

When merged, a git tag v0.9.1 will be automatically created, which triggers the production deployment.
