### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.10.0] - 2026-03-08
+
 ### Added
 - **Schedule Editor Component** — Extracted the schedule editor UI into a reusable `Component.ScheduleEditor` shared by the New Show and Edit Show forms. Supports weekly, twice-a-month, and once-a-month frequencies with week selection and interactive time slot management.
 - **Pending Schedule Preview** — The show edit page now displays a read-only "CURRENT SCHEDULE" and "UPCOMING SCHEDULE (starts YYYY-MM-DD)" preview when a future schedule change is configured. Re-editing replaces the pending schedule rather than stacking duplicates.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.9.2
+version:            0.10.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.10.0

This PR releases version 0.10.0

### What's Changed


### Added
- **Schedule Editor Component** — Extracted the schedule editor UI into a reusable `Component.ScheduleEditor` shared by the New Show and Edit Show forms. Supports weekly, twice-a-month, and once-a-month frequencies with week selection and interactive time slot management.
- **Pending Schedule Preview** — The show edit page now displays a read-only "CURRENT SCHEDULE" and "UPCOMING SCHEDULE (starts YYYY-MM-DD)" preview when a future schedule change is configured. Re-editing replaces the pending schedule rather than stacking duplicates.
- **Schedule Re-Edit E2E Test** — Playwright test verifying that submitting a new schedule change cancels and replaces any existing pending schedule.
- **Security Headers Middleware** — WAI middleware that adds `Strict-Transport-Security`, `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` headers to all responses. CSP is locked down with `default-src 'none'` and explicit allows for CDN scripts, styles, media sources, and third-party integrations (Google Analytics, PayPal, Google Forms).
- **Episode Check Job** — New `episode-check` CLI and daily systemd timer. By default, sends individual email reminders to each host exactly 5 days before their show's air date when no episode audio is uploaded. Use `--dry-run` to log what would be sent without emailing. Runs as a hardened oneshot service reusing the existing `DATABASE_URL` and SMTP env vars from `kpbj-web.env`. Deployed to both production and staging.
- **Parameterized Missing Episodes Query** — `getShowsMissingEpisodesInDays` accepts an `Int32` days parameter instead of the hardcoded 7-day window. The existing `getShowsMissingEpisodes` is preserved as a convenience wrapper.
- **Per-Host Missing Episode Query** — `getHostsMissingEpisodesOnDay` returns one row per host (with email) for shows missing episodes on exactly N days from now, used by the notification system.

### Fixed
- **Schedule Page Off by One Hour During DST** — The public schedule page and dashboard episodes list used a hardcoded `UTC-8` (PST) offset for computing the current Pacific time, causing the "now" indicator and "today" calculation to be one hour behind during daylight saving time (March–November). Replaced with the DST-aware `utcToPacific` from `Domain.Types.Timezone` which uses real tzdata via the `tz` library. Also fixed the same bug in the `CurrentlyAiringSpec` test helper.
- **Weekly Schedule Creation Silently Failing** — Shows with weekly schedules (weeks `[1,2,3,4,5]`) had `weeks_of_month` set to `NULL` on insert, violating the `schedule_templates` CHECK constraint that requires `day_of_week` and `weeks_of_month` to both be non-NULL or both NULL. The DB error was logged but not thrown, so the handler returned success without creating the template. Fixed in both New and Edit show handlers.
- **Cancelled Pending Schedules Still Appearing** — When `cancelPendingSchedule` terminated a pending template by setting `effective_until = effective_from`, the `getPendingScheduleTemplatesForShow` query still returned it because `effective_from > CURRENT_DATE` was true. Added `AND (stv.effective_until IS NULL OR stv.effective_until > stv.effective_from)` to filter out zero-length validity periods.
- **Flaky Episode CRUD E2E Test** — `episodes-crud.spec.ts` and `episode-schedule.spec.ts` both selected the first available scheduled date for `sunday-morning-jazz` in parallel, causing a `unique_episode_scheduled_at` constraint violation when the schedule test won the race. Fixed by having `episodes-crud` select the last available date instead.
- **Staging Emails Using localhost URL** — Verification and password reset emails on staging contained `https://localhost:4000` instead of `https://staging.kpbj.fm`. Two issues: (1) the upstream `web-server-core` library overrides `APP_HOSTNAME` to `localhost` for all non-Production environments (fix pending upstream `isProduction` → `isDevelopment` rename), and (2) NixOS configs passed full URLs with scheme (`https://staging.kpbj.fm`) but `App.BaseUrl` also prepends the scheme, causing double-scheme URLs. Fixed NixOS configs to pass bare hostnames. Refactored playout handlers to use `baseUrl` from `AppM` instead of the hardcoded `siteBaseUrl` from `App.Domains`, and removed the now-unused `siteBaseUrl`.
- **Invalid UTF-8 in Headers Crashing Servant** — Exploit scanners sending invalid UTF-8 bytes (e.g. `\xAD`) in HTTP headers bypassed the path/query `ValidateEncoding` middleware and crashed Servant via strict `decodeUtf8` in `Origin`'s `parseHeader`. Fixed `Origin` to use safe `decodeUtf8'` and simplified the middleware to a `catch`-all for `UnicodeException` that covers path, query, headers, and body.
- **Watchdog Self-Referential False Alarms** — The watchdog collected its own service logs via the `kpbj-*` journal filter, so any previous watchdog failure would be flagged as an anomaly on the next successful run — always a false alarm by definition. Excluded `kpbj-watchdog` from log collection.
- **Watchdog "Argument list too long" Crash** — Large journal logs passed via `jq --arg` could exceed Linux's `ARG_MAX` limit, crashing the script. Moved large data (logs, service status, system prompt) to temp files loaded via `jq --rawfile`.

### Changed
- **Self-Hosted Static Assets** — Alpine.js, HTMX, and Cropper.js are now embedded at compile time and served from `/static/` instead of loaded from CDNs (`unpkg.com`, `cdnjs.cloudflare.com`). Fixes CSP `script-src` mismatch that blocked Alpine on HTTP origins (protocol-relative URL resolved to `http://` but CSP only allowed `https://unpkg.com`). Generalized the static asset route from a single hardcoded `range.png` endpoint to a `GET /static/:filename` handler backed by a compile-time embedded asset map. Added `just update-alpinejs`, `just update-htmx`, and `just update-cropperjs` commands to fetch latest versions from jsdelivr. Also applied to the dashboard frame which was still using CDN URLs.
- **Removed Flowbite** — Flowbite JS was loaded in both the public and dashboard frames but never used. Removed the script tags, tightened the CSP by removing `https://cdn.jsdelivr.net` and `https://unpkg.com` from `script-src`, and removed the unused Flowbite data attribute helpers from `Lucid.Alpine`.
- **CSP Fixes for Cropper.js** — Added `blob:` to `img-src` and `connect-src` directives. Cropper.js uses blob URLs for canvas image operations, which the original CSP blocked.
- **Structured Logging for Batch Jobs** — Migrated `token-cleanup` and `sync-host-emails` jobs from ad-hoc `hPutStrLn stderr` logging to `log-base` structured JSON logging, matching the pattern established by `episode-check`.
- **PostgreSQL Graceful Shutdown on Deploy** — Switched PostgreSQL's systemd stop signal from SIGINT (fast shutdown, aborts transactions) to SIGTERM (smart shutdown, waits for clients to disconnect). Prevents non-graceful shutdown warnings from the watchdog during routine `nixos-rebuild switch` deployments.
- **Email Subsystem Refactor** — Replaced monolithic `Effects.MailSender` with `Effects.Email.Send` (unified send/log dispatch) and inlined email templates into their call sites (`EmailVerification`, `ForgotPassword`, `HostNotifications`). Eliminated the `APP_BASE_URL` env var — base URL is now derived from `Hostname` and `Environment` already in the app context.
- **Library Extraction** — Extracted `kpbj-types` and `kpbj-database` from the `kpbj-api` monolith into standalone libraries under `lib/`. `kpbj-types` contains domain types (`Slug`, `FileUpload`, `StorageBackend`, `Filter`, etc.) and orphan instances. `kpbj-database` contains all Rel8 table definitions, queries, and database test infrastructure. Updated `cabal.project` and `flake.nix` to build the new packages.
- **Email Library Extraction** — Extracted `kpbj-email` from `kpbj-api` into `lib/kpbj-email/`. Contains `SmtpConfig`, `loadSmtpConfig`, the `Email` type, and sending functions (`send`, `sendAsync`, `sendMail`, `buildMail`). `sendAsync` is polymorphic over any monad with `MonadIO`, `MonadReader` (with `Has (Maybe SmtpConfig)`), and `MonadLog` constraints. `send` provides synchronous delivery for batch jobs. Moved `baseUrl` to `App.BaseUrl`. Removed `Effects.Email.Send` from the web service entirely — consumers import directly from `kpbj-email`.

---

When merged, a git tag v0.10.0 will be automatically created, which triggers the production deployment.
