### PR TITLE
Release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.10.2] - 2026-03-08
+
 ### Changed
 - **Dynamic Donate Page** — The donate page content is now editable from the dashboard via Site Pages, matching the About, Privacy Policy, and Terms of Service pages. Markdown content is rendered above the PayPal widget. Added seed migration for initial donate page content.
 - **Backup Info Summary** — `just prod-backup-info` and `just staging-backup-info` now show a concise summary (status, backup count, latest backup, WAL archive per repo) instead of raw pgBackRest output. Full detail available via `just prod-backup-info-full` / `just staging-backup-info-full`.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.10.1
+version:            0.10.2
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.10.2

### Changed
- **Dynamic Donate Page** — The donate page content is now editable from the dashboard via Site Pages, matching the About, Privacy Policy, and Terms of Service pages. Markdown content is rendered above the PayPal widget. Added seed migration for initial donate page content.
- **Backup Info Summary** — `just prod-backup-info` and `just staging-backup-info` now show a concise summary (status, backup count, latest backup, WAL archive per repo) instead of raw pgBackRest output. Full detail available via `just prod-backup-info-full` / `just staging-backup-info-full`.
- **Per-Service Log Commands** — Replaced `prod-logs` / `staging-logs` with per-service variants (`prod-logs-web`, `prod-logs-liquidsoap`, `prod-logs-icecast`, `prod-logs-webhook`) that accept optional `since` and `until` args for querying time ranges. `prod-logs` / `staging-logs` now show all four services interleaved.

### Fixed
- **File Uploads Blocked by CSP** — The uploads subdomain (`uploads.kpbj.fm` / `uploads.staging.kpbj.fm`) was missing from the CSP `connect-src` directive, causing browsers to block XHR upload requests introduced in 0.10.0.
- **PayPal Card Icons Blocked by CSP** — The PayPal hosted button's card icons (`Debit_Credit_APM.svg`) were blocked by Content-Security-Policy. Added `https://www.paypalobjects.com` to the `img-src` directive.
- **VPS Timezone** — Set `time.timeZone = "America/Los_Angeles"` in NixOS common config. Previously defaulted to UTC, causing the episode check job's `CURRENT_DATE` to evaluate ~8 hours ahead of Pacific time.

---

When merged, a git tag v0.10.2 will be automatically created, which triggers the production deployment.