### PR TITLE
feat: Configurable replay times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 - **Analytics Dashboard** — Admin-only dashboard page at `/dashboard/analytics` with live listener count from Icecast, listener trend charts (line), archive play counts by day (bar), and top episodes by plays. Time range selector (24h/7d/30d/90d) with refresh. Uses Chart.js for visualization and Alpine.js for client-side state. Chart data served via JSON endpoint at `/dashboard/analytics/data`.
 - **Cloudflare WAF Custom Rules** — Added 3 WAF rules (of 5 free-tier max) to `cloudflare.tf` that block malicious traffic at the Cloudflare edge before it reaches the origin server: path traversal/LFI/SSRF attempts, known scanner/bot probe paths (wp-admin, .env, phpMyAdmin, etc.), and non-ASCII percent-encoded bytes in URI paths. Complements fail2ban, which cannot ban Cloudflare-proxied traffic via nftables.
 
+### Changed
+- **Configurable Replay Times** — Replaced the `airs_twice_daily` boolean on schedule templates with a `replay_start_time` column that accepts an absolute time of day. Each schedule slot can now specify when (or if) its replay airs, instead of being locked to a +12 hour offset. The schedule editor UI includes an optional replay time picker per slot. Conflict detection covers replay time ranges. Migration swaps existing PM primaries to AM so replays always follow the primary airing.
+
 ### Fixed
 - **S3 Sync File Extension Preservation** — The prod-to-staging S3 sync script was downloading files to a generic temp path (`transfer`) with no extension, then re-uploading. This could cause incorrect content-type inference on the staging bucket. Now preserves the original file extension during transfer (`transfer.$ext`).
+- **Overnight Replay Detection** — Fixed currently-airing query Case 5 (overnight replay before-midnight portion) not correctly handling episodes whose duration fills or exceeds the time until midnight. The old +12h code fell through to a simple comparison that failed when the replay duration crossed midnight.
 - **Episode Check SMTP Config** — The `kpbj-episode-check` systemd service was missing non-secret SMTP environment variables (`APP_SMTP_SERVER`, `APP_SMTP_PORT`, `APP_SMTP_USERNAME`, `APP_SMTP_FROM_EMAIL`, `APP_SMTP_FROM_NAME`), causing it to fail with "SMTP not configured" on every run. The env file only contained the password. Added an `environment` block sourcing these from the web module config.
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 - **Cloudflare WAF Custom Rules** — Added 3 WAF rules (of 5 free-tier max) to `cloudflare.tf` that block malicious traffic at the Cloudflare edge before it reaches the origin server: path traversal/LFI/SSRF attempts, known scanner/bot probe paths (wp-admin, .env, phpMyAdmin, etc.), and non-ASCII percent-encoded bytes in URI paths. Complements fail2ban, which cannot ban Cloudflare-proxied traffic via nftables.
 
 ### Fixed
+- **S3 Sync File Extension Preservation** — The prod-to-staging S3 sync script was downloading files to a generic temp path (`transfer`) with no extension, then re-uploading. This could cause incorrect content-type inference on the staging bucket. Now preserves the original file extension during transfer (`transfer.$ext`).
 - **Episode Check SMTP Config** — The `kpbj-episode-check` systemd service was missing non-secret SMTP environment variables (`APP_SMTP_SERVER`, `APP_SMTP_PORT`, `APP_SMTP_USERNAME`, `APP_SMTP_FROM_EMAIL`, `APP_SMTP_FROM_NAME`), causing it to fail with "SMTP not configured" on every run. The env file only contained the password. Added an `environment` block sourcing these from the web module config.
 
 ### Improved

--- a/lib/kpbj-database/src/Effects/Database/Tables/Episodes.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/Episodes.hs
@@ -431,7 +431,7 @@ getEpisodesByUser userId (Limit lim) (Offset off) =
 -- Standard shows (end > start):
 --
 -- * __Case 1__: Primary airing, scheduled today, within duration or slot
--- * __Case 4__: Replay (+12h), scheduled today, within duration or slot
+-- * __Case 4__: Replay (replay_start_time), scheduled today, within duration or slot
 --
 -- Overnight shows (end <= start, e.g., 11 PM - 2 AM):
 --
@@ -457,106 +457,136 @@ getCurrentlyAiringEpisode currentTime =
         ((#{currentTime} AT TIME ZONE 'America/Los_Angeles')::DATE - INTERVAL '1 day')::DATE as yesterday_pacific,
         (#{currentTime} AT TIME ZONE 'America/Los_Angeles')::TIME as time_now
     ),
-    matching_episodes AS (
+    -- Precompute show duration and replay end time to avoid repeating the
+    -- overnight-aware duration CASE expression across every replay case.
+    schedule_slots AS (
       SELECT
-        e.id, e.show_id, e.description, e.episode_number,
-        e.audio_file_path, e.audio_file_size, e.audio_mime_type, e.duration_seconds,
-        e.artwork_url, e.schedule_template_id, e.scheduled_at, e.published_at,
-        e.deleted_at, e.created_by, e.created_at, e.updated_at
+        st.*,
+        e.id AS ep_id,
+        e.show_id AS ep_show_id,
+        e.description AS ep_description,
+        e.episode_number AS ep_episode_number,
+        e.audio_file_path AS ep_audio_file_path,
+        e.audio_file_size AS ep_audio_file_size,
+        e.audio_mime_type AS ep_audio_mime_type,
+        e.duration_seconds AS ep_duration_seconds,
+        e.artwork_url AS ep_artwork_url,
+        e.schedule_template_id AS ep_schedule_template_id,
+        e.scheduled_at AS ep_scheduled_at,
+        e.published_at AS ep_published_at,
+        e.deleted_at AS ep_deleted_at,
+        e.created_by AS ep_created_by,
+        e.created_at AS ep_created_at,
+        e.updated_at AS ep_updated_at,
+        -- Show duration as interval (handles overnight wraparound)
+        CASE WHEN st.end_time > st.start_time
+          THEN st.end_time - st.start_time
+          ELSE INTERVAL '24 hours' - (st.start_time - st.end_time)
+        END AS show_duration,
+        -- Replay end time (NULL when no replay)
+        (st.replay_start_time + (
+          CASE WHEN st.end_time > st.start_time
+            THEN st.end_time - st.start_time
+            ELSE INTERVAL '24 hours' - (st.start_time - st.end_time)
+          END
+        ))::TIME AS replay_end_time
       FROM episodes e
       JOIN schedule_templates st ON st.id = e.schedule_template_id
       JOIN schedule_template_validity stv ON stv.template_id = st.id
-      CROSS JOIN current_pacific cp
       WHERE
-        -- Episode must have audio and not be deleted
         e.audio_file_path IS NOT NULL
         AND e.deleted_at IS NULL
-        -- Schedule validity must be active for the episode's scheduled date
-        -- effective_from is inclusive, effective_until is exclusive
         AND stv.effective_from <= (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE
         AND (stv.effective_until IS NULL OR stv.effective_until > (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE)
-        AND (
+    ),
+    matching_episodes AS (
+      SELECT
+        ss.ep_id AS id, ss.ep_show_id AS show_id, ss.ep_description AS description,
+        ss.ep_episode_number AS episode_number, ss.ep_audio_file_path AS audio_file_path,
+        ss.ep_audio_file_size AS audio_file_size, ss.ep_audio_mime_type AS audio_mime_type,
+        ss.ep_duration_seconds AS duration_seconds, ss.ep_artwork_url AS artwork_url,
+        ss.ep_schedule_template_id AS schedule_template_id, ss.ep_scheduled_at AS scheduled_at,
+        ss.ep_published_at AS published_at, ss.ep_deleted_at AS deleted_at,
+        ss.ep_created_by AS created_by, ss.ep_created_at AS created_at, ss.ep_updated_at AS updated_at
+      FROM schedule_slots ss
+      CROSS JOIN current_pacific cp
+      WHERE
+        (
           -- Case 1: Standard show (end > start) scheduled for today
-          -- Use episode duration as effective end time (fall back to slot end if NULL)
           (
-            st.end_time > st.start_time
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
-            AND cp.time_now >= st.start_time
+            ss.end_time > ss.start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
+            AND cp.time_now >= ss.start_time
             AND cp.time_now < LEAST(
-              st.end_time,
-              (st.start_time + COALESCE(e.duration_seconds * INTERVAL '1 second', st.end_time - st.start_time))::TIME
+              ss.end_time,
+              (ss.start_time + COALESCE(ss.ep_duration_seconds * INTERVAL '1 second', ss.show_duration))::TIME
             )
           )
           OR
           -- Case 2: Overnight show (end <= start) - before midnight portion (scheduled today)
-          -- Check if we're past start AND either duration extends past midnight OR we're within duration
           (
-            st.end_time <= st.start_time
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
-            AND cp.time_now >= st.start_time
+            ss.end_time <= ss.start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
+            AND cp.time_now >= ss.start_time
             AND (
-              -- If duration is NULL, allow full before-midnight portion
-              e.duration_seconds IS NULL
-              -- If duration extends past midnight, allow the entire before-midnight portion
-              OR e.duration_seconds >= EXTRACT(EPOCH FROM (TIME '24:00:00' - st.start_time))
-              -- If duration ends before midnight, check if we're still within it
-              OR cp.time_now < (st.start_time + e.duration_seconds * INTERVAL '1 second')::TIME
+              ss.ep_duration_seconds IS NULL
+              OR ss.ep_duration_seconds >= EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.start_time))
+              OR cp.time_now < (ss.start_time + ss.ep_duration_seconds * INTERVAL '1 second')::TIME
             )
           )
           OR
           -- Case 3: Overnight show (end <= start) - after midnight portion (scheduled yesterday)
-          -- Check if duration extends past midnight
           (
-            st.end_time <= st.start_time
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.yesterday_pacific
+            ss.end_time <= ss.start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.yesterday_pacific
             AND cp.time_now < LEAST(
-              st.end_time,
-              -- Duration from start, wrapping past midnight: total duration minus time before midnight
+              ss.end_time,
               CASE
-                WHEN e.duration_seconds IS NULL THEN st.end_time
-                WHEN e.duration_seconds > EXTRACT(EPOCH FROM (TIME '24:00:00' - st.start_time))
-                THEN ((e.duration_seconds - EXTRACT(EPOCH FROM (TIME '24:00:00' - st.start_time))) * INTERVAL '1 second')::TIME
-                ELSE TIME '00:00:00'  -- Duration ended before midnight; 00:00 < any time, so this case won't match
+                WHEN ss.ep_duration_seconds IS NULL THEN ss.end_time
+                WHEN ss.ep_duration_seconds > EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.start_time))
+                THEN ((ss.ep_duration_seconds - EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.start_time))) * INTERVAL '1 second')::TIME
+                ELSE TIME '00:00:00'
               END
             )
           )
           OR
-          -- Case 4: Replay airing (+12 hours) for standard shows scheduled today
+          -- Case 4: Replay airing for standard replay shows scheduled today
           (
-            st.airs_twice_daily = TRUE
-            AND (st.end_time + INTERVAL '12 hours')::TIME > (st.start_time + INTERVAL '12 hours')::TIME
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
-            AND cp.time_now >= (st.start_time + INTERVAL '12 hours')::TIME
+            ss.replay_start_time IS NOT NULL
+            AND ss.replay_end_time > ss.replay_start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
+            AND cp.time_now >= ss.replay_start_time
             AND cp.time_now < LEAST(
-              (st.end_time + INTERVAL '12 hours')::TIME,
-              ((st.start_time + INTERVAL '12 hours') + COALESCE(e.duration_seconds * INTERVAL '1 second', st.end_time - st.start_time))::TIME
+              ss.replay_end_time,
+              (ss.replay_start_time + COALESCE(ss.ep_duration_seconds * INTERVAL '1 second', ss.show_duration))::TIME
             )
           )
           OR
-          -- Case 5: Replay airing for overnight shows - before midnight portion (scheduled today)
+          -- Case 5: Replay airing for overnight replay shows - before midnight portion (scheduled today)
           (
-            st.airs_twice_daily = TRUE
-            AND (st.end_time + INTERVAL '12 hours')::TIME <= (st.start_time + INTERVAL '12 hours')::TIME
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
-            AND cp.time_now >= (st.start_time + INTERVAL '12 hours')::TIME
+            ss.replay_start_time IS NOT NULL
+            AND ss.replay_end_time <= ss.replay_start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.today_pacific
+            AND cp.time_now >= ss.replay_start_time
             AND (
-              e.duration_seconds IS NULL
-              OR cp.time_now < ((st.start_time + INTERVAL '12 hours') + e.duration_seconds * INTERVAL '1 second')::TIME
+              ss.ep_duration_seconds IS NULL
+              OR ss.ep_duration_seconds >= EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.replay_start_time))
+              OR cp.time_now < (ss.replay_start_time + ss.ep_duration_seconds * INTERVAL '1 second')::TIME
             )
           )
           OR
-          -- Case 6: Replay airing for overnight shows - after midnight portion (scheduled yesterday)
+          -- Case 6: Replay airing for overnight replay shows - after midnight portion (scheduled yesterday)
           (
-            st.airs_twice_daily = TRUE
-            AND (st.end_time + INTERVAL '12 hours')::TIME <= (st.start_time + INTERVAL '12 hours')::TIME
-            AND (e.scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.yesterday_pacific
+            ss.replay_start_time IS NOT NULL
+            AND ss.replay_end_time <= ss.replay_start_time
+            AND (ss.ep_scheduled_at AT TIME ZONE 'America/Los_Angeles')::DATE = cp.yesterday_pacific
             AND cp.time_now < LEAST(
-              (st.end_time + INTERVAL '12 hours')::TIME,
+              ss.replay_end_time,
               CASE
-                WHEN e.duration_seconds IS NULL THEN (st.end_time + INTERVAL '12 hours')::TIME
-                WHEN e.duration_seconds > EXTRACT(EPOCH FROM (TIME '24:00:00' - (st.start_time + INTERVAL '12 hours')::TIME))
-                THEN ((e.duration_seconds - EXTRACT(EPOCH FROM (TIME '24:00:00' - (st.start_time + INTERVAL '12 hours')::TIME))) * INTERVAL '1 second')::TIME
-                ELSE TIME '00:00:00'  -- Duration ended before midnight; 00:00 < any time, so this case won't match
+                WHEN ss.ep_duration_seconds IS NULL THEN ss.replay_end_time
+                WHEN ss.ep_duration_seconds > EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.replay_start_time))
+                THEN ((ss.ep_duration_seconds - EXTRACT(EPOCH FROM (TIME '24:00:00' - ss.replay_start_time))) * INTERVAL '1 second')::TIME
+                ELSE TIME '00:00:00'
               END
             )
           )

--- a/lib/kpbj-database/src/Effects/Database/Tables/ShowSchedule.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ShowSchedule.hs
@@ -106,7 +106,7 @@ data ScheduleTemplate f = ScheduleTemplate
     stEndTime :: Column f TimeOfDay,
     stTimezone :: Column f Text,
     stCreatedAt :: Column f UTCTime,
-    stAirsTwiceDaily :: Column f Bool
+    stReplayStartTime :: Column f (Maybe TimeOfDay)
   }
   deriving stock (Generic)
   deriving anyclass (Rel8able)
@@ -135,7 +135,7 @@ scheduleTemplateSchema =
             stEndTime = "end_time",
             stTimezone = "timezone",
             stCreatedAt = "created_at",
-            stAirsTwiceDaily = "airs_twice_daily"
+            stReplayStartTime = "replay_start_time"
           }
     }
 
@@ -147,7 +147,7 @@ data ScheduleTemplateInsert = ScheduleTemplateInsert
     stiStartTime :: TimeOfDay,
     stiEndTime :: TimeOfDay,
     stiTimezone :: Text,
-    stiAirsTwiceDaily :: Bool
+    stiReplayStartTime :: Maybe TimeOfDay
   }
   deriving stock (Generic, Show, Eq)
 
@@ -236,7 +236,7 @@ getActiveScheduleTemplatesForShow showId =
   interp
     False
     [sql|
-    SELECT DISTINCT st.id, st.show_id, st.day_of_week, st.weeks_of_month, st.start_time, st.end_time, st.timezone, st.created_at, st.airs_twice_daily
+    SELECT DISTINCT st.id, st.show_id, st.day_of_week, st.weeks_of_month, st.start_time, st.end_time, st.timezone, st.created_at, st.replay_start_time
     FROM schedule_templates st
     JOIN schedule_template_validity stv ON stv.template_id = st.id
     WHERE st.show_id = #{showId}
@@ -255,7 +255,7 @@ getPendingScheduleTemplatesForShow showId =
   interp
     False
     [sql|
-    SELECT DISTINCT st.id, st.show_id, st.day_of_week, st.weeks_of_month, st.start_time, st.end_time, st.timezone, st.created_at, st.airs_twice_daily
+    SELECT DISTINCT st.id, st.show_id, st.day_of_week, st.weeks_of_month, st.start_time, st.end_time, st.timezone, st.created_at, st.replay_start_time
     FROM schedule_templates st
     JOIN schedule_template_validity stv ON stv.template_id = st.id
     WHERE st.show_id = #{showId}
@@ -287,33 +287,60 @@ checkTimeSlotConflict excludeShowId dow weeks start end =
     <$> interp
       False
       [sql|
-    SELECT s.title
-    FROM schedule_templates st
-    JOIN schedule_template_validity stv ON stv.template_id = st.id
-    JOIN shows s ON s.id = st.show_id
-    WHERE s.status = 'active'
-      AND s.deleted_at IS NULL
-      AND st.show_id != #{excludeShowId}
-      AND st.day_of_week = #{dow}::day_of_week
-      AND stv.effective_from <= CURRENT_DATE
-      AND (stv.effective_until IS NULL OR stv.effective_until > CURRENT_DATE)
-      -- Check weeks overlap
-      AND (st.weeks_of_month IS NULL OR st.weeks_of_month && #{weeks})
-      -- Check time overlap (handles overnight shows)
-      AND (
+    WITH slots AS (
+      SELECT
+        s.title,
+        st.start_time,
+        st.end_time,
+        st.replay_start_time,
+        -- Precompute replay end time once
+        (st.replay_start_time + (
+          CASE WHEN st.end_time > st.start_time
+            THEN st.end_time - st.start_time
+            ELSE INTERVAL '24 hours' - (st.start_time - st.end_time)
+          END
+        ))::TIME as replay_end_time
+      FROM schedule_templates st
+      JOIN schedule_template_validity stv ON stv.template_id = st.id
+      JOIN shows s ON s.id = st.show_id
+      WHERE s.status = 'active'
+        AND s.deleted_at IS NULL
+        AND st.show_id != #{excludeShowId}
+        AND st.day_of_week = #{dow}::day_of_week
+        AND stv.effective_from <= CURRENT_DATE
+        AND (stv.effective_until IS NULL OR stv.effective_until > CURRENT_DATE)
+        AND (st.weeks_of_month IS NULL OR st.weeks_of_month && #{weeks})
+    )
+    SELECT sl.title
+    FROM slots sl
+    WHERE
+      -- Proposed slot overlaps existing PRIMARY slot
+      (
         CASE
-          -- Neither overnight: simple overlap check
-          WHEN st.end_time > st.start_time AND #{end} > #{start} THEN
-            st.start_time < #{end} AND #{start} < st.end_time
-          -- Existing is overnight, new is not
-          WHEN st.end_time <= st.start_time AND #{end} > #{start} THEN
-            #{start} < st.end_time OR #{end} > st.start_time
-          -- New is overnight, existing is not
-          WHEN #{end} <= #{start} AND st.end_time > st.start_time THEN
-            st.start_time < #{end} OR st.end_time > #{start}
-          -- Both overnight: always overlap
+          WHEN sl.end_time > sl.start_time AND #{end} > #{start} THEN
+            sl.start_time < #{end} AND #{start} < sl.end_time
+          WHEN sl.end_time <= sl.start_time AND #{end} > #{start} THEN
+            #{start} < sl.end_time OR #{end} > sl.start_time
+          WHEN #{end} <= #{start} AND sl.end_time > sl.start_time THEN
+            sl.start_time < #{end} OR sl.end_time > #{start}
           ELSE TRUE
         END
+      )
+      OR
+      -- Proposed slot overlaps existing REPLAY slot
+      (
+        sl.replay_start_time IS NOT NULL
+        AND (
+          CASE
+            WHEN sl.replay_end_time > sl.replay_start_time AND #{end} > #{start} THEN
+              sl.replay_start_time < #{end} AND #{start} < sl.replay_end_time
+            WHEN sl.replay_end_time <= sl.replay_start_time AND #{end} > #{start} THEN
+              #{start} < sl.replay_end_time OR #{end} > sl.replay_start_time
+            WHEN #{end} <= #{start} AND sl.replay_end_time > sl.replay_start_time THEN
+              sl.replay_start_time < #{end} OR sl.replay_end_time > #{start}
+            ELSE TRUE
+          END
+        )
       )
     LIMIT 1
   |]
@@ -328,8 +355,8 @@ insertScheduleTemplate ScheduleTemplateInsert {..} =
     <$> interp
       False
       [sql|
-    INSERT INTO schedule_templates(show_id, day_of_week, weeks_of_month, start_time, end_time, timezone, created_at, airs_twice_daily)
-    VALUES (#{stiShowId}, #{stiDayOfWeek}::day_of_week, #{stiWeeksOfMonth}, #{stiStartTime}, #{stiEndTime}, #{stiTimezone}, NOW(), #{stiAirsTwiceDaily})
+    INSERT INTO schedule_templates(show_id, day_of_week, weeks_of_month, start_time, end_time, timezone, created_at, replay_start_time)
+    VALUES (#{stiShowId}, #{stiDayOfWeek}::day_of_week, #{stiWeeksOfMonth}, #{stiStartTime}, #{stiEndTime}, #{stiTimezone}, NOW(), #{stiReplayStartTime})
     RETURNING id
   |]
 
@@ -453,7 +480,7 @@ instance Display ScheduledShowWithDetails where
 -- | Get all scheduled shows for a specific date with show and host details.
 --
 -- Returns both recurring and one-time shows scheduled for the given date.
--- For shows with airs_twice_daily = TRUE, returns two rows (primary and +12 hours).
+-- For shows with replay_start_time set, returns two rows (primary and replay).
 -- Used for rendering actual weekly schedules (not just templates).
 -- Uses raw SQL because of complex date arithmetic and CASE expressions.
 -- Excludes soft-deleted shows.
@@ -522,7 +549,7 @@ getScheduledShowsForDate targetDate =
 
     UNION ALL
 
-    -- Replay airings (+12 hours) for dual-airing shows
+    -- Replay airings for shows with replay_start_time set
     SELECT
       #{targetDate}::date as show_date,
       COALESCE(
@@ -537,8 +564,13 @@ getScheduledShowsForDate targetDate =
           WHEN 6 THEN 'saturday'::day_of_week
         END
       ) as day_of_week,
-      ((st.start_time + INTERVAL '12 hours')::time) as start_time,
-      ((st.end_time + INTERVAL '12 hours')::time) as end_time,
+      st.replay_start_time as start_time,
+      (st.replay_start_time + (
+        CASE WHEN st.end_time > st.start_time
+          THEN st.end_time - st.start_time
+          ELSE (INTERVAL '24 hours' - (st.start_time - st.end_time))
+        END
+      ))::TIME as end_time,
       s.slug,
       s.title,
       COALESCE(
@@ -555,7 +587,7 @@ getScheduledShowsForDate targetDate =
     WHERE s.status = 'active'
       AND s.deleted_at IS NULL
       AND EXISTS (SELECT 1 FROM show_hosts sh2 WHERE sh2.show_id = s.id AND sh2.left_at IS NULL)
-      AND st.airs_twice_daily = TRUE
+      AND st.replay_start_time IS NOT NULL
       AND stv.effective_from <= #{targetDate}::date
       AND (stv.effective_until IS NULL OR stv.effective_until > #{targetDate}::date)
       AND (
@@ -579,7 +611,7 @@ getScheduledShowsForDate targetDate =
         (st.day_of_week IS NULL
          AND stv.effective_from = #{targetDate}::date)
       )
-    GROUP BY st.id, st.day_of_week, st.start_time, st.end_time, s.slug, s.title, s.logo_url
+    GROUP BY st.id, st.day_of_week, st.start_time, st.end_time, st.replay_start_time, s.slug, s.title, s.logo_url
 
     ORDER BY start_time
   |]

--- a/lib/kpbj-database/test/Effects/Database/Tables/CurrentlyAiringSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/CurrentlyAiringSpec.hs
@@ -7,7 +7,7 @@
 -- 2. Schedule validity periods (effective_from, effective_until)
 -- 3. Episode scheduled_at matching today's date
 -- 4. Overnight shows (end_time <= start_time, e.g., 11 PM - 2 AM)
--- 5. Replay airings (airs_twice_daily = TRUE, +12 hours offset)
+-- 5. Replay airings (replay_start_time IS NOT NULL)
 -- 6. Audio file presence and episode deletion status
 module Effects.Database.Tables.CurrentlyAiringSpec where
 
@@ -73,10 +73,11 @@ spec =
         it "returns the episode when current time is after midnight but before end" overnightAfterMidnight
         it "returns Nothing when current time is after end (next day)" overnightAfterEnd
 
-      -- Replay airing tests (airs_twice_daily)
-      describe "airs_twice_daily replay" $ do
+      -- Replay airing tests (replay_start_time)
+      describe "replay_start_time replay" $ do
         it "returns the episode during primary airing" replayPrimaryAiring
         it "returns the episode during replay airing (+12 hours)" replaySecondAiring
+        it "returns the episode during non-+12h replay (custom replay time)" replayCustomTime
         it "returns Nothing between primary and replay" replayBetweenAirings
         it "returns Nothing after replay ends" replayAfterBothEnd
 
@@ -146,8 +147,8 @@ setupTestData ::
   TimeOfDay ->
   -- | Schedule end time
   TimeOfDay ->
-  -- | Airs twice daily?
-  Bool ->
+  -- | Replay start time (Nothing = no replay)
+  Maybe TimeOfDay ->
   -- | Episode scheduled_at (UTC)
   UTCTime ->
   -- | Audio file path (Nothing = no audio)
@@ -157,7 +158,7 @@ setupTestData ::
   -- | Validity effective_until
   Maybe Day ->
   TRX.Transaction (Episodes.Id, Shows.Id)
-setupTestData passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil =
+setupTestData passHash startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil =
   -- Calculate slot duration in seconds and delegate to setupTestDataWithDuration
   -- For standard shows: end - start
   -- For overnight shows: (24h - start) + end
@@ -165,7 +166,7 @@ setupTestData passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath e
         if endTime > startTime
           then truncate (timeOfDayToTime endTime - timeOfDayToTime startTime)
           else truncate ((24 * 3600) - timeOfDayToTime startTime + timeOfDayToTime endTime)
-   in setupTestDataWithDuration passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil (Just slotDuration)
+   in setupTestDataWithDuration passHash startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil (Just slotDuration)
 
 -- | Setup test data with custom duration, returning user ID as well.
 --
@@ -178,8 +179,8 @@ setupTestDataFull ::
   TimeOfDay ->
   -- | Schedule end time
   TimeOfDay ->
-  -- | Airs twice daily?
-  Bool ->
+  -- | Replay start time (Nothing = no replay)
+  Maybe TimeOfDay ->
   -- | Episode scheduled_at (UTC)
   UTCTime ->
   -- | Audio file path (Nothing = no audio)
@@ -191,7 +192,7 @@ setupTestDataFull ::
   -- | Episode duration in seconds (Nothing = NULL)
   Maybe Int ->
   TRX.Transaction (Episodes.Id, Shows.Id, User.Id)
-setupTestDataFull passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration = do
+setupTestDataFull passHash startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration = do
   -- Create user
   (OneRow userId) <-
     TRX.statement () $
@@ -233,7 +234,7 @@ setupTestDataFull passHash startTime endTime airsTwiceDaily scheduledAt mAudioPa
             stiStartTime = startTime,
             stiEndTime = endTime,
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = airsTwiceDaily
+            stiReplayStartTime = replayStartTime
           }
 
   -- Create validity period
@@ -270,15 +271,15 @@ setupTestDataWithDuration ::
   PasswordHash Argon2 ->
   TimeOfDay ->
   TimeOfDay ->
-  Bool ->
+  Maybe TimeOfDay ->
   UTCTime ->
   Maybe Text ->
   Day ->
   Maybe Day ->
   Maybe Int ->
   TRX.Transaction (Episodes.Id, Shows.Id)
-setupTestDataWithDuration passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration = do
-  (episodeId, showId, _userId) <- setupTestDataFull passHash startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration
+setupTestDataWithDuration passHash startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration = do
+  (episodeId, showId, _userId) <- setupTestDataFull passHash startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil mDuration
   pure (episodeId, showId)
 
 -- | Add a second timeslot (template + validity + episode) to an existing show.
@@ -291,8 +292,8 @@ addTimeslot ::
   TimeOfDay ->
   -- | End time
   TimeOfDay ->
-  -- | Airs twice daily?
-  Bool ->
+  -- | Replay start time (Nothing = no replay)
+  Maybe TimeOfDay ->
   -- | Episode scheduled_at (UTC)
   UTCTime ->
   -- | Audio file path
@@ -302,7 +303,7 @@ addTimeslot ::
   -- | Validity effective_until
   Maybe Day ->
   TRX.Transaction Episodes.Id
-addTimeslot showId userId startTime endTime airsTwiceDaily scheduledAt mAudioPath effectiveFrom effectiveUntil = do
+addTimeslot showId userId startTime endTime replayStartTime scheduledAt mAudioPath effectiveFrom effectiveUntil = do
   let slotDuration :: Integer
       slotDuration =
         if endTime > startTime
@@ -319,7 +320,7 @@ addTimeslot showId userId startTime endTime airsTwiceDaily scheduledAt mAudioPat
             stiStartTime = startTime,
             stiEndTime = endTime,
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = airsTwiceDaily
+            stiReplayStartTime = replayStartTime
           }
 
   _ <-
@@ -366,7 +367,7 @@ basicNoAudio cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 15 0 0) -- 3 PM (mid-show)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt Nothing testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt Nothing testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -382,7 +383,7 @@ basicDeletedEpisode cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 15 0 0)
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     -- Soft delete the episode
     _ <- TRX.statement () $ Episodes.deleteEpisode episodeId
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
@@ -402,7 +403,7 @@ basicDifferentDay cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 15 0 0)
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -418,7 +419,7 @@ basicCurrentlyAiring cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 15 0 0)
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -439,7 +440,7 @@ standardBeforeStart cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 13 59 59) -- 1:59:59 PM (1 second before)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -454,7 +455,7 @@ standardAtStart cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime startTime -- Exactly at start
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -472,7 +473,7 @@ standardMidShow cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 15 0 0) -- 3 PM (middle)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -490,7 +491,7 @@ standardAtEnd cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime endTime -- Exactly at end (exclusive)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -505,7 +506,7 @@ standardAfterEnd cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 16 0 1) -- 1 second after end
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -523,7 +524,7 @@ overnightBeforeStart cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 22 59 59) -- 10:59:59 PM (before start)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -538,7 +539,7 @@ overnightAfterStartSameDay cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 23 30 0) -- 11:30 PM (same day, during show)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -558,7 +559,7 @@ overnightAfterMidnight cfg = bracketConn cfg $ do
       queryTime = mkTestTimeNextDay (TimeOfDay 1 0 0)
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -576,7 +577,7 @@ overnightAfterEnd cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTimeNextDay (TimeOfDay 2 0 1) -- 2:00:01 AM (after end)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -584,7 +585,7 @@ overnightAfterEnd cfg = bracketConn cfg $ do
     Right mEpisode -> liftIO $ mEpisode `shouldBe` Nothing
 
 --------------------------------------------------------------------------------
--- Replay Airing Tests (airs_twice_daily)
+-- Replay Airing Tests (replay_start_time)
 
 replayPrimaryAiring :: TestDBConfig -> IO ()
 replayPrimaryAiring cfg = bracketConn cfg $ do
@@ -594,7 +595,7 @@ replayPrimaryAiring cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 7 0 0) -- 7 AM (during primary)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime True scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime (Just (TimeOfDay 18 0 0)) scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -613,7 +614,29 @@ replaySecondAiring cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 19 0 0) -- 7 PM (during replay)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime True scheduledAt (Just "audio/test.mp3") testDay Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime (Just (TimeOfDay 18 0 0)) scheduledAt (Just "audio/test.mp3") testDay Nothing
+    mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
+    pure (episodeId, mEpisode)
+
+  case result of
+    Left err -> error $ "DB error: " <> show err
+    Right (expectedId, mEpisode) -> liftIO $ do
+      episode <- assertJustIO mEpisode
+      Episodes.id episode `shouldBe` expectedId
+
+-- | Test a non-+12h replay: 10 AM - 11 AM primary, replay at 9 PM.
+-- Replay runs 9 PM - 10 PM (1 hour duration matches primary).
+-- +12h would put replay at 10 PM, so 9 PM proves configurable replay works.
+replayCustomTime :: TestDBConfig -> IO ()
+replayCustomTime cfg = bracketConn cfg $ do
+  passHash <- hashPassword $ mkPassword "testpass"
+  let startTime = TimeOfDay 10 0 0 -- 10 AM
+      endTime = TimeOfDay 11 0 0 -- 11 AM (1 hour show)
+      replayStart = TimeOfDay 21 0 0 -- 9 PM (not +12h which would be 10 PM)
+      scheduledAt = mkTestTime startTime
+      queryTime = mkTestTime (TimeOfDay 21 30 0) -- 9:30 PM (during replay 9 PM - 10 PM)
+  result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+    (episodeId, _) <- setupTestData passHash startTime endTime (Just replayStart) scheduledAt (Just "audio/test.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -631,7 +654,7 @@ replayBetweenAirings cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 12 0 0) -- Noon (between 8 AM and 6 PM)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime True scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime (Just (TimeOfDay 18 0 0)) scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -647,7 +670,7 @@ replayAfterBothEnd cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 20 0 1) -- 8:00:01 PM (after replay)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime True scheduledAt (Just "audio/test.mp3") testDay Nothing
+    _ <- setupTestData passHash startTime endTime (Just (TimeOfDay 18 0 0)) scheduledAt (Just "audio/test.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -668,7 +691,7 @@ validityNotStarted cfg = bracketConn cfg $ do
       effectiveFrom = addDays 1 testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -687,7 +710,7 @@ validityEnded cfg = bracketConn cfg $ do
       effectiveUntil = Just $ addDays (-1) testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -705,7 +728,7 @@ validityActiveNoEnd cfg = bracketConn cfg $ do
       effectiveFrom = addDays (-30) testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -727,7 +750,7 @@ validityActiveFutureEnd cfg = bracketConn cfg $ do
       effectiveUntil = Just $ addDays 30 testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -750,7 +773,7 @@ validityEndsToday cfg = bracketConn cfg $ do
       effectiveUntil = Just testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
+    _ <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -770,7 +793,7 @@ validityEndsTomorrow cfg = bracketConn cfg $ do
       effectiveUntil = Just $ addDays 1 testDay
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
+    (episodeId, _) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom effectiveUntil
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -797,7 +820,7 @@ durationEndedSlotContinues cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 14 35 0) -- 2:35 PM (past 30-min duration)
       duration = Just 1800 -- 30 minutes in seconds
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    _ <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -817,7 +840,7 @@ durationMidway cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 14 15 0) -- 2:15 PM (within 30-min duration)
       duration = Just 1800 -- 30 minutes
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -839,7 +862,7 @@ durationNullFallback cfg = bracketConn cfg $ do
       scheduledAt = mkTestTime startTime
       queryTime = mkTestTime (TimeOfDay 15 30 0) -- 3:30 PM
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing Nothing
+    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -865,7 +888,7 @@ overnightDurationBeforeMidnightWithin cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 23 15 0) -- 11:15 PM (within 30-min duration)
       duration = Just 1800 -- 30 minutes
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -888,7 +911,7 @@ overnightDurationBeforeMidnightPast cfg = bracketConn cfg $ do
       queryTime = mkTestTime (TimeOfDay 23 45 0) -- 11:45 PM (past 30-min duration)
       duration = Just 1800 -- 30 minutes
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    _ <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -909,7 +932,7 @@ overnightDurationAfterMidnightWithin cfg = bracketConn cfg $ do
       queryTime = mkTestTimeNextDay (TimeOfDay 0 30 0)
       duration = Just 7200 -- 2 hours
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    (episodeId, _) <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (episodeId, mEpisode)
 
@@ -933,7 +956,7 @@ overnightDurationEndedBeforeMidnight cfg = bracketConn cfg $ do
       queryTime = mkTestTimeNextDay (TimeOfDay 1 0 0)
       duration = Just 1800 -- 30 minutes (ends at 11:30 PM)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    _ <- setupTestDataWithDuration passHash startTime endTime False scheduledAt (Just "audio/test.mp3") testDay Nothing duration
+    _ <- setupTestDataWithDuration passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") testDay Nothing duration
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -961,7 +984,7 @@ transitionPreservedSlot cfg = bracketConn cfg $ do
 
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
     -- Create T1 (2-4 PM) with episode — the existing slot
-    (episodeId, showId) <- setupTestData passHash startTime endTime False scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
+    (episodeId, showId) <- setupTestData passHash startTime endTime Nothing scheduledAt (Just "audio/test.mp3") effectiveFrom Nothing
 
     -- Create T2 (6-8 PM) — simulating an added slot (slot-level diff leaves T1 alone)
     templateId2 <-
@@ -974,7 +997,7 @@ transitionPreservedSlot cfg = bracketConn cfg $ do
               stiStartTime = TimeOfDay 18 0 0,
               stiEndTime = TimeOfDay 20 0 0,
               stiTimezone = "America/Los_Angeles",
-              stiAirsTwiceDaily = False
+              stiReplayStartTime = Nothing
             }
 
     _ <-
@@ -1036,7 +1059,7 @@ transitionReplacedSlot cfg = bracketConn cfg $ do
               stiStartTime = startTime,
               stiEndTime = endTime,
               stiTimezone = "America/Los_Angeles",
-              stiAirsTwiceDaily = False
+              stiReplayStartTime = Nothing
             }
 
     validityId1 <-
@@ -1074,7 +1097,7 @@ transitionReplacedSlot cfg = bracketConn cfg $ do
               stiStartTime = startTime,
               stiEndTime = endTime,
               stiTimezone = "America/Los_Angeles",
-              stiAirsTwiceDaily = False
+              stiReplayStartTime = Nothing
             }
 
     _ <-
@@ -1128,7 +1151,7 @@ transitionRemovedSlot cfg = bracketConn cfg $ do
               stiStartTime = startTime,
               stiEndTime = endTime,
               stiTimezone = "America/Los_Angeles",
-              stiAirsTwiceDaily = False
+              stiReplayStartTime = Nothing
             }
 
     validityId1 <-
@@ -1183,8 +1206,8 @@ multiSlotFirstSlot cfg = bracketConn cfg $ do
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 10 0 0) -- 10 AM (during first slot)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
-    _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
+    (ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End Nothing scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
+    _ep2 <- addTimeslot showId userId slot2Start slot2End Nothing scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (ep1, mEpisode)
 
@@ -1210,8 +1233,8 @@ multiSlotSecondSlot cfg = bracketConn cfg $ do
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 15 0 0) -- 3 PM (during second slot)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
-    ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
+    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End Nothing scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
+    ep2 <- addTimeslot showId userId slot2Start slot2End Nothing scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
     mEpisode <- TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
     pure (ep2, mEpisode)
 
@@ -1237,8 +1260,8 @@ multiSlotBetween cfg = bracketConn cfg $ do
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 12 0 0) -- Noon (between slots)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
-    _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
+    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End Nothing scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
+    _ep2 <- addTimeslot showId userId slot2Start slot2End Nothing scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -1260,8 +1283,8 @@ multiSlotBeforeAll cfg = bracketConn cfg $ do
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 8 0 0) -- 8 AM (before both)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
-    _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
+    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End Nothing scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
+    _ep2 <- addTimeslot showId userId slot2Start slot2End Nothing scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of
@@ -1283,8 +1306,8 @@ multiSlotAfterAll cfg = bracketConn cfg $ do
       scheduledAt2 = mkTestTime slot2Start
       queryTime = mkTestTime (TimeOfDay 17 0 0) -- 5 PM (after both)
   result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
-    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End False scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
-    _ep2 <- addTimeslot showId userId slot2Start slot2End False scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
+    (_ep1, showId, userId) <- setupTestDataFull passHash slot1Start slot1End Nothing scheduledAt1 (Just "audio/slot1.mp3") testDay Nothing Nothing
+    _ep2 <- addTimeslot showId userId slot2Start slot2End Nothing scheduledAt2 (Just "audio/slot2.mp3") testDay Nothing
     TRX.statement () $ Episodes.getCurrentlyAiringEpisode queryTime
 
   case result of

--- a/lib/kpbj-database/test/Effects/Database/Tables/ShowScheduleMissingEpisodesSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ShowScheduleMissingEpisodesSpec.hs
@@ -69,7 +69,7 @@ prop_missingEpisodeAppears cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -102,7 +102,7 @@ prop_episodeWithAudioNotMissing cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -150,7 +150,7 @@ prop_episodeWithoutAudioIsMissing cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -196,7 +196,7 @@ prop_beyondWindowNotShown cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just futureDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just futureDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         -- Validity starts from 8 days from now (outside 7-day window)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays 8 today) Nothing))
@@ -224,7 +224,7 @@ prop_deletedShowNotShown cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -255,13 +255,13 @@ prop_sortedByDate cfg = do
         -- Create two shows on the same day but different times
         let show1 = showInsert1 {Shows.siStatus = Shows.Active, Shows.siSlug = Shows.siSlug showInsert1 <> "sort1"}
         showId1 <- unwrapInsert (Shows.insertShow show1)
-        let sched1 = ShowSchedule.ScheduleTemplateInsert showId1 (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) timezone False
+        let sched1 = ShowSchedule.ScheduleTemplateInsert showId1 (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) timezone Nothing
         tid1 <- TRX.statement () (ShowSchedule.insertScheduleTemplate sched1)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert tid1 (addDays (-7) today) Nothing))
 
         let show2 = showInsert2 {Shows.siStatus = Shows.Active, Shows.siSlug = Shows.siSlug showInsert2 <> "sort2"}
         showId2 <- unwrapInsert (Shows.insertShow show2)
-        let sched2 = ShowSchedule.ScheduleTemplateInsert showId2 (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) timezone False
+        let sched2 = ShowSchedule.ScheduleTemplateInsert showId2 (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) timezone Nothing
         tid2 <- TRX.statement () (ShowSchedule.insertScheduleTemplate sched2)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert tid2 (addDays (-7) today) Nothing))
 
@@ -296,7 +296,7 @@ prop_hostMissingEpisodeOnDay cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -330,7 +330,7 @@ prop_hostNotReturnedWithAudio cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -373,7 +373,7 @@ prop_noHostNoRow cfg = do
         let show1 = showInsert {Shows.siStatus = Shows.Active}
         showId <- unwrapInsert (Shows.insertShow show1)
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -409,7 +409,7 @@ prop_wrongDayNotReturned cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just nearbyDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just nearbyDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -441,7 +441,7 @@ prop_hostDeletedShowNotReturned cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -475,7 +475,7 @@ prop_hostReturnedWithoutAudio cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -524,7 +524,7 @@ prop_multipleHostsMultipleRows cfg = do
         addTestShowHost showId userId1
         addTestShowHost showId userId2
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-7) today) Nothing))
 
@@ -558,7 +558,7 @@ prop_hostExpiredValidityNotReturned cfg = do
         showId <- unwrapInsert (Shows.insertShow show1)
         addTestShowHost showId userId
 
-        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" False
+        let scheduleInsert = ShowSchedule.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) "UTC" Nothing
         templateId <- TRX.statement () (ShowSchedule.insertScheduleTemplate scheduleInsert)
         -- Validity expired yesterday
         _ <- unwrapInsert (ShowSchedule.insertValidity (ShowSchedule.ValidityInsert templateId (addDays (-30) today) (Just (addDays (-1) today))))

--- a/lib/kpbj-database/test/Effects/Database/Tables/ShowScheduleSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ShowScheduleSpec.hs
@@ -95,7 +95,7 @@ prop_insertSelectTemplate cfg = do
                   stiStartTime = startTime,
                   stiEndTime = endTime,
                   stiTimezone = timezone,
-                  stiAirsTwiceDaily = False
+                  stiReplayStartTime = Nothing
                 }
 
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
@@ -112,7 +112,7 @@ prop_insertSelectTemplate cfg = do
         scheduleInsert.stiStartTime === selectedTemplate.stStartTime
         scheduleInsert.stiEndTime === selectedTemplate.stEndTime
         scheduleInsert.stiTimezone === selectedTemplate.stTimezone
-        scheduleInsert.stiAirsTwiceDaily === selectedTemplate.stAirsTwiceDaily
+        scheduleInsert.stiReplayStartTime === selectedTemplate.stReplayStartTime
         templateId === selectedTemplate.stId
 
 prop_getTemplatesForShow :: TestDBConfig -> PropertyT IO ()
@@ -130,8 +130,8 @@ prop_getTemplatesForShow cfg = do
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
 
-        let schedule1 = UUT.ScheduleTemplateInsert showId dow1 (Just allWeeksOfMonth) start1 end1 tz1 False
-            schedule2 = UUT.ScheduleTemplateInsert showId dow2 (Just allWeeksOfMonth) start2 end2 tz2 False
+        let schedule1 = UUT.ScheduleTemplateInsert showId dow1 (Just allWeeksOfMonth) start1 end1 tz1 Nothing
+            schedule2 = UUT.ScheduleTemplateInsert showId dow2 (Just allWeeksOfMonth) start2 end2 tz2 Nothing
 
         _ <- TRX.statement () (UUT.insertScheduleTemplate schedule1)
         _ <- TRX.statement () (UUT.insertScheduleTemplate schedule2)
@@ -160,7 +160,7 @@ prop_getActiveTemplates cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         let validityInsert = UUT.ValidityInsert templateId (addDays (-7) today) Nothing
@@ -191,7 +191,7 @@ prop_upcomingDatesInFuture cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         let validityInsert = UUT.ValidityInsert templateId (addDays (-7) today) Nothing
@@ -228,7 +228,7 @@ prop_weeklyScheduleRepeats cfg = do
                   stiStartTime = startTime,
                   stiEndTime = endTime,
                   stiTimezone = timezone,
-                  stiAirsTwiceDaily = False
+                  stiReplayStartTime = Nothing
                 }
 
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
@@ -266,7 +266,7 @@ prop_upcomingDatesDayOfWeek cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         let validityInsert = UUT.ValidityInsert templateId (addDays (-7) today) Nothing
@@ -296,7 +296,7 @@ prop_respectsValidityPeriods cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Add validity that ends soon
@@ -331,7 +331,7 @@ prop_handlesYearBoundaries cfg = do
       let referenceDate = fromGregorian 2026 12 20
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Set validity to start before our reference date
@@ -366,7 +366,7 @@ prop_unscheduledExcludesScheduled cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Add active validity with fixed dates
@@ -410,7 +410,7 @@ prop_oneTimeShowCreation cfg = do
                   stiStartTime = startTime,
                   stiEndTime = endTime,
                   stiTimezone = timezone,
-                  stiAirsTwiceDaily = False
+                  stiReplayStartTime = Nothing
                 }
 
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
@@ -451,7 +451,7 @@ prop_timezoneStorage cfg = do
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
 
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
         selected <- TRX.statement () (UUT.getScheduleTemplateById templateId)
         TRX.condemn
@@ -476,7 +476,7 @@ prop_timezoneConversion cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         let validityInsert = UUT.ValidityInsert templateId (addDays (-7) today) Nothing
@@ -515,7 +515,7 @@ prop_checkTimeSlotConflict cfg = do
         -- Create first show with a schedule 10:00-12:00
         let show1 = showInsert1 {Shows.siStatus = Shows.Active, Shows.siSlug = Shows.siSlug showInsert1 <> "conflict1"}
         showId1 <- unwrapInsert (Shows.insertShow show1)
-        let schedule1 = UUT.ScheduleTemplateInsert showId1 (Just dow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone False
+        let schedule1 = UUT.ScheduleTemplateInsert showId1 (Just dow) (Just allWeeksOfMonth) (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) timezone Nothing
         templateId1 <- TRX.statement () (UUT.insertScheduleTemplate schedule1)
         _ <- unwrapInsert (UUT.insertValidity (UUT.ValidityInsert templateId1 (addDays (-7) today) Nothing))
 
@@ -556,7 +556,7 @@ prop_getActiveValidityPeriodsForTemplate cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Active validity (started 7 days ago, no end)
@@ -589,7 +589,7 @@ prop_endValidity cfg = do
       today <- liftIO $ utctDay <$> getCurrentTime
       result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
         showId <- unwrapInsert (Shows.insertShow showInsert)
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId dayOfWeek (Just allWeeksOfMonth) startTime endTime timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Create active validity
@@ -643,7 +643,7 @@ prop_getScheduledShowsForDate cfg = do
         TRX.statement () $ ShowHost.insertShowHost $ ShowHost.Insert showId userId ShowHost.Host
 
         -- Create a recurring schedule for today's day of week
-        let scheduleInsert = UUT.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) timezone False
+        let scheduleInsert = UUT.ScheduleTemplateInsert showId (Just targetDow) (Just allWeeksOfMonth) (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) timezone Nothing
         templateId <- TRX.statement () (UUT.insertScheduleTemplate scheduleInsert)
 
         -- Add active validity

--- a/lib/kpbj-database/test/Test/Gen/Tables/ShowSchedule.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/ShowSchedule.hs
@@ -66,15 +66,37 @@ genTimezone =
       "UTC"
     ]
 
--- | Generate a recurring schedule template insert
--- For recurring shows, both day_of_week and weeks_of_month must be NOT NULL
+-- | Generate a valid replay start time that is >= end time.
+--
+-- Converts end time to total minutes to ensure replay is never before end,
+-- even when end has non-zero minutes (e.g., end = 22:30 won't generate 22:00).
+genReplayStartTime :: (MonadGen m) => TimeOfDay -> m (Maybe TimeOfDay)
+genReplayStartTime endTime = do
+  hasReplay <- Gen.bool
+  if hasReplay
+    then do
+      let endMins = todHour endTime * 60 + todMin endTime
+          -- Round up to next 30-minute boundary if not already aligned
+          minReplayMins = if endMins `mod` 30 == 0 then endMins else endMins + (30 - endMins `mod` 30)
+          maxMins = 23 * 60 + 30 -- 23:30
+      if minReplayMins > maxMins
+        then pure Nothing -- Not enough room for a replay
+        else do
+          -- Generate in 30-minute increments from minReplayMins to maxMins
+          let slots = [minReplayMins, minReplayMins + 30 .. maxMins]
+          replayMins <- Gen.element slots
+          pure $ Just (TimeOfDay (replayMins `div` 60) (replayMins `mod` 60) 0)
+    else pure Nothing
+
+-- | Generate a recurring schedule template insert.
+-- For recurring shows, both day_of_week and weeks_of_month must be NOT NULL.
 genRecurringScheduleInsert :: (MonadGen m) => Shows.Id -> m ShowSchedule.ScheduleTemplateInsert
 genRecurringScheduleInsert showId = do
   (startTime, endTime) <- genTimeRange
   dayOfWeek <- Just <$> genDayOfWeek
   weeksOfMonth <- Just <$> genWeeksOfMonth -- Must be Just for recurring shows
   timezone <- genTimezone
-  airsTwiceDaily <- Gen.bool
+  replayStartTime <- genReplayStartTime endTime
   pure
     ShowSchedule.ScheduleTemplateInsert
       { stiShowId = showId,
@@ -83,7 +105,7 @@ genRecurringScheduleInsert showId = do
         stiStartTime = startTime,
         stiEndTime = endTime,
         stiTimezone = timezone,
-        stiAirsTwiceDaily = airsTwiceDaily
+        stiReplayStartTime = replayStartTime
       }
 
 -- | Generate a one-time schedule template insert
@@ -91,7 +113,7 @@ genOneTimeScheduleInsert :: (MonadGen m) => Shows.Id -> m ShowSchedule.ScheduleT
 genOneTimeScheduleInsert showId = do
   (startTime, endTime) <- genTimeRange
   timezone <- genTimezone
-  airsTwiceDaily <- Gen.bool
+  replayStartTime <- genReplayStartTime endTime
   pure
     ShowSchedule.ScheduleTemplateInsert
       { stiShowId = showId,
@@ -100,7 +122,7 @@ genOneTimeScheduleInsert showId = do
         stiStartTime = startTime,
         stiEndTime = endTime,
         stiTimezone = timezone,
-        stiAirsTwiceDaily = airsTwiceDaily
+        stiReplayStartTime = replayStartTime
       }
 
 -- | Generate any schedule template insert (recurring or one-time)

--- a/lib/kpbj-types/src/Domain/Types/Timezone.hs
+++ b/lib/kpbj-types/src/Domain/Types/Timezone.hs
@@ -13,6 +13,7 @@ module Domain.Types.Timezone
 
     -- * Time Utilities
     addMinutesToTimeOfDay,
+    slotDurationMins,
     parseTimeHHMM,
     parseDateYMD,
 
@@ -92,6 +93,16 @@ addMinutesToTimeOfDay (TimeOfDay h m s) mins =
       newH = (totalMinutes `div` 60) `mod` 24
       newM = totalMinutes `mod` 60
    in TimeOfDay newH newM s
+
+-- | Compute the duration in minutes between two 'TimeOfDay' values.
+--
+-- Handles overnight shows (end < start) by wrapping around midnight.
+slotDurationMins :: TimeOfDay -> TimeOfDay -> Int
+slotDurationMins start end =
+  let startMins = todHour start * 60 + todMin start
+      endMins = todHour end * 60 + todMin end
+      rawMins = endMins - startMins
+   in if rawMins <= 0 then rawMins + (24 * 60) else rawMins
 
 -- | Parse a time of day from @\"HH:MM\"@ format.
 parseTimeHHMM :: Text -> Maybe TimeOfDay

--- a/lib/kpbj-types/src/OrphanInstances/TimeOfDay.hs
+++ b/lib/kpbj-types/src/OrphanInstances/TimeOfDay.hs
@@ -2,7 +2,6 @@
 
 module OrphanInstances.TimeOfDay
   ( formatTimeOfDay,
-    add12Hours,
     formatScheduleDual,
     formatWeeksOfMonth,
   )
@@ -16,6 +15,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time (TimeOfDay (..))
 import Data.Time.Format (defaultTimeLocale, formatTime)
+import Domain.Types.Timezone (addMinutesToTimeOfDay, slotDurationMins)
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Interpolate (DecodeValue (..), EncodeValue (..))
@@ -34,33 +34,26 @@ instance DecodeValue TimeOfDay where
 formatTimeOfDay :: TimeOfDay -> Text
 formatTimeOfDay = Text.pack . formatTime defaultTimeLocale "%l:%M %p"
 
--- | Add 12 hours to a TimeOfDay (wraps around midnight).
-add12Hours :: TimeOfDay -> TimeOfDay
-add12Hours (TimeOfDay h m s) = TimeOfDay ((h + 12) `mod` 24) m s
-
--- | Format schedule with optional dual-airing display.
+-- | Format schedule with optional replay display.
 --
--- For dual-airing shows, displays both time ranges:
+-- When a replay start time is provided, displays both time ranges:
 -- e.g., "09:00 - 11:00 & 21:00 - 23:00"
 formatScheduleDual ::
   -- | Start time
   TimeOfDay ->
   -- | End time
   TimeOfDay ->
-  -- | Airs twice daily
-  Bool ->
+  -- | Replay start time (Nothing = no replay)
+  Maybe TimeOfDay ->
   Text
-formatScheduleDual start end airsTwice
-  | airsTwice =
-      formatTimeOfDay start
-        <> " - "
-        <> formatTimeOfDay end
-        <> " & "
-        <> formatTimeOfDay (add12Hours start)
-        <> " - "
-        <> formatTimeOfDay (add12Hours end)
-  | otherwise =
-      formatTimeOfDay start <> " - " <> formatTimeOfDay end
+formatScheduleDual start end mReplayStart =
+  let primary = formatTimeOfDay start <> " - " <> formatTimeOfDay end
+   in case mReplayStart of
+        Just replayStart ->
+          let durMins = slotDurationMins start end
+              replayEnd = addMinutesToTimeOfDay replayStart durMins
+           in primary <> " & " <> formatTimeOfDay replayStart <> " - " <> formatTimeOfDay replayEnd
+        Nothing -> primary
 
 -- | Format weeks of month as ordinal prefix.
 --

--- a/scripts/lib/sync-s3.sh
+++ b/scripts/lib/sync-s3.sh
@@ -97,17 +97,20 @@ sync_s3_buckets() {
     echo "Copying new/changed files..."
     while IFS= read -r key; do
       echo "  -> $key"
+      ext="${key##*.}"
+      tmpfile="$tmpdir/transfer.$ext"
+
       AWS_ACCESS_KEY_ID="$PROD_AWS_ACCESS_KEY_ID" \
       AWS_SECRET_ACCESS_KEY="$PROD_AWS_SECRET_ACCESS_KEY" \
-      aws s3 cp "s3://$PROD_BUCKET/$key" "$tmpdir/transfer" \
+      aws s3 cp "s3://$PROD_BUCKET/$key" "$tmpfile" \
         --endpoint-url "$PROD_ENDPOINT" --quiet
 
       AWS_ACCESS_KEY_ID="$STAGING_AWS_ACCESS_KEY_ID" \
       AWS_SECRET_ACCESS_KEY="$STAGING_AWS_SECRET_ACCESS_KEY" \
-      aws s3 cp "$tmpdir/transfer" "s3://$STAGING_BUCKET/$key" \
+      aws s3 cp "$tmpfile" "s3://$STAGING_BUCKET/$key" \
         --endpoint-url "$STAGING_ENDPOINT" --acl public-read --quiet
 
-      rm -f "$tmpdir/transfer"
+      rm -f "$tmpfile"
     done < "$tmpdir/to_copy.txt"
   fi
 

--- a/services/web/migrations/20260318075001_replace_airs_twice_daily_with_replay_start_time.sql
+++ b/services/web/migrations/20260318075001_replace_airs_twice_daily_with_replay_start_time.sql
@@ -1,0 +1,30 @@
+-- Replace airs_twice_daily BOOLEAN with replay_start_time TIME
+-- Allows configurable replay times instead of hardcoded +12h offset.
+
+-- 1. Add replay_start_time column (nullable TIME — NULL means no replay)
+ALTER TABLE schedule_templates ADD COLUMN replay_start_time TIME;
+
+-- 2a. PM primaries (start_time >= 12:00): swap so AM becomes primary, PM becomes replay
+--     e.g., 20:00-22:00 primary → 08:00-10:00 primary, replay at 20:00
+UPDATE schedule_templates
+SET
+  replay_start_time = start_time,
+  start_time = (start_time + INTERVAL '12 hours')::TIME,
+  end_time = (end_time + INTERVAL '12 hours')::TIME
+WHERE airs_twice_daily = TRUE
+  AND start_time >= TIME '12:00:00';
+
+-- 2b. AM primaries (start_time < 12:00): keep primary as-is, replay is +12h (already PM)
+--     e.g., 08:00-10:00 primary → replay at 20:00
+UPDATE schedule_templates
+SET
+  replay_start_time = (start_time + INTERVAL '12 hours')::TIME
+WHERE airs_twice_daily = TRUE
+  AND start_time < TIME '12:00:00';
+
+-- 3. Drop the old column
+ALTER TABLE schedule_templates DROP COLUMN airs_twice_daily;
+
+-- 4. Add comment
+COMMENT ON COLUMN schedule_templates.replay_start_time IS
+  'When not NULL, show replays at this time of day (same calendar day). Must be >= end_time.';

--- a/services/web/src/API/Dashboard/Shows/New/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/New/Post/Handler.hs
@@ -6,7 +6,7 @@ module API.Dashboard.Shows.New.Post.Handler (handler, action) where
 --------------------------------------------------------------------------------
 
 import API.Dashboard.Shows.New.Post.Route (NewShowForm (..))
-import API.Dashboard.Shows.Slug.Edit.Post.Handler (ParsedScheduleSlot (..), parseScheduleSlot)
+import API.Dashboard.Shows.Slug.Edit.Post.Handler (ParsedScheduleSlot (..), checkScheduleConflicts, parseScheduleSlot)
 import API.Links (dashboardShowsLinks)
 import API.Types
 import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
@@ -26,8 +26,7 @@ import Data.String.Interpolate (i)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
-import Data.Time (Day, TimeOfDay)
-import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time (Day)
 import Domain.Types.Cookie (Cookie (..))
 import Domain.Types.FileUpload (uploadResultStoragePath)
 import Domain.Types.Slug qualified as Slug
@@ -306,26 +305,6 @@ parseSchedules (Just schedulesJson)
       Left err -> Left $ "Invalid schedules JSON: " <> Text.pack err
       Right slots -> traverse parseScheduleSlot slots
 
--- | Check for schedule conflicts with other shows.
---
--- For new show creation, pass Shows.Id 0 to check against ALL active shows.
-checkScheduleConflicts ::
-  Shows.Id ->
-  [ParsedScheduleSlot] ->
-  AppM (Either Text ())
-checkScheduleConflicts showId = go
-  where
-    go [] = pure (Right ())
-    go (slot : rest) = do
-      let weeks = map fromIntegral (pssWeeks slot)
-      execQuery (ShowSchedule.checkTimeSlotConflict showId (pssDay slot) weeks (pssStart slot) (pssEnd slot)) >>= \case
-        Left err -> do
-          Log.logAttention "Failed to check schedule conflict" (Text.pack $ show err)
-          pure (Left "Unable to verify schedule availability. Please try again.")
-        Right (Just conflictingShow) ->
-          pure (Left $ "Schedule conflict: " <> Text.pack (show (pssDay slot)) <> " " <> formatTimeHHMM (pssStart slot) <> "-" <> formatTimeHHMM (pssEnd slot) <> " overlaps with \"" <> conflictingShow <> "\"")
-        Right Nothing -> go rest
-
 -- | Create schedules for a newly created show.
 --
 -- When @mStartDate@ is provided it is used as the @effective_from@ date for
@@ -350,7 +329,7 @@ createSchedulesForShow showId slots mStartDate = do
               ShowSchedule.stiStartTime = pssStart slot,
               ShowSchedule.stiEndTime = pssEnd slot,
               ShowSchedule.stiTimezone = "America/Los_Angeles",
-              ShowSchedule.stiAirsTwiceDaily = True
+              ShowSchedule.stiReplayStartTime = pssReplayStartTime slot
             }
 
     templateResult <- execQuery (ShowSchedule.insertScheduleTemplate templateInsert)
@@ -385,6 +364,3 @@ buildTimeslotDescription [] = Nothing
 buildTimeslotDescription (slot : _) =
   Just $ HostNotifications.formatTimeslotDescription (pssDay slot) (pssStart slot) (pssEnd slot)
 
--- | Format a TimeOfDay as "HH:MM" for error messages.
-formatTimeHHMM :: TimeOfDay -> Text
-formatTimeHHMM = Text.pack . formatTime defaultTimeLocale "%H:%M"

--- a/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Handler.hs
@@ -9,6 +9,8 @@ module API.Dashboard.Shows.Slug.Edit.Post.Handler
     normalizeTemplate,
     parseScheduleSlot,
     schedulesMatch,
+    validateNoOverlaps,
+    checkScheduleConflicts,
   )
 where
 
@@ -44,7 +46,7 @@ import Domain.Types.Cookie (Cookie)
 import Domain.Types.FileUpload (uploadResultStoragePath)
 import Domain.Types.Slug (Slug)
 import Domain.Types.Slug qualified as Slug
-import Domain.Types.Timezone (LocalTime (..), addMinutesToTimeOfDay, parseDateYMD, parseTimeHHMM, utcToPacific)
+import Domain.Types.Timezone (LocalTime (..), addMinutesToTimeOfDay, parseDateYMD, parseTimeHHMM, slotDurationMins, utcToPacific)
 import Effects.Clock (currentSystemTime)
 import Effects.ContentSanitization (sanitizeTitle)
 import Effects.Database.Execute (execQuery)
@@ -76,7 +78,8 @@ data ParsedScheduleSlot = ParsedScheduleSlot
   { pssDay :: DayOfWeek,
     pssWeeks :: [Int64],
     pssStart :: TimeOfDay,
-    pssEnd :: TimeOfDay
+    pssEnd :: TimeOfDay,
+    pssReplayStartTime :: Maybe TimeOfDay
   }
   deriving stock (Eq, Ord, Show)
 
@@ -261,37 +264,62 @@ parseScheduleSlot slot = do
   let dur = duration slot
   if dur `notElem` [30, 60, 120]
     then Left $ "Invalid duration: " <> Text.pack (show dur) <> " (must be 30, 60, or 120)"
-    else
+    else do
+      let end = addMinutesToTimeOfDay start dur
+      mReplay <- case replayTime slot of
+        Nothing -> Right Nothing
+        Just rt
+          | Text.null (Text.strip rt) -> Right Nothing
+          | otherwise -> case parseTimeHHMM rt of
+              Nothing -> Left $ "Invalid replay time: " <> rt
+              Just replayTod -> Right (Just replayTod)
       Right $
         ParsedScheduleSlot
           { pssDay = dow,
             pssWeeks = sort (weeksOfMonth slot),
             pssStart = start,
-            pssEnd = addMinutesToTimeOfDay start dur
+            pssEnd = end,
+            pssReplayStartTime = mReplay
           }
 
 -- | Validate that schedule slots don't overlap on the same day.
 --
 -- Two slots overlap if they're on the same day, share at least one week of the month,
--- and their time ranges intersect.
+-- and their time ranges intersect. Also checks replay time ranges against all other
+-- primary and replay ranges.
 validateNoOverlaps :: [ParsedScheduleSlot] -> Either Text [ParsedScheduleSlot]
 validateNoOverlaps slots =
-  case findOverlap slots of
-    Just (slot1, slot2) ->
-      Left $
-        "Schedule conflict: "
-          <> Text.pack (show (pssDay slot1))
-          <> " "
-          <> formatTimeHHMM (pssStart slot1)
-          <> "-"
-          <> formatTimeHHMM (pssEnd slot1)
-          <> " overlaps with "
-          <> Text.pack (show (pssDay slot2))
-          <> " "
-          <> formatTimeHHMM (pssStart slot2)
-          <> "-"
-          <> formatTimeHHMM (pssEnd slot2)
-    Nothing -> Right slots
+  let -- Expand each slot into primary + optional replay virtual slot
+      expandSlot s =
+        let primary = s {pssReplayStartTime = Nothing}
+            replay = case pssReplayStartTime s of
+              Nothing -> []
+              Just rt ->
+                let dur = slotDurationMins (pssStart s) (pssEnd s)
+                 in [ s
+                        { pssStart = rt,
+                          pssEnd = addMinutesToTimeOfDay rt dur,
+                          pssReplayStartTime = Nothing
+                        }
+                    ]
+         in primary : replay
+      allVirtual = concatMap expandSlot slots
+   in case findOverlap allVirtual of
+        Just (slot1, slot2) ->
+          Left $
+            "Schedule conflict: "
+              <> Text.pack (show (pssDay slot1))
+              <> " "
+              <> formatTimeHHMM (pssStart slot1)
+              <> "-"
+              <> formatTimeHHMM (pssEnd slot1)
+              <> " overlaps with "
+              <> Text.pack (show (pssDay slot2))
+              <> " "
+              <> formatTimeHHMM (pssStart slot2)
+              <> "-"
+              <> formatTimeHHMM (pssEnd slot2)
+        Nothing -> Right slots
 
 -- | Find the first pair of overlapping slots, if any.
 findOverlap :: [ParsedScheduleSlot] -> Maybe (ParsedScheduleSlot, ParsedScheduleSlot)
@@ -352,7 +380,8 @@ normalizeTemplate t = case t.stDayOfWeek of
         { pssDay = dow,
           pssWeeks = sort (fromMaybe [1, 2, 3, 4, 5] t.stWeeksOfMonth),
           pssStart = t.stStartTime,
-          pssEnd = t.stEndTime
+          pssEnd = t.stEndTime,
+          pssReplayStartTime = t.stReplayStartTime
         }
   Nothing -> Nothing
 
@@ -369,6 +398,8 @@ schedulesMatch dbTemplates parsedSlots =
 --------------------------------------------------------------------------------
 
 -- | Check for schedule conflicts with other shows.
+--
+-- Checks both primary and replay time ranges against the database.
 checkScheduleConflicts ::
   Shows.Id ->
   [ParsedScheduleSlot] ->
@@ -378,13 +409,27 @@ checkScheduleConflicts showId = go
     go [] = pure (Right ())
     go (slot : rest) = do
       let weeks = map fromIntegral (pssWeeks slot)
+      -- Check primary slot
       execQuery (ShowSchedule.checkTimeSlotConflict showId (pssDay slot) weeks (pssStart slot) (pssEnd slot)) >>= \case
         Left err -> do
           Log.logAttention "Failed to check schedule conflict" (Text.pack $ show err)
           pure (Left "Unable to verify schedule availability. Please try again.")
         Right (Just conflictingShow) ->
           pure (Left $ "Schedule conflict: " <> Text.pack (show (pssDay slot)) <> " " <> formatTimeHHMM (pssStart slot) <> "-" <> formatTimeHHMM (pssEnd slot) <> " overlaps with \"" <> conflictingShow <> "\"")
-        Right Nothing -> go rest
+        Right Nothing ->
+          -- Check replay slot if set
+          case pssReplayStartTime slot of
+            Nothing -> go rest
+            Just replayStart -> do
+              let dur = slotDurationMins (pssStart slot) (pssEnd slot)
+                  replayEnd = addMinutesToTimeOfDay replayStart dur
+              execQuery (ShowSchedule.checkTimeSlotConflict showId (pssDay slot) weeks replayStart replayEnd) >>= \case
+                Left err -> do
+                  Log.logAttention "Failed to check replay conflict" (Text.pack $ show err)
+                  pure (Left "Unable to verify schedule availability. Please try again.")
+                Right (Just conflictingShow) ->
+                  pure (Left $ "Replay conflict: " <> Text.pack (show (pssDay slot)) <> " " <> formatTimeHHMM replayStart <> "-" <> formatTimeHHMM replayEnd <> " overlaps with \"" <> conflictingShow <> "\"")
+                Right Nothing -> go rest
 
 -- | Update schedules for a show.
 --
@@ -543,7 +588,7 @@ updateScheduleTemplates showId activeTemplates parsedSlots startDate = do
               ShowSchedule.stiStartTime = pssStart slot,
               ShowSchedule.stiEndTime = pssEnd slot,
               ShowSchedule.stiTimezone = "America/Los_Angeles",
-              ShowSchedule.stiAirsTwiceDaily = True
+              ShowSchedule.stiReplayStartTime = pssReplayStartTime slot
             }
 
     templateResult <- execQuery (ShowSchedule.insertScheduleTemplate templateInsert)

--- a/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Edit/Post/Route.hs
@@ -51,7 +51,8 @@ data ScheduleSlotInfo = ScheduleSlotInfo
   { dayOfWeek :: Text,
     weeksOfMonth :: [Int64],
     startTime :: Text,
-    duration :: Int
+    duration :: Int,
+    replayTime :: Maybe Text
   }
   deriving stock (Show, Generic, Eq)
   deriving anyclass (FromJSON, ToJSON)

--- a/services/web/src/API/Dashboard/Shows/Slug/Get/Templates/ShowHeader.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Get/Templates/ShowHeader.hs
@@ -94,7 +94,7 @@ renderShowHeader backend showModel hosts schedules tags = do
                 $ Lucid.toHtml (ShowTags.stName tag)
   where
     renderSchedule :: ShowSchedule.ScheduleTemplate Result -> Text
-    renderSchedule ShowSchedule.ScheduleTemplate {stDayOfWeek = mDow, stWeeksOfMonth = weeksOfMonth, stStartTime = st, stEndTime = et, stAirsTwiceDaily = airsTwice} =
+    renderSchedule ShowSchedule.ScheduleTemplate {stDayOfWeek = mDow, stWeeksOfMonth = weeksOfMonth, stStartTime = st, stEndTime = et, stReplayStartTime = mReplay} =
       case mDow of
         Nothing -> "One-time show"
         Just dow ->
@@ -107,7 +107,7 @@ renderShowHeader backend showModel hosts schedules tags = do
                 Thursday -> "Thursday"
                 Friday -> "Friday"
                 Saturday -> "Saturday"
-           in formatWeeksOfMonth weeksOfMonth <> dayName <> "s " <> formatScheduleDual st et airsTwice
+           in formatWeeksOfMonth weeksOfMonth <> dayName <> "s " <> formatScheduleDual st et mReplay
 
     showsGetByTagUrl :: ShowTags.Id -> Links.URI
     showsGetByTagUrl tagId = Links.linkURI $ showsLinks.list Nothing (Just (Filter (Just tagId))) Nothing Nothing Nothing

--- a/services/web/src/API/Shows/Slug/Get/Templates/ShowHeader.hs
+++ b/services/web/src/API/Shows/Slug/Get/Templates/ShowHeader.hs
@@ -80,7 +80,7 @@ renderShowHeader backend showModel hosts schedules tags = do
           Tags.renderTags (map showTagToLink tags)
   where
     renderSchedule :: ShowSchedule.ScheduleTemplate Result -> Text
-    renderSchedule ShowSchedule.ScheduleTemplate {stDayOfWeek = mDow, stWeeksOfMonth = weeksOfMonth, stStartTime = st, stEndTime = et, stAirsTwiceDaily = airsTwice} =
+    renderSchedule ShowSchedule.ScheduleTemplate {stDayOfWeek = mDow, stWeeksOfMonth = weeksOfMonth, stStartTime = st, stEndTime = et, stReplayStartTime = mReplay} =
       case mDow of
         Nothing -> "One-time show"
         Just dow ->
@@ -93,7 +93,7 @@ renderShowHeader backend showModel hosts schedules tags = do
                 Thursday -> "Thursday"
                 Friday -> "Friday"
                 Saturday -> "Saturday"
-           in formatWeeksOfMonth weeksOfMonth <> dayName <> "s " <> formatScheduleDual st et airsTwice
+           in formatWeeksOfMonth weeksOfMonth <> dayName <> "s " <> formatScheduleDual st et mReplay
 
     showTagToLink :: ShowTags.Model -> Tags.TagLink
     showTagToLink tag =

--- a/services/web/src/Component/ScheduleEditor.hs
+++ b/services/web/src/Component/ScheduleEditor.hs
@@ -76,6 +76,9 @@ schedulesToEditorJson templates =
           durationMins = computeDuration sched.stStartTime sched.stEndTime
           freq = weeksToFrequency sched.stWeeksOfMonth
           weeksVal = sched.stWeeksOfMonth
+          replayTimeText = case sched.stReplayStartTime of
+            Just rt -> Text.take 5 (Text.pack $ show rt)
+            Nothing -> "" :: Text
        in Aeson.object
             [ "frequency" Aeson..= freq,
               "weeks" Aeson..= weeksVal,
@@ -83,7 +86,8 @@ schedulesToEditorJson templates =
                 Aeson..= [ Aeson.object
                              [ "day" Aeson..= dayText,
                                "time" Aeson..= timeText,
-                               "duration" Aeson..= durationMins
+                               "duration" Aeson..= durationMins,
+                               "replayTime" Aeson..= replayTimeText
                              ]
                          ]
             ]
@@ -143,7 +147,9 @@ alpineState existingJson startDateText =
   startDate: '#{startDateText}',
   slots: [],
   activeTimePicker: null,
+  activeReplayPicker: null,
   timeFilter: '',
+  replayFilter: '',
   allTimes: (function() {
     var times = [];
     for (var h = 0; h < 24; h++) {
@@ -174,7 +180,8 @@ alpineState existingJson startDateText =
             this.slots.push({
               day: item.slots[j].day || '',
               time: item.slots[j].time || '',
-              duration: item.slots[j].duration || null
+              duration: item.slots[j].duration || null,
+              replayTime: item.slots[j].replayTime || ''
             });
           }
         }
@@ -192,7 +199,7 @@ alpineState existingJson startDateText =
       this.weeks = [1];
     }
     if (this.slots.length === 0) {
-      this.slots.push({ day: '', time: '', duration: null });
+      this.slots.push({ day: '', time: '', duration: null, replayTime: '' });
     }
   },
 
@@ -201,7 +208,7 @@ alpineState existingJson startDateText =
   },
 
   addSlot() {
-    this.slots.push({ day: '', time: '', duration: null });
+    this.slots.push({ day: '', time: '', duration: null, replayTime: '' });
   },
 
   removeSlot(index) {
@@ -214,17 +221,95 @@ alpineState existingJson startDateText =
 
   openTimePicker(index) {
     this.activeTimePicker = index;
-    this.timeFilter = this.slots[index].time || '';
+    this.timeFilter = this.formatTime(this.slots[index].time);
   },
 
-  closeTimePicker() {
+  closeTimePicker(resolve) {
+    if (resolve !== false && this.activeTimePicker !== null) {
+      var text = (this.timeFilter || '').trim();
+      if (text) {
+        var match = this.resolveFilter(text, this.filteredTimes());
+        if (match) this.slots[this.activeTimePicker].time = match;
+      }
+    }
     this.activeTimePicker = null;
     this.timeFilter = '';
   },
 
   selectTime(index, time) {
     this.slots[index].time = time;
-    this.closeTimePicker();
+    this.closeTimePicker(false);
+  },
+
+  openReplayPicker(index) {
+    this.activeReplayPicker = index;
+    this.replayFilter = this.formatTime(this.slots[index].replayTime);
+  },
+
+  closeReplayPicker(resolve) {
+    if (resolve !== false && this.activeReplayPicker !== null) {
+      var text = (this.replayFilter || '').trim();
+      if (text) {
+        var match = this.resolveFilter(text, this.filteredReplayTimes(this.activeReplayPicker));
+        if (match) this.slots[this.activeReplayPicker].replayTime = match;
+      }
+    }
+    this.activeReplayPicker = null;
+    this.replayFilter = '';
+  },
+
+  selectReplayTime(index, time) {
+    this.slots[index].replayTime = time;
+    this.closeReplayPicker(false);
+  },
+
+  resolveFilter(text, filtered) {
+    if (!text) return null;
+    if (filtered.length === 1) return filtered[0].value;
+    var lower = text.toLowerCase();
+    var exact = this.allTimes.find(function(t) {
+      return t.label.toLowerCase() === lower || t.value === text;
+    });
+    if (exact) return exact.value;
+    var shorthand = this.allTimes.find(function(t) {
+      return this.matchShorthand(lower, t);
+    }.bind(this));
+    if (shorthand) return shorthand.value;
+    return null;
+  },
+
+  clearReplayTime(index) {
+    this.slots[index].replayTime = '';
+  },
+
+  slotEndTime(slot) {
+    if (!slot.time || !slot.duration) return null;
+    var parts = slot.time.split(':');
+    var h = parseInt(parts[0], 10);
+    var m = parseInt(parts[1], 10);
+    var totalMins = h * 60 + m + slot.duration;
+    return totalMins % (24 * 60);
+  },
+
+  filteredReplayTimes(index) {
+    var filter = this.replayFilter.trim().toLowerCase();
+    var slot = this.slots[index];
+    var endMins = this.slotEndTime(slot);
+    var available = this.allTimes;
+    if (endMins !== null) {
+      available = available.filter(function(t) {
+        var parts = t.value.split(':');
+        var tMins = parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
+        return tMins >= endMins;
+      });
+    }
+    if (!filter) return available;
+    var self = this;
+    return available.filter(function(t) {
+      return t.label.toLowerCase().includes(filter) ||
+        t.value.toLowerCase().includes(filter) ||
+        self.matchShorthand(filter, t);
+    });
   },
 
   filteredTimes() {
@@ -287,12 +372,14 @@ alpineState existingJson startDateText =
     var valid = this.slots
       .filter(function(s) { return s.day && s.time && s.duration; })
       .map(function(s) {
-        return {
+        var obj = {
           dayOfWeek: s.day,
           weeksOfMonth: weeks,
           startTime: s.time,
           duration: s.duration
         };
+        if (s.replayTime) { obj.replayTime = s.replayTime; }
+        return obj;
       });
     return JSON.stringify(valid);
   }
@@ -409,6 +496,9 @@ renderSlotRow =
         -- Duration buttons
         renderDurationButtons
 
+      -- Replay time picker (shown when time and duration are set)
+      renderReplayTimePicker
+
 --------------------------------------------------------------------------------
 -- Day Dropdown
 
@@ -439,33 +529,44 @@ renderDayDropdown =
 
 renderTimePicker :: Lucid.Html ()
 renderTimePicker =
-  Lucid.div_ [class_ $ base ["relative"]] $ do
-    Lucid.label_ [class_ $ base [Tokens.textSm, Tokens.fontBold, Tokens.mb2, "block"]] "TIME"
+  Lucid.div_
+    [ class_ $ base ["relative"],
+      xOnClickOutside_ "if (activeTimePicker === index) closeTimePicker()"
+    ]
+    $ do
+      Lucid.label_ [class_ $ base [Tokens.textSm, Tokens.fontBold, Tokens.mb2, "block"]] "TIME"
 
-    -- Display input (opens picker)
-    Lucid.input_
-      [ Lucid.type_ "text",
-        Lucid.placeholder_ "e.g. 8:00 PM",
-        xOnClick_ "openTimePicker(index)",
-        xOnInput_ "timeFilter = $event.target.value",
-        xBindValue_ "activeTimePicker === index ? timeFilter : formatTime(slot.time)",
-        xOnClickOutside_ "if (activeTimePicker === index) closeTimePicker()",
-        class_ $ base ["w-full", Tokens.p3, Tokens.border2, Tokens.borderMuted, Tokens.bgMain, Tokens.fgPrimary, "font-mono", Tokens.textSm]
-      ]
-
-    -- Dropdown list
-    Lucid.div_
-      [ class_ $ base ["absolute", "z-10", "w-full", "max-h-48", "overflow-y-auto", Tokens.border2, Tokens.borderMuted, Tokens.bgMain],
-        xShow_ "activeTimePicker === index"
-      ]
-      $ Lucid.template_
-        [xFor_ "t in filteredTimes()", xKey_ "t.value"]
-      $ Lucid.div_
-        [ xOnClick_ "selectTime(index, t.value)",
-          class_ $ base [Tokens.p3, Tokens.textSm, "cursor-pointer", Tokens.hoverBg, "font-mono"],
-          xText_ "t.label"
+      -- Display input (opens picker)
+      Lucid.input_
+        [ Lucid.type_ "text",
+          Lucid.placeholder_ "e.g. 8:00 PM",
+          xOnClick_ "openTimePicker(index)",
+          xOnInput_ "timeFilter = $event.target.value",
+          xBindValue_ "activeTimePicker === index ? timeFilter : formatTime(slot.time)",
+          xOn_ "keydown.enter.prevent" "closeTimePicker()",
+          xOn_ "keydown.escape" "closeTimePicker(false)",
+          class_ $ base ["w-full", Tokens.p3, Tokens.border2, Tokens.borderMuted, Tokens.bgMain, Tokens.fgPrimary, "font-mono", Tokens.textSm]
         ]
-        mempty
+
+      -- Dropdown list
+      Lucid.div_
+        [ class_ $ base ["absolute", "z-10", "w-full", "max-h-48", "overflow-y-auto", Tokens.border2, Tokens.borderMuted, Tokens.bgMain],
+          xShow_ "activeTimePicker === index"
+        ]
+        $ do
+          Lucid.template_
+            [xFor_ "t in filteredTimes()", xKey_ "t.value"]
+            $ Lucid.div_
+              [ xOnClick_ "selectTime(index, t.value)",
+                class_ $ base [Tokens.p3, Tokens.textSm, "cursor-pointer", Tokens.hoverBg, "font-mono"],
+                xText_ "t.label"
+              ]
+              mempty
+          Lucid.div_
+            [ class_ $ base [Tokens.p3, Tokens.textSm, Tokens.errorText, "font-mono"],
+              xShow_ "timeFilter.trim() && filteredTimes().length === 0"
+            ]
+            "No matching times \x2014 try \"8:00 PM\" or \"8p\""
 
 --------------------------------------------------------------------------------
 -- Duration Buttons
@@ -491,6 +592,64 @@ durationButton dur label =
           : '#{Tokens.bgAlt} #{Tokens.fgPrimary} #{Tokens.borderMuted}'|]
     ]
     (Lucid.toHtml label)
+
+--------------------------------------------------------------------------------
+-- Replay Time Picker
+
+renderReplayTimePicker :: Lucid.Html ()
+renderReplayTimePicker =
+  Lucid.div_
+    [ class_ $ base [Tokens.mt4],
+      xShow_ "slot.time && slot.duration"
+    ]
+    $ do
+      Lucid.div_ [class_ $ base ["flex", "items-center", Tokens.gap2, Tokens.mb2]] $ do
+        Lucid.label_ [class_ $ base [Tokens.textSm, Tokens.fontBold]] "REPLAY TIME"
+        Lucid.span_ [class_ $ base [Tokens.textSm, Tokens.fgMuted]] "(optional)"
+      Lucid.div_ [class_ $ base ["flex", "items-center", Tokens.gap2]] $ do
+        -- Replay time input with typeahead
+        Lucid.div_
+          [ class_ $ base ["relative", "flex-1"],
+            xOnClickOutside_ "if (activeReplayPicker === index) closeReplayPicker()"
+          ]
+          $ do
+            Lucid.input_
+              [ Lucid.type_ "text",
+                Lucid.placeholder_ "e.g. 8:00 PM",
+                xOnClick_ "openReplayPicker(index)",
+                xOnInput_ "replayFilter = $event.target.value",
+                xBindValue_ "activeReplayPicker === index ? replayFilter : formatTime(slot.replayTime)",
+                xOn_ "keydown.enter.prevent" "closeReplayPicker()",
+                xOn_ "keydown.escape" "closeReplayPicker(false)",
+                class_ $ base ["w-full", Tokens.p3, Tokens.border2, Tokens.borderMuted, Tokens.bgMain, Tokens.fgPrimary, "font-mono", Tokens.textSm]
+              ]
+            -- Dropdown list
+            Lucid.div_
+              [ class_ $ base ["absolute", "z-10", "w-full", "max-h-48", "overflow-y-auto", Tokens.border2, Tokens.borderMuted, Tokens.bgMain],
+                xShow_ "activeReplayPicker === index"
+              ]
+              $ do
+                Lucid.template_
+                  [xFor_ "t in filteredReplayTimes(index)", xKey_ "t.value"]
+                  $ Lucid.div_
+                    [ xOnClick_ "selectReplayTime(index, t.value)",
+                      class_ $ base [Tokens.p3, Tokens.textSm, "cursor-pointer", Tokens.hoverBg, "font-mono"],
+                      xText_ "t.label"
+                    ]
+                    mempty
+                Lucid.div_
+                  [ class_ $ base [Tokens.p3, Tokens.textSm, Tokens.errorText, "font-mono"],
+                    xShow_ "replayFilter.trim() && filteredReplayTimes(index).length === 0"
+                  ]
+                  "No matching times \x2014 try \"8:00 PM\" or \"8p\""
+        -- Clear button
+        Lucid.template_ [xIf_ "slot.replayTime"] $
+          Lucid.button_
+            [ Lucid.type_ "button",
+              xOnClick_ "clearReplayTime(index)",
+              class_ $ base [Tokens.textSm, Tokens.fontBold, Tokens.errorText, "hover:opacity-80", Tokens.px4, Tokens.py2]
+            ]
+            "CLEAR"
 
 --------------------------------------------------------------------------------
 -- Start Date Picker

--- a/services/web/test/API/Dashboard/Episodes/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Get/HandlerSpec.hs
@@ -48,7 +48,7 @@ test_emptyDbReturnsNoEpisodes cfg = do
             stiStartTime = read "10:00:00",
             stiEndTime = read "11:00:00",
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = False
+            stiReplayStartTime = Nothing
           }
 
   bracketAppM cfg $ do
@@ -78,7 +78,7 @@ test_insertedEpisodeAppears cfg = do
             stiStartTime = read "10:00:00",
             stiEndTime = read "11:00:00",
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = False
+            stiReplayStartTime = Nothing
           }
 
   bracketAppM cfg $ do

--- a/services/web/test/API/Dashboard/Episodes/Slug/Edit/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Edit/Get/HandlerSpec.hs
@@ -53,7 +53,7 @@ setupFixture showInsert userInsert = do
             stiStartTime = read "10:00:00",
             stiEndTime = read "11:00:00",
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = False
+            stiReplayStartTime = Nothing
           }
   (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleInsert
 

--- a/services/web/test/API/Dashboard/Episodes/Slug/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Episodes/Slug/Get/HandlerSpec.hs
@@ -51,7 +51,7 @@ setupFixture showInsert userInsert = do
             stiStartTime = read "10:00:00",
             stiEndTime = read "11:00:00",
             stiTimezone = "America/Los_Angeles",
-            stiAirsTwiceDaily = False
+            stiReplayStartTime = Nothing
           }
   (showId, templateId) <- insertTestShowWithSchedule showInsert scheduleInsert
 

--- a/services/web/test/API/Dashboard/Shows/Slug/Edit/Post/ScheduleDiffSpec.hs
+++ b/services/web/test/API/Dashboard/Shows/Slug/Edit/Post/ScheduleDiffSpec.hs
@@ -8,8 +8,9 @@ module API.Dashboard.Shows.Slug.Edit.Post.ScheduleDiffSpec where
 
 --------------------------------------------------------------------------------
 
-import API.Dashboard.Shows.Slug.Edit.Post.Handler (ParsedScheduleSlot (..), normalizeTemplate, parseScheduleSlot, schedulesMatch)
+import API.Dashboard.Shows.Slug.Edit.Post.Handler (ParsedScheduleSlot (..), normalizeTemplate, parseScheduleSlot, schedulesMatch, validateNoOverlaps)
 import API.Dashboard.Shows.Slug.Edit.Post.Route (ScheduleSlotInfo (..))
+import Data.Either (isLeft)
 import Data.Int (Int64)
 import Data.List (sort)
 import Data.Set qualified as Set
@@ -22,7 +23,7 @@ import Hedgehog
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Rel8 qualified
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import Test.Hspec.Hedgehog (hedgehog)
 
 --------------------------------------------------------------------------------
@@ -34,12 +35,12 @@ spec =
       it "extracts and sorts fields from a DB template" $ do
         let template = mkTemplate (Just Friday) (Just [3, 1, 2]) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0)
         normalizeTemplate template
-          `shouldBe` Just (ParsedScheduleSlot Friday [1, 2, 3] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0))
+          `shouldBe` Just (ParsedScheduleSlot Friday [1, 2, 3] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) Nothing)
 
       it "handles Nothing weeks as all weeks (weekly)" $ do
         let template = mkTemplate (Just Monday) Nothing (TimeOfDay 14 0 0) (TimeOfDay 16 0 0)
         normalizeTemplate template
-          `shouldBe` Just (ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 14 0 0) (TimeOfDay 16 0 0))
+          `shouldBe` Just (ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) Nothing)
 
       it "returns Nothing for template with no day of week" $ do
         let template = mkTemplate Nothing (Just [1, 2]) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0)
@@ -49,7 +50,7 @@ spec =
       it "parses and normalizes a valid form slot" $ do
         let slot = mkSlot "friday" [3, 1, 2] "08:00" 120
         parseScheduleSlot slot
-          `shouldBe` Right (ParsedScheduleSlot Friday [1, 2, 3] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0))
+          `shouldBe` Right (ParsedScheduleSlot Friday [1, 2, 3] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) Nothing)
 
       it "rejects invalid start time" $ do
         let slot = mkSlot "friday" [1, 2] "invalid" 60
@@ -66,7 +67,7 @@ spec =
     describe "schedulesMatch" $ do
       it "returns True for identical schedules" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` True
 
       it "returns True for reordered schedules (set comparison)" $ do
@@ -75,41 +76,41 @@ spec =
                 mkTemplate (Just Monday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0)
               ]
             slots =
-              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0),
-                ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) Nothing,
+                ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing
               ]
         schedulesMatch templates slots `shouldBe` True
 
       it "returns True when DB template has unsorted weeks (normalizeTemplate sorts)" $ do
         let templates = [mkTemplate (Just Friday) (Just [5, 1, 3]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 3, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 3, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` True
 
       it "returns False for different day of week" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Saturday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Saturday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` False
 
       it "returns False for different weeks of month" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 3] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 3] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` False
 
       it "returns False for different start time" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 20 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 20 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` False
 
       it "returns False for different end time" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 22 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 22 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` False
 
       it "returns False for added schedule slot" $ do
         let templates = [mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
             slots =
-              [ ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0),
-                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0)
+              [ ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing,
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 8 0 0) (TimeOfDay 10 0 0) Nothing
               ]
         schedulesMatch templates slots `shouldBe` False
 
@@ -118,12 +119,12 @@ spec =
               [ mkTemplate (Just Friday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 19 0 0) (TimeOfDay 21 0 0),
                 mkTemplate (Just Monday) (Just [1, 2, 3, 4, 5]) (TimeOfDay 8 0 0) (TimeOfDay 10 0 0)
               ]
-            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` False
 
       it "returns True when DB has NULL weeks (weekly) and form sends [1..5]" $ do
         let templates = [mkTemplate (Just Friday) Nothing (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
-            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+            slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch templates slots `shouldBe` True
 
       it "returns True for empty schedules" $ do
@@ -134,8 +135,109 @@ spec =
         schedulesMatch templates [] `shouldBe` False
 
       it "returns False when form has schedules but DB is empty" $ do
-        let slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0)]
+        let slots = [ParsedScheduleSlot Friday [1, 2, 3, 4, 5] (TimeOfDay 19 0 0) (TimeOfDay 21 0 0) Nothing]
         schedulesMatch [] slots `shouldBe` False
+
+    describe "validateNoOverlaps" $ do
+      -- No-overlap cases
+      it "allows slots on different days" $ do
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing,
+                ParsedScheduleSlot Tuesday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
+
+      it "allows same day with non-overlapping weeks" $ do
+        let slots =
+              [ ParsedScheduleSlot Monday [1] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing,
+                ParsedScheduleSlot Monday [3] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
+
+      it "allows adjacent time slots (end of first = start of second)" $ do
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing,
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 12 0 0) (TimeOfDay 14 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
+
+      it "allows two slots without replays that don't overlap" $ do
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing,
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
+
+      -- Primary vs primary overlap
+      it "rejects overlapping primary slots on the same day and weeks" $ do
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) Nothing,
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 11 0 0) (TimeOfDay 13 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Replay overlaps own primary
+      it "rejects a slot whose replay overlaps its own primary" $ do
+        -- 10:00-12:00 primary with replay at 11:00 → replay 11:00-13:00 overlaps primary
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) (Just (TimeOfDay 11 0 0))
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Replay overlaps another slot's primary
+      it "rejects when a slot's replay overlaps another slot's primary" $ do
+        -- Slot A: 10:00-12:00, replay at 14:00 → replay 14:00-16:00
+        -- Slot B: 15:00-17:00 primary → overlaps slot A's replay
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) (Just (TimeOfDay 14 0 0)),
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 15 0 0) (TimeOfDay 17 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Primary overlaps another slot's replay
+      it "rejects when a slot's primary overlaps another slot's replay" $ do
+        -- Slot A: 14:00-16:00 primary, replay at 10:00 → replay 10:00-12:00
+        -- Slot B: 11:00-12:00 primary → overlaps slot A's replay
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) (Just (TimeOfDay 10 0 0)),
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 11 0 0) (TimeOfDay 12 0 0) Nothing
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Replay vs replay overlap
+      it "rejects when two slots' replays overlap each other" $ do
+        -- Slot A: 10:00-12:00 (2h), replay at 18:00 → replay 18:00-20:00
+        -- Slot B: 14:00-16:00 (2h), replay at 19:00 → replay 19:00-21:00
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 10 0 0) (TimeOfDay 12 0 0) (Just (TimeOfDay 18 0 0)),
+                ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 14 0 0) (TimeOfDay 16 0 0) (Just (TimeOfDay 19 0 0))
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Midnight-ending show cases
+      it "allows midnight-ending show with replay starting at midnight" $ do
+        -- 23:00-00:00 (1h) with replay at 00:00 → replay 00:00-01:00
+        -- Primary is overnight (end 00:00 <= start 23:00), replay is standard
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 23 0 0) (TimeOfDay 0 0 0) (Just (TimeOfDay 0 0 0))
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
+
+      it "rejects midnight-ending show with replay during primary" $ do
+        -- 23:00-00:00 (1h) with replay at 23:30 → replay 23:30-00:30
+        -- Both overnight → always overlap
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 23 0 0) (TimeOfDay 0 0 0) (Just (TimeOfDay 23 30 0))
+              ]
+        validateNoOverlaps slots `shouldSatisfy` isLeft
+
+      -- Overnight primary with non-overlapping replay
+      it "allows overnight show with non-overlapping replay" $ do
+        -- 23:00-01:00 (2h overnight) with replay at 02:00 → replay 02:00-04:00
+        let slots =
+              [ ParsedScheduleSlot Monday [1, 2, 3, 4, 5] (TimeOfDay 23 0 0) (TimeOfDay 1 0 0) (Just (TimeOfDay 2 0 0))
+              ]
+        validateNoOverlaps slots `shouldBe` Right slots
 
     describe "diff algebra" $ do
       it "unchanged slots appear in neither removed nor added" $ hedgehog $ do
@@ -180,7 +282,7 @@ mkTemplate dow weeks start end =
       stEndTime = end,
       stTimezone = "America/Los_Angeles",
       stCreatedAt = UTCTime (fromGregorian 2025 1 1) 0,
-      stAirsTwiceDaily = False
+      stReplayStartTime = Nothing
     }
 
 -- | Create a ScheduleSlotInfo for testing.
@@ -190,7 +292,8 @@ mkSlot dow weeks start dur =
     { dayOfWeek = dow,
       weeksOfMonth = weeks,
       startTime = start,
-      duration = dur
+      duration = dur,
+      replayTime = Nothing
     }
 
 --------------------------------------------------------------------------------
@@ -202,10 +305,14 @@ genParsedScheduleSlot = do
   weeks <- sort <$> Gen.subsequence [1, 2, 3, 4, 5]
   startHour <- Gen.int (Range.linear 6 22)
   let endHour = min 23 (startHour + 2)
+  mReplay <- Gen.maybe $ do
+    replayHour <- Gen.int (Range.linear endHour 23)
+    pure $ TimeOfDay replayHour 0 0
   pure $
     ParsedScheduleSlot
       { pssDay = day,
         pssWeeks = weeks,
         pssStart = TimeOfDay startHour 0 0,
-        pssEnd = TimeOfDay endHour 0 0
+        pssEnd = TimeOfDay endHour 0 0,
+        pssReplayStartTime = mReplay
       }

--- a/services/web/test/API/Shows/Slug/Blog/Post/Get/HandlerSpec.hs
+++ b/services/web/test/API/Shows/Slug/Blog/Post/Get/HandlerSpec.hs
@@ -58,7 +58,7 @@ mkScheduleTemplate =
       stiStartTime = read "10:00:00",
       stiEndTime = read "12:00:00",
       stiTimezone = "America/Los_Angeles",
-      stiAirsTwiceDaily = False
+      stiReplayStartTime = Nothing
     }
 
 -- | Construct a show blog post insert with a fixed canonical slug.

--- a/services/web/test/Component/ScheduleEditorSpec.hs
+++ b/services/web/test/Component/ScheduleEditorSpec.hs
@@ -164,7 +164,7 @@ mkTemplate dow weeks start end =
       stEndTime = end,
       stTimezone = "America/Los_Angeles",
       stCreatedAt = UTCTime (fromGregorian 2025 1 1) 0,
-      stAirsTwiceDaily = False
+      stReplayStartTime = Nothing
     }
 
 -- | Decode the editor JSON into a list of Aeson objects for inspection.

--- a/services/web/test/Test/Handler/Fixtures.hs
+++ b/services/web/test/Test/Handler/Fixtures.hs
@@ -65,7 +65,7 @@ defaultScheduleInsert =
       stiStartTime = TimeOfDay 10 0 0,
       stiEndTime = TimeOfDay 11 0 0,
       stiTimezone = "America/Los_Angeles",
-      stiAirsTwiceDaily = False
+      stiReplayStartTime = Nothing
     }
 
 -- | Set up a user from a pre-built insert and return User.Model + UserMetadata.Model.


### PR DESCRIPTION
## Summary
- Replaces the `airs_twice_daily` boolean on schedule templates with a `replay_start_time` column that accepts an absolute time of day, allowing each schedule slot to specify when (or if) its replay airs instead of being locked to a +12h offset.
- Schedule editor UI includes an optional replay time picker per slot with conflict detection covering replay time ranges.
- Migration swaps existing PM primaries to AM so replays always follow the primary airing.

## Also includes
- **Bugfix**: Fixed currently-airing query Case 5 (overnight replay before-midnight) not correctly handling episodes whose duration fills or exceeds time until midnight.
- **Cleanup**: Extracted shared `checkScheduleConflicts` from Edit handler, removing duplication with New handler.
- **Testing**: Extended property test generator to exercise `pssReplayStartTime` values in diff algebra tests.

## Test plan
- [x] All 488 tests pass (242 database + 246 API)
- [x] Manual test: create show with replay time, verify schedule displays correctly
- [x] Manual test: edit show replay time, verify conflict detection works
- [x] Manual test: verify migration on staging with existing `airs_twice_daily` data
- [x] Verify overnight replay detection with custom replay times

🤖 Generated with [Claude Code](https://claude.com/claude-code)