### PR TITLE
Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.9.2] - 2026-03-01
+
 ### Fixed
 - **Invalid UTF-8 Crashes from Exploit Scanners** — Requests with invalid UTF-8 byte sequences in paths or query strings (e.g. `%AD` → `\xad`) crashed the app with `Data.Text.Encoding: Invalid UTF-8 stream` — 11 occurrences in 2 days on staging. Added a WAI middleware that percent-decodes and validates UTF-8 before Servant routing, rejecting malformed requests with 400 Bad Request.
 - **Liquidsoap Annotate Parse Failure on Quoted Titles** — Track titles containing double quotes (e.g. `"Usher II"`) caused Liquidsoap's `annotate:` URI parser to fail with a syntax error. The `sanitizeAnnotateValue` function existed but was only applied in the force-play webhook path — the `/api/playout/fallback` and `/api/playout/now` endpoints passed raw metadata through unsanitized. Moved sanitization into a smart constructor (`mkPlayoutMetadata`) so all `PlayoutMetadata` values are sanitized by construction.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.9.1
+version:            0.9.2
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.9.2

This PR releases version 0.9.2

### What's Changed


### Fixed
- **Invalid UTF-8 Crashes from Exploit Scanners** — Requests with invalid UTF-8 byte sequences in paths or query strings (e.g. `%AD` → `\xad`) crashed the app with `Data.Text.Encoding: Invalid UTF-8 stream` — 11 occurrences in 2 days on staging. Added a WAI middleware that percent-decodes and validates UTF-8 before Servant routing, rejecting malformed requests with 400 Bad Request.
- **Liquidsoap Annotate Parse Failure on Quoted Titles** — Track titles containing double quotes (e.g. `"Usher II"`) caused Liquidsoap's `annotate:` URI parser to fail with a syntax error. The `sanitizeAnnotateValue` function existed but was only applied in the force-play webhook path — the `/api/playout/fallback` and `/api/playout/now` endpoints passed raw metadata through unsanitized. Moved sanitization into a smart constructor (`mkPlayoutMetadata`) so all `PlayoutMetadata` values are sanitized by construction.
- **Watchdog False Positives on Liquidsoap Internals** — The LLM watchdog flagged several normal Liquidsoap/FFmpeg messages as anomalies. Added to the watchdog's "NORMAL" list: `Ffmpeg_decoder.End_of_file` (normal track completion), `Could not update timestamps for discarded samples` (VBR MP3 warning), ID3 tag parsing warnings (unsynchronized headers, BOM errors, comment frame errors — FFmpeg handles these as fallback), decoder negotiation messages ("Unsupported MIME type/extension"), and embedded album art reported as video streams.
- **Watchdog False Positive on FFmpeg "Header missing"** — FFmpeg's `mp3float` decoder logs a non-fatal "Header missing" warning when it encounters a corrupted or missing MP3 frame header mid-file. The decoder skips the bad frame and continues — no stream disruption. Added to the watchdog's known normal messages. Also moved universal known issues (bot scanner probes, Node.js injection attempts) from per-environment NixOS config into the script's permanent "What is NORMAL" section, reserving the NixOS `knownIssues` option for environment-specific items.

---

When merged, a git tag v0.9.2 will be automatically created, which triggers the production deployment.
