### PR TITLE
feat: queue station ID before each fallback ephemeral track

### DIFF
--- a/lib/kpbj-database/src/Effects/Database/Tables/StationIds.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/StationIds.hs
@@ -29,6 +29,7 @@ module Effects.Database.Tables.StationIds
     -- * Queries
     getAllStationIds,
     getStationIdById,
+    getRandomStationId,
     insertStationId,
     deleteStationId,
   )
@@ -181,6 +182,23 @@ getStationIdById stationIdId = fmap listToMaybe $ run $ select do
   row <- each stationIdSchema
   where_ $ simId row ==. lit stationIdId
   pure row
+
+-- | Get a random station ID for playout.
+--
+-- Returns a randomly selected station ID, or Nothing if none exist.
+-- Used by the fallback playout handler to prepend station identification
+-- before ephemeral tracks.
+getRandomStationId :: Hasql.Statement () (Maybe Model)
+getRandomStationId =
+  interp
+    False
+    [sql|
+    SELECT id, title, audio_file_path, mime_type, file_size, creator_id, created_at
+    FROM station_ids
+    ORDER BY RANDOM()
+    LIMIT 1
+  |]
+
 
 -- | Insert a new station ID and return its ID.
 insertStationId :: Insert -> Hasql.Statement () (Maybe Id)

--- a/lib/kpbj-database/test/Effects/Database/Tables/StationIdsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/StationIdsSpec.hs
@@ -33,6 +33,10 @@ spec =
       describe "Queries" $ do
         runs 10 . it "getAllStationIds: returns paginated results" $
           hedgehog . prop_getAllStationIds_paginated
+        runs 10 . it "getRandomStationId: returns a station ID when entries exist" $
+          hedgehog . prop_getRandomStationId
+        runs 10 . it "getRandomStationId: returns Nothing when table is empty" $
+          hedgehog . prop_getRandomStationId_empty
 
       describe "Mutations" $ do
         runs 10 . it "deleteStationId: removes station ID" $ hedgehog . prop_deleteStationId
@@ -107,6 +111,46 @@ prop_getAllStationIds_paginated cfg = do
         length limited === 2
         length offset === 1
         pure ()
+
+-- | getRandomStationId: returns a station ID when entries exist.
+prop_getRandomStationId :: TestDBConfig -> PropertyT IO ()
+prop_getRandomStationId cfg = do
+  arrange (bracketConn cfg) $ do
+    userWithMetadata <- forAllT userWithMetadataInsertGen
+    template <- forAllT $ stationIdInsertGen (User.Id 1)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        userId <- insertTestUser userWithMetadata
+
+        let stationIdInsert = template {UUT.siiCreatorId = userId}
+        _ <- unwrapInsert (UUT.insertStationId stationIdInsert)
+
+        randomStationId <- TRX.statement () UUT.getRandomStationId
+        TRX.condemn
+        pure randomStationId
+
+      assert $ do
+        mRandom <- assertRight result
+        _ <- assertJust mRandom
+        pure ()
+
+
+-- | getRandomStationId: returns Nothing when no station IDs exist.
+prop_getRandomStationId_empty :: TestDBConfig -> PropertyT IO ()
+prop_getRandomStationId_empty cfg = do
+  arrange (bracketConn cfg) $ do
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        randomStationId <- TRX.statement () UUT.getRandomStationId
+        TRX.condemn
+        pure randomStationId
+
+      assert $ do
+        mRandom <- assertRight result
+        assertNothing mRandom
+        pure ()
+
 
 --------------------------------------------------------------------------------
 -- Mutation tests

--- a/services/liquidsoap/radio.liq
+++ b/services/liquidsoap/radio.liq
@@ -41,30 +41,33 @@ null_poll_count = ref(0)
 # survives connection drops (e.g. Icecast container restart).
 last_metadata = ref([])
 
-# Fetch a fallback track from the API
+# Fetch fallback tracks from the API (station ID + ephemeral)
 def get_fallback()
   response = http.get(timeout=5., "#{api_base}/fallback")
   if response.status_code == 200 then
     try
-      let json.parse (data : {url: string, title: string?, artist: string?}) = response
-      title = data.title ?? "KPBJ 95.9 FM"
-      artist = data.artist ?? "Community Radio"
-      url = rewrite_url(data.url)
-      annotated = "annotate:title=\"#{title}\",artist=\"#{artist}\",source_type=\"ephemeral\",source_url=\"#{url}\":#{url}"
-      request.create(annotated)
+      let json.parse (tracks : [{url: string, title: string?, artist: string?, source_type: string?}]) = response
+      list.map(fun(track) -> begin
+        title = track.title ?? "KPBJ 95.9 FM"
+        artist = track.artist ?? "Community Radio"
+        source_type = track.source_type ?? "unknown"
+        url = rewrite_url(track.url)
+        annotated = "annotate:title=\"#{title}\",artist=\"#{artist}\",source_type=\"#{source_type}\",source_url=\"#{url}\":#{url}"
+        request.create(annotated)
+      end, tracks)
     catch _ do
       log.info("[KPBJ] Failed to parse fallback response")
-      null()
+      []
     end
   else
     log.info("[KPBJ] Fallback API returned status #{response.status_code}")
-    null()
+    []
   end
 end
 
 # Fallback source - always has something to play
 # prefetch=1 for accurate metadata timing (higher values queue tracks ahead)
-fallback_queue = request.dynamic(prefetch=1, get_fallback)
+fallback_queue = request.dynamic.list(prefetch=1, get_fallback)
 
 # Add buffer to absorb latency from HTTP downloads (5s buffer, 10s max)
 fallback_source = buffer(buffer=5., max=10., fallback_queue)

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -613,6 +613,7 @@ test-suite kpbj-api-test
        API.Events.Event.Get.HandlerSpec
        API.Events.Get.HandlerSpec
        API.Get.HandlerSpec
+       API.Playout.Fallback.Get.HandlerSpec
        API.Schedule.Get.HandlerSpec
        API.Shows.Get.HandlerSpec
        API.Shows.Slug.Blog.Get.HandlerSpec

--- a/services/web/migrations/20260316151123_add_station_id_source_type.sql
+++ b/services/web/migrations/20260316151123_add_station_id_source_type.sql
@@ -1,0 +1,6 @@
+-- Allow 'station_id' as a source_type in playback_history.
+-- Needed for logging station ID plays from the fallback system.
+
+ALTER TABLE playback_history DROP CONSTRAINT playback_history_source_type_check;
+ALTER TABLE playback_history ADD CONSTRAINT playback_history_source_type_check
+  CHECK (source_type IN ('episode', 'ephemeral', 'station_id'));

--- a/services/web/src/API/Playout/Fallback/Get/Handler.hs
+++ b/services/web/src/API/Playout/Fallback/Get/Handler.hs
@@ -6,7 +6,7 @@ where
 
 --------------------------------------------------------------------------------
 
-import API.Playout.Types (PlayoutResponse (..), mkPlayoutMetadata)
+import API.Playout.Types (FallbackResponse, PlayoutTrack (..), sanitizeAnnotateValue)
 import App.BaseUrl (baseUrl)
 import App.Monad (AppM)
 import App.Storage (StorageBackend (..), buildMediaUrl)
@@ -15,28 +15,51 @@ import Data.Has qualified as Has
 import Data.Text (Text)
 import Effects.Database.Execute (execQuery)
 import Effects.Database.Tables.EphemeralUploads qualified as EphemeralUploads
+import Effects.Database.Tables.StationIds qualified as StationIds
 
 --------------------------------------------------------------------------------
 
 -- | Handler for GET /api/playout/fallback.
 --
--- Returns the audio URL for a randomly selected ephemeral upload.
--- Returns null (PlayoutUnavailable) if no ephemeral uploads exist or on any database error.
--- Used by Liquidsoap for fallback audio when no show is scheduled.
--- Graceful degradation: any error returns null rather than failing.
-handler :: AppM PlayoutResponse
+-- Returns a JSON array of tracks for fallback playback:
+-- 1. A randomly selected station ID (if any exist)
+-- 2. A randomly selected ephemeral upload
+--
+-- Returns an empty array if no ephemeral uploads exist or on ephemeral DB error.
+-- Station ID DB errors are silently skipped (only the ephemeral track is returned).
+handler :: AppM FallbackResponse
 handler = do
-  result <- execQuery EphemeralUploads.getRandomEphemeralUpload
+  ephemeralResult <- execQuery EphemeralUploads.getRandomEphemeralUpload
 
-  case result of
-    Left _err -> pure PlayoutUnavailable -- Graceful degradation on DB error
-    Right Nothing -> pure PlayoutUnavailable
+  case ephemeralResult of
+    Left _err -> pure [] -- Graceful degradation on DB error
+    Right Nothing -> pure []
     Right (Just upload) -> do
-      let metadata = mkPlayoutMetadata upload.eumTitle "KPBJ 95.9 FM"
       storageBackend <- asks (Has.getter @StorageBackend)
       appBaseUrl <- baseUrl
-      let fullUrl = buildFullMediaUrl appBaseUrl storageBackend upload.eumAudioFilePath
-      pure $ PlayoutAvailable fullUrl metadata
+
+      let ephemeralTrack =
+            PlayoutTrack
+              { ptUrl = buildFullMediaUrl appBaseUrl storageBackend upload.eumAudioFilePath,
+                ptTitle = sanitizeAnnotateValue upload.eumTitle,
+                ptArtist = sanitizeAnnotateValue "KPBJ 95.9 FM",
+                ptSourceType = "ephemeral"
+              }
+
+      -- Try to get a station ID; skip on error or if none exist
+      stationIdResult <- execQuery StationIds.getRandomStationId
+      let mStationIdTrack = case stationIdResult of
+            Right (Just sid) ->
+              Just
+                PlayoutTrack
+                  { ptUrl = buildFullMediaUrl appBaseUrl storageBackend sid.simAudioFilePath,
+                    ptTitle = sanitizeAnnotateValue sid.simTitle,
+                    ptArtist = sanitizeAnnotateValue "KPBJ 95.9 FM",
+                    ptSourceType = "station_id"
+                  }
+            _ -> Nothing
+
+      pure $ maybe [ephemeralTrack] (\sidTrack -> [sidTrack, ephemeralTrack]) mStationIdTrack
 
 -- | Build a full URL for media files, ensuring external services can fetch them.
 --

--- a/services/web/src/API/Playout/Fallback/Get/Route.hs
+++ b/services/web/src/API/Playout/Fallback/Get/Route.hs
@@ -6,7 +6,7 @@ where
 
 --------------------------------------------------------------------------------
 
-import API.Playout.Types (PlayoutResponse)
+import API.Playout.Types (FallbackResponse)
 import Servant ((:>))
 import Servant qualified
 
@@ -14,10 +14,14 @@ import Servant qualified
 
 -- | "GET /api/playout/fallback"
 --
--- Returns a random ephemeral track URL for fallback playback, or null if none exist.
+-- Returns a JSON array of tracks for fallback playback:
+-- 1. A randomly selected station ID (if any exist)
+-- 2. A randomly selected ephemeral upload
+--
+-- Returns an empty array if no ephemeral uploads exist or on any database error.
 -- Used by Liquidsoap when no show is scheduled.
 type Route =
   "api"
     :> "playout"
     :> "fallback"
-    :> Servant.Get '[Servant.JSON] PlayoutResponse
+    :> Servant.Get '[Servant.JSON] FallbackResponse

--- a/services/web/src/API/Playout/Now/Get/Handler.hs
+++ b/services/web/src/API/Playout/Now/Get/Handler.hs
@@ -6,7 +6,7 @@ where
 
 --------------------------------------------------------------------------------
 
-import API.Playout.Types (PlayoutResponse (..), mkPlayoutMetadata)
+import API.Playout.Types (NowPlayingResponse (..), mkPlayoutMetadata)
 import App.BaseUrl (baseUrl)
 import App.Monad (AppM)
 import App.Storage (StorageBackend (..), buildMediaUrl)
@@ -25,19 +25,19 @@ import Effects.Database.Tables.Shows qualified as Shows
 -- | Handler for GET /api/playout/now.
 --
 -- Returns the audio URL for the currently airing episode based on the schedule.
--- Returns null (PlayoutUnavailable) if no episode is currently scheduled,
+-- Returns null (NothingPlaying) if no episode is currently scheduled,
 -- if the scheduled episode has no audio uploaded, or on any database error.
 -- Graceful degradation: any error returns null rather than failing.
-handler :: AppM PlayoutResponse
+handler :: AppM NowPlayingResponse
 handler = do
   currentTime <- liftIO getCurrentTime
   result <- execQuery $ Episodes.getCurrentlyAiringEpisode currentTime
 
   case result of
-    Left _err -> pure PlayoutUnavailable -- Graceful degradation on DB error
-    Right Nothing -> pure PlayoutUnavailable
+    Left _err -> pure NothingPlaying -- Graceful degradation on DB error
+    Right Nothing -> pure NothingPlaying
     Right (Just episode) -> case episode.audioFilePath of
-      Nothing -> pure PlayoutUnavailable
+      Nothing -> pure NothingPlaying
       Just audioPath -> do
         -- Fetch show info for metadata
         showResult <- execQuery $ Shows.getShowById episode.showId
@@ -47,7 +47,7 @@ handler = do
         storageBackend <- asks (Has.getter @StorageBackend)
         appBaseUrl <- baseUrl
         let fullUrl = buildFullMediaUrl appBaseUrl storageBackend audioPath
-        pure $ PlayoutAvailable fullUrl metadata
+        pure $ NowPlaying fullUrl metadata
 
 -- | Build a full URL for media files, ensuring external services can fetch them.
 --

--- a/services/web/src/API/Playout/Now/Get/Route.hs
+++ b/services/web/src/API/Playout/Now/Get/Route.hs
@@ -6,7 +6,7 @@ where
 
 --------------------------------------------------------------------------------
 
-import API.Playout.Types (PlayoutResponse)
+import API.Playout.Types (NowPlayingResponse)
 import Servant ((:>))
 import Servant qualified
 
@@ -20,4 +20,4 @@ type Route =
   "api"
     :> "playout"
     :> "now"
-    :> Servant.Get '[Servant.JSON] PlayoutResponse
+    :> Servant.Get '[Servant.JSON] NowPlayingResponse

--- a/services/web/src/API/Playout/Types.hs
+++ b/services/web/src/API/Playout/Types.hs
@@ -4,11 +4,13 @@
 --
 -- These endpoints are used by Liquidsoap to fetch audio URLs for playback.
 module API.Playout.Types
-  ( PlayoutResponse (..),
-    PlayoutMetadata (title, artist),
+  ( PlayoutMetadata (title, artist),
     mkPlayoutMetadata,
     PlayedRequest (..),
     sanitizeAnnotateValue,
+    PlayoutTrack (..),
+    FallbackResponse,
+    NowPlayingResponse (..),
   )
 where
 
@@ -31,21 +33,47 @@ data PlayoutMetadata = PlayoutMetadata
 
 --------------------------------------------------------------------------------
 
--- | Response type for playout endpoints.
+-- | A single track in a playout response with its source type.
+--
+-- Used by the fallback endpoint to return multiple tracks (station ID + ephemeral).
+-- Serializes to flat JSON: @{"url": "...", "title": "...", "artist": "...", "source_type": "..."}@
+data PlayoutTrack = PlayoutTrack
+  { ptUrl :: Text,
+    ptTitle :: Text,
+    ptArtist :: Text,
+    ptSourceType :: Text
+  }
+  deriving stock (Generic, Show, Eq)
+
+instance ToJSON PlayoutTrack where
+  toJSON track =
+    object
+      [ "url" .= track.ptUrl,
+        "title" .= track.ptTitle,
+        "artist" .= track.ptArtist,
+        "source_type" .= track.ptSourceType
+      ]
+
+-- | Fallback response is a list of tracks (station ID + ephemeral).
+--
+-- Serializes to a JSON array. Empty array means no content available.
+type FallbackResponse = [PlayoutTrack]
+
+--------------------------------------------------------------------------------
+
+-- | Response type for the "now playing" endpoint.
 --
 -- Serializes to either:
 -- - @{"url": "https://...", "title": "...", "artist": "..."}@ when audio is available
 -- - @null@ when no audio is available
-data PlayoutResponse
-  = -- | Audio URL is available for playback with metadata
-    PlayoutAvailable Text PlayoutMetadata
-  | -- | No audio currently available
-    PlayoutUnavailable
+data NowPlayingResponse
+  = NowPlaying Text PlayoutMetadata
+  | NothingPlaying
   deriving stock (Generic, Show, Eq)
 
-instance ToJSON PlayoutResponse where
-  toJSON PlayoutUnavailable = toJSON (Nothing :: Maybe Text)
-  toJSON (PlayoutAvailable url meta) =
+instance ToJSON NowPlayingResponse where
+  toJSON NothingPlaying = toJSON (Nothing :: Maybe Text)
+  toJSON (NowPlaying url meta) =
     object
       [ "url" .= url,
         "title" .= meta.title,
@@ -73,8 +101,10 @@ data PlayedRequest = PlayedRequest
 --
 -- Sanitizes title and artist for safe use in Liquidsoap @annotate:@ URIs.
 mkPlayoutMetadata ::
-  Text -> -- ^ Track title
-  Text -> -- ^ Artist name
+  -- | Track title
+  Text ->
+  -- | Artist name
+  Text ->
   PlayoutMetadata
 mkPlayoutMetadata t a =
   PlayoutMetadata

--- a/services/web/test/API/Playout/Fallback/Get/HandlerSpec.hs
+++ b/services/web/test/API/Playout/Fallback/Get/HandlerSpec.hs
@@ -1,0 +1,108 @@
+module API.Playout.Fallback.Get.HandlerSpec where
+
+--------------------------------------------------------------------------------
+
+import API.Playout.Fallback.Get.Handler (handler)
+import API.Playout.Types (PlayoutTrack (..))
+import Control.Monad.IO.Class (liftIO)
+import Data.Int (Int64)
+import Data.Text (Text)
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.EphemeralUploads qualified as EphemeralUploads
+import Effects.Database.Tables.StationIds qualified as StationIds
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Hasql.Transaction.Sessions qualified as TRX
+import Test.Database.Helpers (insertTestEphemeralUpload, insertTestStationId, insertTestUser)
+import Test.Database.Monad (TestDBConfig, withTestDB)
+import Test.Handler.Fixtures (mkUserInsert)
+import Test.Handler.Monad (bracketAppM)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "API.Playout.Fallback.Get.Handler" $ do
+      it "returns 2-element array when both station ID and ephemeral exist" test_bothExist
+      it "returns 1-element array when only ephemeral exists" test_onlyEphemeral
+      it "returns empty array when neither exists" test_neitherExist
+
+--------------------------------------------------------------------------------
+
+mkEphemeralInsert :: Text -> User.Id -> EphemeralUploads.Insert
+mkEphemeralInsert title creatorId =
+  EphemeralUploads.Insert
+    { euiTitle = title,
+      euiDescription = "Test ephemeral upload",
+      euiAudioFilePath = "audio/ephemeral/2026/03/15/test_2026-03-15_abc123.mp3",
+      euiMimeType = "audio/mpeg",
+      euiFileSize = 1024 :: Int64,
+      euiCreatorId = creatorId
+    }
+
+mkStationIdInsert :: Text -> User.Id -> StationIds.Insert
+mkStationIdInsert title creatorId =
+  StationIds.Insert
+    { siiTitle = title,
+      siiAudioFilePath = "audio/station-ids/2026/03/15/test_2026-03-15_def456.mp3",
+      siiMimeType = "audio/mpeg",
+      siiFileSize = 512 :: Int64,
+      siiCreatorId = creatorId
+    }
+
+--------------------------------------------------------------------------------
+
+test_bothExist :: TestDBConfig -> IO ()
+test_bothExist cfg = do
+  userInsert <- mkUserInsert "fallback-both" UserMetadata.Host
+
+  bracketAppM cfg $ do
+    dbResult <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+      userId <- insertTestUser userInsert
+      _ <- insertTestEphemeralUpload (mkEphemeralInsert "Test Ephemeral" userId)
+      _ <- insertTestStationId (mkStationIdInsert "Test Station ID" userId)
+      pure ()
+
+    liftIO $ case dbResult of
+      Left err -> error $ "Setup failed: " <> show err
+      Right () -> pure ()
+
+    tracks <- handler
+
+    liftIO $ do
+      length tracks `shouldBe` 2
+      case tracks of
+        (first : second : _) -> do
+          ptSourceType first `shouldBe` "station_id"
+          ptSourceType second `shouldBe` "ephemeral"
+        _ -> error "Expected at least 2 tracks"
+
+test_onlyEphemeral :: TestDBConfig -> IO ()
+test_onlyEphemeral cfg = do
+  userInsert <- mkUserInsert "fallback-eph-only" UserMetadata.Host
+
+  bracketAppM cfg $ do
+    dbResult <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+      userId <- insertTestUser userInsert
+      _ <- insertTestEphemeralUpload (mkEphemeralInsert "Test Ephemeral" userId)
+      pure ()
+
+    liftIO $ case dbResult of
+      Left err -> error $ "Setup failed: " <> show err
+      Right () -> pure ()
+
+    tracks <- handler
+
+    liftIO $ do
+      length tracks `shouldBe` 1
+      case tracks of
+        (first : _) -> ptSourceType first `shouldBe` "ephemeral"
+        _ -> error "Expected at least 1 track"
+
+test_neitherExist :: TestDBConfig -> IO ()
+test_neitherExist cfg =
+  bracketAppM cfg $ do
+    tracks <- handler
+    liftIO $ tracks `shouldSatisfy` null

--- a/services/web/test/Main.hs
+++ b/services/web/test/Main.hs
@@ -71,6 +71,7 @@ import API.Dashboard.Users.Unsuspend.Post.HandlerSpec qualified as DashboardUser
 import API.Events.Event.Get.HandlerSpec qualified as EventHandler
 import API.Events.Get.HandlerSpec qualified as EventsHandler
 import API.Get.HandlerSpec qualified as HomeHandler
+import API.Playout.Fallback.Get.HandlerSpec qualified as PlayoutFallbackGetHandler
 import API.Schedule.Get.HandlerSpec qualified as ScheduleHandler
 import API.Shows.Get.HandlerSpec qualified as ShowsHandler
 import API.Shows.Slug.Blog.Get.HandlerSpec qualified as ShowBlogHandler
@@ -127,6 +128,7 @@ main = do
   withTmpPG $ hspecWith cfg $ parallel $ do
     Combinators.spec
     HomeHandler.spec
+    PlayoutFallbackGetHandler.spec
     EventsHandler.spec
     EventHandler.spec
     ShowsHandler.spec


### PR DESCRIPTION
Change the fallback playout endpoint from returning a single ephemeral track to a JSON array of tracks: a randomly selected station ID followed by a randomly selected ephemeral upload. Liquidsoap now uses request.dynamic.list to queue both tracks in order, ensuring listeners always hear a station identification clip before fallback content.

- Add getRandomStationId query to StationIds module
- Split PlayoutResponse into FallbackResponse and NowPlayingResponse
- Rewrite fallback handler to return [station_id, ephemeral] array
- Update Liquidsoap to parse array and use request.dynamic.list
- Add station_id to playback_history source_type CHECK constraint
- Add handler integration tests for fallback endpoint