### PR TITLE
fix: Reject requests with invalid UTF-8 in path/query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ### Fixed
 - **Liquidsoap Annotate Parse Failure on Quoted Titles** — Track titles containing double quotes (e.g. `"Usher II"`) caused Liquidsoap's `annotate:` URI parser to fail with a syntax error. The `sanitizeAnnotateValue` function existed but was only applied in the force-play webhook path — the `/api/playout/fallback` and `/api/playout/now` endpoints passed raw metadata through unsanitized. Moved sanitization into a smart constructor (`mkPlayoutMetadata`) so all `PlayoutMetadata` values are sanitized by construction.
+- **Watchdog False Positives on Liquidsoap Internals** — The LLM watchdog flagged several normal Liquidsoap/FFmpeg messages as anomalies. Added to the watchdog's "NORMAL" list: `Ffmpeg_decoder.End_of_file` (normal track completion), `Could not update timestamps for discarded samples` (VBR MP3 warning), ID3 tag parsing warnings (unsynchronized headers, BOM errors, comment frame errors — FFmpeg handles these as fallback), decoder negotiation messages ("Unsupported MIME type/extension"), and embedded album art reported as video streams.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Invalid UTF-8 Crashes from Exploit Scanners** — Requests with invalid UTF-8 byte sequences in paths or query strings (e.g. `%AD` → `\xad`) crashed the app with `Data.Text.Encoding: Invalid UTF-8 stream` — 11 occurrences in 2 days on staging. Added a WAI middleware that percent-decodes and validates UTF-8 before Servant routing, rejecting malformed requests with 400 Bad Request.
 - **Liquidsoap Annotate Parse Failure on Quoted Titles** — Track titles containing double quotes (e.g. `"Usher II"`) caused Liquidsoap's `annotate:` URI parser to fail with a syntax error. The `sanitizeAnnotateValue` function existed but was only applied in the force-play webhook path — the `/api/playout/fallback` and `/api/playout/now` endpoints passed raw metadata through unsanitized. Moved sanitization into a smart constructor (`mkPlayoutMetadata`) so all `PlayoutMetadata` values are sanitized by construction.
 - **Watchdog False Positives on Liquidsoap Internals** — The LLM watchdog flagged several normal Liquidsoap/FFmpeg messages as anomalies. Added to the watchdog's "NORMAL" list: `Ffmpeg_decoder.End_of_file` (normal track completion), `Could not update timestamps for discarded samples` (VBR MP3 warning), ID3 tag parsing warnings (unsynchronized headers, BOM errors, comment frame errors — FFmpeg handles these as fallback), decoder negotiation messages ("Unsupported MIME type/extension"), and embedded album art reported as video streams.
 

--- a/nixos/scripts/watchdog.sh
+++ b/nixos/scripts/watchdog.sh
@@ -94,6 +94,11 @@ You are a watchdog for KPBJ 95.9FM community radio infrastructure running on a N
 
 - Listener connects and disconnects in Icecast (these are routine)
 - Liquidsoap polling the API and fetching tracks (routine operation)
+- Liquidsoap "Ffmpeg_decoder.End_of_file" messages — this is normal track completion, not a decoding failure. FFmpeg raises End_of_file when it finishes reading a track. The subsequent "Finished with" and new request preparation confirm healthy track transitions.
+- Liquidsoap "Could not update timestamps for discarded samples" warnings — common with VBR MP3s, does not affect playback
+- Liquidsoap ID3 tag parsing warnings: "Unsynchronized headers not handled", "Incorrect BOM value", "Error reading comment frame, skipped" — these mean Liquidsoap's built-in ID3 parser can't read certain tag formats. FFmpeg handles them fine as fallback. Does not affect playback.
+- Liquidsoap "Unsupported MIME type" or "Unsupported file extension" messages during decoder selection — this is normal decoder negotiation, not an error. Liquidsoap tries each decoder in priority order and the correct one (usually ffmpeg) is selected.
+- MP3 files reported as containing video streams (e.g. "video: {codec: mjpeg, ...}") — this is embedded album art in the MP3, not actual video. Completely normal.
 - PostgreSQL autovacuum, checkpoint, and WAL archiving activity
 - Oneshot timer services (kpbj-token-cleanup, kpbj-sync-host-emails, kpbj-backup-full) showing as inactive/dead — they only run on their timer schedule
 - Empty or sparse journal logs during quiet periods

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -511,6 +511,7 @@ library
     Effects.Storage.S3
     Helpers.RelativeTime
     Middleware.NotFound
+    Middleware.ValidateEncoding
     OrphanInstances.DayOfWeek
     OrphanInstances.Rel8
     OrphanInstances.TimeOfDay
@@ -574,6 +575,8 @@ test-suite kpbj-api-test
                     , unliftio-core
                     , uuid
                     , vector
+                    , wai
+                    , http-types
     other-modules:
        App.Handler.CombinatorsSpec
        API.Blog.Get.HandlerSpec
@@ -686,6 +689,7 @@ test-suite kpbj-api-test
        Effects.Database.Tables.UserRoleSpec
        Effects.MimeTypeValidationSpec
        Effects.StagedUploadsSpec
+       Middleware.ValidateEncodingSpec
        Test.Database.Expectation
        Test.Database.Helpers
        Test.Database.Monad

--- a/services/web/src/API.hs
+++ b/services/web/src/API.hs
@@ -159,6 +159,7 @@ import Component.NotFound (notFoundPage)
 import Data.Has (getter)
 import Lucid qualified
 import Middleware.NotFound (notFoundMiddleware)
+import Middleware.ValidateEncoding (validateEncodingMiddleware)
 import Network.Wai.Handler.Warp qualified as Warp
 import Servant (Context ((:.)))
 import Servant qualified
@@ -187,7 +188,10 @@ runApi = do
           -- Build the WAI application with 404 middleware
           servantCtx = Auth.authHandler (appDbPool appCtx) (appEnvironment appCtx) :. Servant.EmptyContext
           warpSettings = App.mkWarpSettings (appLoggerEnv appCtx) (appWarpConfig appCtx)
-          app = notFoundMiddleware notFoundHtml $ App.mkApp @API (const server) servantCtx appCtx
+          app =
+            validateEncodingMiddleware
+              . notFoundMiddleware notFoundHtml
+              $ App.mkApp @API (const server) servantCtx appCtx
 
       Warp.runSettings warpSettings app
 

--- a/services/web/src/Middleware/ValidateEncoding.hs
+++ b/services/web/src/Middleware/ValidateEncoding.hs
@@ -1,0 +1,42 @@
+-- | WAI middleware that rejects requests with invalid UTF-8 in the
+-- path or query string.
+--
+-- Exploit scanners send requests with invalid UTF-8 byte sequences
+-- (e.g. @%AD@ → @\\xad@) which crash downstream decoding with
+-- @Data.Text.Encoding: Invalid UTF-8 stream@. This middleware
+-- percent-decodes the raw path and query, validates UTF-8, and
+-- returns 400 Bad Request for any malformed input before the
+-- request reaches Servant routing.
+module Middleware.ValidateEncoding
+  ( validateEncodingMiddleware,
+    isValidUtf8,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.ByteString (ByteString)
+import Data.Text.Encoding qualified as Text
+import Network.HTTP.Types qualified as HTTP
+import Network.Wai qualified as Wai
+
+--------------------------------------------------------------------------------
+
+-- | Middleware that rejects requests containing invalid UTF-8 in the
+-- path or query string with a 400 Bad Request response.
+validateEncodingMiddleware :: Wai.Middleware
+validateEncodingMiddleware app req respond =
+  if isValidUtf8 (Wai.rawPathInfo req) && isValidUtf8 (Wai.rawQueryString req)
+    then app req respond
+    else respond $ Wai.responseLBS HTTP.status400 [] "Bad Request"
+
+-- | Check whether a percent-encoded 'ByteString' decodes to valid UTF-8.
+--
+-- Percent-decodes the input (without plus-as-space conversion) and
+-- then attempts a strict UTF-8 decode. Returns 'True' when the
+-- decoded bytes form a valid UTF-8 sequence, 'False' otherwise.
+isValidUtf8 :: ByteString -> Bool
+isValidUtf8 bs =
+  case Text.decodeUtf8' (HTTP.urlDecode False bs) of
+    Right _ -> True
+    Left _ -> False

--- a/services/web/test/Main.hs
+++ b/services/web/test/Main.hs
@@ -114,6 +114,7 @@ import Effects.DiffSpec qualified as Diff
 import Effects.MarkdownSpec qualified as Markdown
 import Effects.MimeTypeValidationSpec qualified as MimeTypeValidation
 import Effects.StagedUploadsSpec qualified as StagedUploadsEffects
+import Middleware.ValidateEncodingSpec qualified as ValidateEncoding
 import System.Environment (lookupEnv)
 import Test.Database.Setup (withTmpPG)
 import Test.Hspec
@@ -148,6 +149,7 @@ main = do
     MimeTypeValidation.spec
     UserRole.spec
     StagedUploadsEffects.spec
+    ValidateEncoding.spec
 
   -- Database-dependent tests
   withTmpPG $ hspecWith cfg $ parallel $ do

--- a/services/web/test/Middleware/ValidateEncodingSpec.hs
+++ b/services/web/test/Middleware/ValidateEncodingSpec.hs
@@ -1,0 +1,104 @@
+module Middleware.ValidateEncodingSpec (spec) where
+
+--------------------------------------------------------------------------------
+
+import Data.ByteString (ByteString)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text.Encoding qualified as Text
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Middleware.ValidateEncoding (isValidUtf8, validateEncodingMiddleware)
+import Network.HTTP.Types qualified as HTTP
+import Network.Wai qualified as Wai
+import Network.Wai.Internal (ResponseReceived (..))
+import Test.Hspec
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "Middleware.ValidateEncoding" $ do
+  describe "isValidUtf8" $ do
+    it "accepts an empty bytestring" $
+      isValidUtf8 "" `shouldBe` True
+
+    it "accepts a valid ASCII path" $
+      isValidUtf8 "/api/shows/123" `shouldBe` True
+
+    it "accepts valid multi-byte UTF-8" $
+      -- é encoded as %C3%A9
+      isValidUtf8 "/caf%C3%A9" `shouldBe` True
+
+    it "rejects lone \\xAD (the exploit payload)" $
+      isValidUtf8 "%AD" `shouldBe` False
+
+    it "rejects \\xFF" $
+      isValidUtf8 "%FF" `shouldBe` False
+
+    it "rejects \\xFE" $
+      isValidUtf8 "%FE" `shouldBe` False
+
+    it "rejects \\xC0 (overlong encoding start)" $
+      isValidUtf8 "%C0" `shouldBe` False
+
+    it "rejects invalid byte embedded in valid text" $
+      isValidUtf8 "/valid%ADpath" `shouldBe` False
+
+    it "accepts any valid Text after UTF-8 percent-encoding" $ hedgehog $ do
+      t <- forAll $ Gen.text (Range.linear 0 200) Gen.unicode
+      assert $ isValidUtf8 (HTTP.urlEncode False (Text.encodeUtf8 t))
+
+  describe "validateEncodingMiddleware" $ do
+    it "passes through a request with an ASCII path" $ do
+      (status, passed) <- runMiddleware "/hello" ""
+      passed `shouldBe` True
+      status `shouldBe` 200
+
+    it "passes through percent-encoded valid UTF-8 in path" $ do
+      (status, passed) <- runMiddleware "/caf%C3%A9" ""
+      passed `shouldBe` True
+      status `shouldBe` 200
+
+    it "blocks %AD in path with 400" $ do
+      (status, passed) <- runMiddleware "/exploit%AD" ""
+      passed `shouldBe` False
+      status `shouldBe` 400
+
+    it "blocks %AD in query string with 400" $ do
+      (status, passed) <- runMiddleware "/" "?q=%AD"
+      passed `shouldBe` False
+      status `shouldBe` 400
+
+    it "passes through empty path and query" $ do
+      (status, passed) <- runMiddleware "" ""
+      passed `shouldBe` True
+      status `shouldBe` 200
+
+    it "passes through valid UTF-8 in query string" $ do
+      (status, passed) <- runMiddleware "/" "?q=%C3%A9"
+      passed `shouldBe` True
+      status `shouldBe` 200
+
+--------------------------------------------------------------------------------
+
+-- | Run the middleware with a crafted request and return the response
+-- status code and whether the inner app was called.
+runMiddleware :: ByteString -> ByteString -> IO (Int, Bool)
+runMiddleware path query = do
+  passedRef <- newIORef False
+  let req =
+        Wai.defaultRequest
+          { Wai.rawPathInfo = path,
+            Wai.rawQueryString = query
+          }
+      innerApp _req respond = do
+        writeIORef passedRef True
+        respond $ Wai.responseLBS HTTP.status200 [] ""
+  statusRef <- newIORef 0
+  _ <- validateEncodingMiddleware innerApp req $ \resp -> do
+    writeIORef statusRef (HTTP.statusCode $ Wai.responseStatus resp)
+    pure ResponseReceived
+  status <- readIORef statusRef
+  passed <- readIORef passedRef
+  pure (status, passed)


### PR DESCRIPTION
## Summary

- Adds `Middleware.ValidateEncoding` that percent-decodes `rawPathInfo` and `rawQueryString`, validates UTF-8 via `decodeUtf8'`, and returns 400 Bad Request for malformed input
- Wired as the outermost WAI middleware in `API.hs`, before `notFoundMiddleware`
- Prevents exploit scanners from crashing the app with `Data.Text.Encoding: Invalid UTF-8 stream` (11 occurrences in 2 days on staging)

## Test plan

- [x] 8 pure `isValidUtf8` tests (empty, ASCII, multi-byte UTF-8, lone `\xAD`, `\xFF`, `\xFE`, `\xC0`, invalid embedded in valid)
- [x] 6 WAI-level middleware tests (ASCII passthrough, valid UTF-8 passthrough, `%AD` in path blocked, `%AD` in query blocked, empty path/query passthrough, valid UTF-8 in query passthrough)
- [x] `just build` compiles
- [x] `just test` — 474 tests pass, 0 failures