### PR TITLE
feat: Webstore Phase 1 — DB layer, admin interface, form builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Webstore — Product Management Dashboard** — Staff can manage store products from `/dashboard/store/products`. Inline product creation on the list page (+ NEW button reveals input row). Full edit page with basic info, pricing, inventory, images, and options/variants. Products default to inactive on creation, slug auto-generated from name.
+- **Webstore — Combined Options & Variants** — Shopify-style options/variants UI on the product edit page. Add option types (Size, Color) with tag-style value inputs, variants auto-generated as cartesian product. Inline editable variant table (price override, inventory, SKU, weight). All managed client-side with Alpine.js, serialized as JSON, persisted in a single database transaction.
+- **Webstore — Multi-Image Upload (`imagesField`)** — New form builder field for managing ordered sets of images with Cropper.js cropping, drag-and-drop reorder, per-image alt text, and inline preview. First image is hero/thumbnail. Integrated into the product edit form.
+- **Webstore — Database Schema** — Migration for all store tables: `products`, `product_images`, `product_option_types`, `product_option_values`, `product_variants`, `product_variant_options`, `orders`, `order_items`, `store_settings`. Variants use soft-delete (`deleted_at`) for order history FK integrity.
+- **Webstore — Store Settings** — Admin page at `/dashboard/store/settings` for tax rate, ship-from address, and order notification email.
+- **Webstore — Orders Placeholder** — Dashboard order list page at `/dashboard/store/orders` (placeholder for Phase 3 checkout integration).
+- **`Cents` Newtype** — Type-safe price representation (`newtype Cents = Cents Int64`) in `Domain.Types.Cents` with `fromDollars`, `toDollars`, `formatDisplay` helpers. Replaces raw `Int64` for all price columns. Property tests for round-trip, formatting, and invariants.
+- **`ImageData` Type** — Form builder owns its own `ImageData` type for the `imagesField` contract, decoupling the Alpine.js component from domain model types.
+- **Dashboard Navigation** — Store section in the dashboard sidebar with Products, Orders, and Settings links. Products and Orders visible to Staff+, Settings visible to Admin only.
+
+### Changed
+- **`getStdGen` → `newStdGen`** — All file upload functions now use `newStdGen` instead of `getStdGen` to avoid duplicate filenames when uploading multiple files in a single request.
+- **Form Builder Library** — Added `imagesField`, `currentImages`, `previewSize` field builders. Added `ImagesField` variant, `ImageData` type, and `fcPreviewSize`/`fcCurrentImages` config fields. Added `aeson`, `bytestring`, `DeriveGeneric` dependencies.
+
 - **Analytics Dashboard** — Admin-only dashboard page at `/dashboard/analytics` with live listener count from Icecast, listener trend charts (line), archive play counts by day (bar), and top episodes by plays. Time range selector (24h/7d/30d/90d) with refresh. Uses Chart.js for visualization and Alpine.js for client-side state. Chart data served via JSON endpoint at `/dashboard/analytics/data`.
 - **Cloudflare WAF Custom Rules** — Added 3 WAF rules (of 5 free-tier max) to `cloudflare.tf` that block malicious traffic at the Cloudflare edge before it reaches the origin server: path traversal/LFI/SSRF attempts, known scanner/bot probe paths (wp-admin, .env, phpMyAdmin, etc.), and non-ASCII percent-encoded bytes in URI paths. Complements fail2ban, which cannot ban Cloudflare-proxied traffic via nftables.
 - **Host Invitation System** — Staff can generate invitation links from `/dashboard/invitations` with pre-configured show schedules. New hosts use the link to create their account and show in a single guided flow. Tokens are single-use and expire after 7 days. Includes invitation management (list, regenerate, delete) and a public signup form at `/invite/:token` that creates the user, show, and schedule template in one transaction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ import API.Links (rootLink, userLinks)
 Lucid.href_ (rootLink $ userLinks.loginGet Nothing Nothing)
 ```
 
-Available link structures: `apiLinks`, `blogLinks`, `eventsLinks`, `showsLinks`, `showBlogLinks`, `showEpisodesLinks`, `userLinks`, `dashboardLinks`, `dashboardHostLinks`, `dashboardAdminLinks`, etc. See `API.Links` for the full list.
+Available link structures: `apiLinks`, `blogLinks`, `eventsLinks`, `showsLinks`, `showBlogLinks`, `showEpisodesLinks`, `userLinks`, `dashboardLinks`, `dashboardHostLinks`, `dashboardAdminLinks`, `dashboardStoreLinks`, `dashboardStoreProductsLinks`, `dashboardStoreSettingsLinks`, `dashboardStoreOrdersLinks`, etc. See `API.Links` for the full list.
 
 ### Concrete AppM Monad
 
@@ -156,6 +156,9 @@ handler cookie (foldHxReq -> hxRequest) = do
 - **Uploads**: `staged_uploads`, `ephemeral_uploads`
 - **Content**: `site_pages`, `site_page_revisions`, `station_ids`
 - **Streaming**: `playback_history`
+- **Store**: `products`, `product_images`, `product_option_types`, `product_option_values`, `product_variants`, `product_variant_options`, `orders`, `order_items`, `store_settings`
+
+The `products_with_inventory` view replaces product-level inventory with the sum of active variant inventories when variants exist. All product read queries use this view.
 
 ### Access Pattern
 
@@ -177,8 +180,8 @@ Execute: `result <- execQuery (Table.getById id)`
 
 - **User**: View content, newsletter, account management
 - **Host**: Upload episodes for assigned shows, create show blogs, submit events
-- **Staff**: Station-wide blog posts, moderate content, manage multiple shows
-- **Admin**: User management, system configuration
+- **Staff**: Station-wide blog posts, moderate content, manage multiple shows, manage store products and orders
+- **Admin**: User management, system configuration, store settings
 
 Enforcement: `user_metadata.role` enum, handler combinators in `App.Handler.Combinators` (`requireAuth`, `requireHostNotSuspended`, `requireStaffNotSuspended`, `requireAdminNotSuspended`, `requireShowHostOrStaff`), role in session cookie.
 
@@ -193,6 +196,8 @@ Enforcement: `user_metadata.role` enum, handler combinators in `App.Handler.Comb
 **Structure**: `{audio,images,documents}/{resource-type}/{YYYY}/{MM}/{DD}/{slug}_{date}_{uuid}.{ext}`
 
 Example: `audio/episodes/2024/09/27/show-slug_2024-09-27_abc123.mp3`
+
+**Product Images**: Uploaded directly via `uploadProductImage` (no staged upload). Stored at `images/product-images/{YYYY}/{MM}/{DD}/{product-slug}_{uuid}.{ext}`. Uses Cropper.js for client-side cropping before upload.
 
 ## Development Commands
 

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
         in
         rec {
           devShell = hsPkgs.shellFor {
-            packages = p: [ p.kpbj-types p.kpbj-database p.kpbj-email p.kpbj-api p.sync-host-emails p.token-cleanup p.episode-check p.listener-snapshots ];
+            packages = p: map pkgs.haskell.lib.doCheck [ p.kpbj-types p.kpbj-database p.kpbj-email p.kpbj-api p.sync-host-emails p.token-cleanup p.episode-check p.listener-snapshots ];
             withHoogle = false;
             buildInputs = [
               pkgs.cabal-install

--- a/lib/kpbj-database/kpbj-database.cabal
+++ b/lib/kpbj-database/kpbj-database.cabal
@@ -48,6 +48,7 @@ library
     , kpbj-types
     , password
     , rel8
+    , scientific
     , servant-server
     , string-interpolate
     , text
@@ -68,8 +69,16 @@ library
     Effects.Database.Tables.EpisodeTrack
     Effects.Database.Tables.Events
     Effects.Database.Tables.HostInvitation
+    Effects.Database.Tables.OrderItems
+    Effects.Database.Tables.Orders
     Effects.Database.Tables.PasswordResetTokens
     Effects.Database.Tables.PlaybackHistory
+    Effects.Database.Tables.ProductImages
+    Effects.Database.Tables.ProductOptionTypes
+    Effects.Database.Tables.ProductOptionValues
+    Effects.Database.Tables.Products
+    Effects.Database.Tables.ProductVariantOptions
+    Effects.Database.Tables.ProductVariants
     Effects.Database.Tables.ShowBlogPosts
     Effects.Database.Tables.ShowBlogTags
     Effects.Database.Tables.ShowHost
@@ -80,6 +89,7 @@ library
     Effects.Database.Tables.SitePages
     Effects.Database.Tables.StagedUploads
     Effects.Database.Tables.StationIds
+    Effects.Database.Tables.StoreSettings
     Effects.Database.Tables.UserMetadata
     Effects.Database.Tables.Util
     OrphanInstances.Rel8
@@ -119,6 +129,7 @@ library kpbj-database-test-lib
     , mtl
     , password
     , postgres-options
+    , scientific
     , text
     , time
     , tmp-postgres
@@ -154,6 +165,12 @@ library kpbj-database-test-lib
     Test.Gen.Tables.StagedUploads
     Test.Gen.Tables.StationIds
     Test.Gen.Tables.UserMetadata
+    Test.Gen.Tables.Products
+    Test.Gen.Tables.ProductImages
+    Test.Gen.Tables.ProductOptionTypes
+    Test.Gen.Tables.ProductOptionValues
+    Test.Gen.Tables.ProductVariants
+    Test.Gen.Tables.StoreSettings
 
 --------------------------------------------------------------------------------
 
@@ -192,6 +209,7 @@ test-suite kpbj-database-test
     , mtl
     , password
     , postgres-options
+    , scientific
     , text
     , text-display
     , time
@@ -223,6 +241,13 @@ test-suite kpbj-database-test
     Effects.Database.Tables.StationIdsSpec
     Effects.Database.Tables.UserMetadataSpec
     Effects.Database.Tables.UserRoleSpec
+    Effects.Database.Tables.ProductsSpec
+    Effects.Database.Tables.ProductImagesSpec
+    Effects.Database.Tables.ProductVariantsSpec
+    Effects.Database.Tables.ProductVariantOptionsSpec
+    Effects.Database.Tables.ProductOptionTypesSpec
+    Effects.Database.Tables.StoreSettingsSpec
+    Domain.Types.CentsSpec
     Domain.Types.FileUploadSpec
     Domain.Types.SlugSpec
     Domain.Types.StorageBackendSpec
@@ -252,5 +277,11 @@ test-suite kpbj-database-test
     Test.Gen.Tables.StagedUploads
     Test.Gen.Tables.StationIds
     Test.Gen.Tables.UserMetadata
+    Test.Gen.Tables.Products
+    Test.Gen.Tables.ProductImages
+    Test.Gen.Tables.ProductOptionTypes
+    Test.Gen.Tables.ProductOptionValues
+    Test.Gen.Tables.ProductVariants
+    Test.Gen.Tables.StoreSettings
     Test.Gen.Text
     Test.Gen.Time

--- a/lib/kpbj-database/src/Effects/Database/Tables/OrderItems.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/OrderItems.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition for @order_items@.
+--
+-- Schema-only module — queries are implemented in Phase 3.
+module Effects.Database.Tables.OrderItems
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    OrderItem (..),
+    orderItemSchema,
+
+    -- * Model (Result alias)
+    Model,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int64)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import Domain.Types.Cents (Cents)
+import Effects.Database.Tables.Orders qualified as Orders
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..))
+import OrphanInstances.Rel8 ()
+import Rel8
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for order item primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @order_items@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data OrderItem f = OrderItem
+  { oiId :: Column f Id,
+    oiOrderId :: Column f Orders.Id,
+    oiProductId :: Column f Products.Id,
+    oiVariantId :: Column f (Maybe ProductVariants.Id),
+    oiProductName :: Column f Text,
+    oiVariantLabel :: Column f Text,
+    oiQuantity :: Column f Int64,
+    oiUnitPriceCents :: Column f Cents,
+    oiCreatedAt :: Column f UTCTime
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (OrderItem f)
+
+deriving stock instance (f ~ Result) => Eq (OrderItem f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (OrderItem Result)
+
+-- | Display instance for OrderItem Result.
+instance Display (OrderItem Result) where
+  displayBuilder oi =
+    "OrderItem { id = "
+      <> displayBuilder oi.oiId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @OrderItem Result@.
+type Model = OrderItem Result
+
+-- | Table schema connecting the Haskell type to the database table.
+orderItemSchema :: TableSchema (OrderItem Name)
+orderItemSchema =
+  TableSchema
+    { name = "order_items",
+      columns =
+        OrderItem
+          { oiId = "id",
+            oiOrderId = "order_id",
+            oiProductId = "product_id",
+            oiVariantId = "variant_id",
+            oiProductName = "product_name",
+            oiVariantLabel = "variant_label",
+            oiQuantity = "quantity",
+            oiUnitPriceCents = "unit_price_cents",
+            oiCreatedAt = "created_at"
+          }
+    }

--- a/lib/kpbj-database/src/Effects/Database/Tables/Orders.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/Orders.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition for @orders@.
+--
+-- Schema-only module — queries are implemented in Phase 3.
+module Effects.Database.Tables.Orders
+  ( -- * Id Type
+    Id (..),
+
+    -- * Enums
+    OrderStatus (..),
+    PaymentMethod (..),
+
+    -- * Table Definition
+    Order (..),
+    orderSchema,
+
+    -- * Model (Result alias)
+    Model,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int64)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import Domain.Types.Cents (Cents)
+import GHC.Generics (Generic)
+import Hasql.Decoders qualified as Decoders
+import Hasql.Encoders qualified as Encoders
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..))
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Enum, Order)
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for order primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Enums
+
+-- | Order lifecycle status.
+data OrderStatus = Pending | Paid | Shipped | Completed | Cancelled | Refunded
+  deriving stock (Generic, Show, Eq, Ord, Enum, Bounded)
+  deriving anyclass (FromJSON, ToJSON)
+
+instance DBType OrderStatus where
+  typeInformation =
+    parseTypeInformation
+      ( \case
+          "pending" -> Right Pending
+          "paid" -> Right Paid
+          "shipped" -> Right Shipped
+          "completed" -> Right Completed
+          "cancelled" -> Right Cancelled
+          "refunded" -> Right Refunded
+          other -> Left $ "Invalid OrderStatus: " <> Text.unpack other
+      )
+      ( \case
+          Pending -> "pending"
+          Paid -> "paid"
+          Shipped -> "shipped"
+          Completed -> "completed"
+          Cancelled -> "cancelled"
+          Refunded -> "refunded"
+      )
+      typeInformation
+
+instance DBEq OrderStatus
+
+instance DecodeValue OrderStatus where
+  decodeValue = Decoders.enum $ \case
+    "pending" -> Just Pending
+    "paid" -> Just Paid
+    "shipped" -> Just Shipped
+    "completed" -> Just Completed
+    "cancelled" -> Just Cancelled
+    "refunded" -> Just Refunded
+    _ -> Nothing
+
+instance EncodeValue OrderStatus where
+  encodeValue = Encoders.enum $ \case
+    Pending -> "pending"
+    Paid -> "paid"
+    Shipped -> "shipped"
+    Completed -> "completed"
+    Cancelled -> "cancelled"
+    Refunded -> "refunded"
+
+instance Display OrderStatus where
+  displayBuilder = \case
+    Pending -> "Pending"
+    Paid -> "Paid"
+    Shipped -> "Shipped"
+    Completed -> "Completed"
+    Cancelled -> "Cancelled"
+    Refunded -> "Refunded"
+
+-- | Payment provider used for the order.
+data PaymentMethod = Stripe | Paypal
+  deriving stock (Generic, Show, Eq, Ord, Enum, Bounded)
+  deriving anyclass (FromJSON, ToJSON)
+
+instance DBType PaymentMethod where
+  typeInformation =
+    parseTypeInformation
+      ( \case
+          "stripe" -> Right Stripe
+          "paypal" -> Right Paypal
+          other -> Left $ "Invalid PaymentMethod: " <> Text.unpack other
+      )
+      ( \case
+          Stripe -> "stripe"
+          Paypal -> "paypal"
+      )
+      typeInformation
+
+instance DBEq PaymentMethod
+
+instance DecodeValue PaymentMethod where
+  decodeValue = Decoders.enum $ \case
+    "stripe" -> Just Stripe
+    "paypal" -> Just Paypal
+    _ -> Nothing
+
+instance EncodeValue PaymentMethod where
+  encodeValue = Encoders.enum $ \case
+    Stripe -> "stripe"
+    Paypal -> "paypal"
+
+instance Display PaymentMethod where
+  displayBuilder = \case
+    Stripe -> "Stripe"
+    Paypal -> "PayPal"
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @orders@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data Order f = Order
+  { oId :: Column f Id,
+    oOrderNumber :: Column f Text,
+    oEmail :: Column f Text,
+    oStatus :: Column f OrderStatus,
+    oShippingFirstName :: Column f Text,
+    oShippingLastName :: Column f Text,
+    oShippingAddressLine1 :: Column f Text,
+    oShippingAddressLine2 :: Column f Text,
+    oShippingCity :: Column f Text,
+    oShippingState :: Column f Text,
+    oShippingZip :: Column f Text,
+    oShippingCountry :: Column f Text,
+    oShippingMethod :: Column f Text,
+    oSubtotalCents :: Column f Cents,
+    oShippingCents :: Column f Cents,
+    oTaxCents :: Column f Cents,
+    oTotalCents :: Column f Cents,
+    oStripePaymentIntentId :: Column f (Maybe Text),
+    oPaypalOrderId :: Column f (Maybe Text),
+    oPaymentMethod :: Column f PaymentMethod,
+    oEasypostShipmentId :: Column f (Maybe Text),
+    oTrackingNumber :: Column f (Maybe Text),
+    oLabelUrl :: Column f (Maybe Text),
+    oNotes :: Column f Text,
+    oCreatedAt :: Column f UTCTime,
+    oUpdatedAt :: Column f UTCTime
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (Order f)
+
+deriving stock instance (f ~ Result) => Eq (Order f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (Order Result)
+
+-- | Display instance for Order Result.
+instance Display (Order Result) where
+  displayBuilder o =
+    "Order { id = "
+      <> displayBuilder o.oId
+      <> ", orderNumber = "
+      <> displayBuilder o.oOrderNumber
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @Order Result@.
+type Model = Order Result
+
+-- | Table schema connecting the Haskell type to the database table.
+orderSchema :: TableSchema (Order Name)
+orderSchema =
+  TableSchema
+    { name = "orders",
+      columns =
+        Order
+          { oId = "id",
+            oOrderNumber = "order_number",
+            oEmail = "email",
+            oStatus = "status",
+            oShippingFirstName = "shipping_first_name",
+            oShippingLastName = "shipping_last_name",
+            oShippingAddressLine1 = "shipping_address_line1",
+            oShippingAddressLine2 = "shipping_address_line2",
+            oShippingCity = "shipping_city",
+            oShippingState = "shipping_state",
+            oShippingZip = "shipping_zip",
+            oShippingCountry = "shipping_country",
+            oShippingMethod = "shipping_method",
+            oSubtotalCents = "subtotal_cents",
+            oShippingCents = "shipping_cents",
+            oTaxCents = "tax_cents",
+            oTotalCents = "total_cents",
+            oStripePaymentIntentId = "stripe_payment_intent_id",
+            oPaypalOrderId = "paypal_order_id",
+            oPaymentMethod = "payment_method",
+            oEasypostShipmentId = "easypost_shipment_id",
+            oTrackingNumber = "tracking_number",
+            oLabelUrl = "label_url",
+            oNotes = "notes",
+            oCreatedAt = "created_at",
+            oUpdatedAt = "updated_at"
+          }
+    }

--- a/lib/kpbj-database/src/Effects/Database/Tables/ProductImages.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ProductImages.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @product_images@.
+--
+-- Uses rel8 for simple queries.
+module Effects.Database.Tables.ProductImages
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    ProductImage (..),
+    productImageSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Insert Type
+    Insert (..),
+
+    -- * Queries
+    getById,
+    getByProductId,
+    insertImage,
+    deleteImage,
+    updateSortOrder,
+    updateImageMeta,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Util (nextId)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..))
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Insert)
+import Rel8 qualified
+import Rel8.Expr.Time (now)
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for product image primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @product_images@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data ProductImage f = ProductImage
+  { piId :: Column f Id,
+    piProductId :: Column f Products.Id,
+    piImagePath :: Column f Text,
+    piAltText :: Column f Text,
+    piSortOrder :: Column f Int64,
+    piCreatedAt :: Column f UTCTime
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (ProductImage f)
+
+deriving stock instance (f ~ Result) => Eq (ProductImage f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (ProductImage Result)
+
+
+-- | Display instance for ProductImage Result.
+instance Display (ProductImage Result) where
+  displayBuilder image =
+    "ProductImage { id = "
+      <> displayBuilder image.piId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @ProductImage Result@.
+type Model = ProductImage Result
+
+-- | Table schema connecting the Haskell type to the database table.
+productImageSchema :: TableSchema (ProductImage Name)
+productImageSchema =
+  TableSchema
+    { name = "product_images",
+      columns =
+        ProductImage
+          { piId = "id",
+            piProductId = "product_id",
+            piImagePath = "image_path",
+            piAltText = "alt_text",
+            piSortOrder = "sort_order",
+            piCreatedAt = "created_at"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Insert Type
+
+-- | Insert type for creating new product images.
+data Insert = Insert
+  { iiProductId :: Products.Id,
+    iiImagePath :: Text,
+    iiAltText :: Text,
+    iiSortOrder :: Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get all images for a product, ordered by sort_order.
+getByProductId :: Products.Id -> Hasql.Statement () [Model]
+getByProductId productId =
+  run $
+    select $
+      orderBy (piSortOrder >$< asc) do
+        image <- each productImageSchema
+        where_ $ piProductId image ==. lit productId
+        pure image
+
+-- | Insert a new product image.
+insertImage :: Insert -> Hasql.Statement () (Maybe Id)
+insertImage Insert {..} =
+  fmap listToMaybe $
+    run $
+      insert
+        Rel8.Insert
+          { into = productImageSchema,
+            rows =
+              values
+                [ ProductImage
+                    { piId = nextId "product_images_id_seq",
+                      piProductId = lit iiProductId,
+                      piImagePath = lit iiImagePath,
+                      piAltText = lit iiAltText,
+                      piSortOrder = lit iiSortOrder,
+                      piCreatedAt = now
+                    }
+                ],
+            onConflict = Abort,
+            returning = Returning piId
+          }
+
+-- | Delete a product image by ID.
+deleteImage :: Id -> Hasql.Statement () (Maybe Id)
+deleteImage imageId =
+  fmap listToMaybe $
+    run $
+      delete
+        Rel8.Delete
+          { from = productImageSchema,
+            using = pure (),
+            deleteWhere = \_ image -> piId image ==. lit imageId,
+            returning = Returning piId
+          }
+
+-- | Get a single product image by its ID.
+getById :: Id -> Hasql.Statement () (Maybe Model)
+getById imageId =
+  fmap listToMaybe $
+    run $
+      select do
+        image <- each productImageSchema
+        where_ $ piId image ==. lit imageId
+        pure image
+
+
+-- | Update the sort order of a product image.
+updateSortOrder :: Id -> Int64 -> Hasql.Statement () ()
+updateSortOrder imageId newSortOrder =
+  run_ $
+    update
+      Rel8.Update
+        { target = productImageSchema,
+          from = pure (),
+          set = \_ image -> image {piSortOrder = lit newSortOrder},
+          updateWhere = \_ image -> piId image ==. lit imageId,
+          returning = NoReturning
+        }
+
+
+-- | Update both sort order and alt text of a product image.
+updateImageMeta ::
+  Id ->
+  -- | New sort order.
+  Int64 ->
+  -- | New alt text.
+  Text ->
+  Hasql.Statement () ()
+updateImageMeta imageId newSortOrder newAltText =
+  run_ $
+    update
+      Rel8.Update
+        { target = productImageSchema,
+          from = pure (),
+          set = \_ image ->
+            image
+              { piSortOrder = lit newSortOrder,
+                piAltText = lit newAltText
+              },
+          updateWhere = \_ image -> piId image ==. lit imageId,
+          returning = NoReturning
+        }

--- a/lib/kpbj-database/src/Effects/Database/Tables/ProductOptionTypes.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ProductOptionTypes.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @product_option_types@.
+--
+-- Uses rel8 for simple queries.
+module Effects.Database.Tables.ProductOptionTypes
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    ProductOptionType (..),
+    productOptionTypeSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Insert Type
+    Insert (..),
+
+    -- * Queries
+    getByProductId,
+    insertOptionType,
+    deleteOptionType,
+    deleteByProductId,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Util (nextId)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..))
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Insert)
+import Rel8 qualified
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for product option type primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @product_option_types@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data ProductOptionType f = ProductOptionType
+  { potId :: Column f Id,
+    potProductId :: Column f Products.Id,
+    potName :: Column f Text,
+    potSortOrder :: Column f Int64
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (ProductOptionType f)
+
+deriving stock instance (f ~ Result) => Eq (ProductOptionType f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (ProductOptionType Result)
+
+
+-- | Display instance for ProductOptionType Result.
+instance Display (ProductOptionType Result) where
+  displayBuilder optionType =
+    "ProductOptionType { id = "
+      <> displayBuilder optionType.potId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @ProductOptionType Result@.
+type Model = ProductOptionType Result
+
+-- | Table schema connecting the Haskell type to the database table.
+productOptionTypeSchema :: TableSchema (ProductOptionType Name)
+productOptionTypeSchema =
+  TableSchema
+    { name = "product_option_types",
+      columns =
+        ProductOptionType
+          { potId = "id",
+            potProductId = "product_id",
+            potName = "name",
+            potSortOrder = "sort_order"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Insert Type
+
+-- | Insert type for creating new product option types.
+data Insert = Insert
+  { otiProductId :: Products.Id,
+    otiName :: Text,
+    otiSortOrder :: Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get all option types for a product, ordered by sort_order.
+getByProductId :: Products.Id -> Hasql.Statement () [Model]
+getByProductId productId =
+  run $
+    select $
+      orderBy (potSortOrder >$< asc) do
+        optionType <- each productOptionTypeSchema
+        where_ $ potProductId optionType ==. lit productId
+        pure optionType
+
+-- | Insert a new product option type.
+insertOptionType :: Insert -> Hasql.Statement () Id
+insertOptionType Insert {..} =
+  run1 $
+    insert
+        Rel8.Insert
+          { into = productOptionTypeSchema,
+            rows =
+              values
+                [ ProductOptionType
+                    { potId = nextId "product_option_types_id_seq",
+                      potProductId = lit otiProductId,
+                      potName = lit otiName,
+                      potSortOrder = lit otiSortOrder
+                    }
+                ],
+            onConflict = Abort,
+            returning = Returning potId
+          }
+
+-- | Delete a product option type by ID.
+--
+-- CASCADE deletes associated option values.
+deleteOptionType :: Id -> Hasql.Statement () (Maybe Id)
+deleteOptionType optionTypeId =
+  fmap listToMaybe $
+    run $
+      delete
+        Rel8.Delete
+          { from = productOptionTypeSchema,
+            using = pure (),
+            deleteWhere = \_ optionType -> potId optionType ==. lit optionTypeId,
+            returning = Returning potId
+          }
+
+-- | Delete all option types for a product.
+--
+-- CASCADE deletes associated option values and variant-option join rows.
+deleteByProductId :: Products.Id -> Hasql.Statement () [Id]
+deleteByProductId productId =
+  run $
+    delete
+      Rel8.Delete
+        { from = productOptionTypeSchema,
+          using = pure (),
+          deleteWhere = \_ optionType -> potProductId optionType ==. lit productId,
+          returning = Returning potId
+        }

--- a/lib/kpbj-database/src/Effects/Database/Tables/ProductOptionValues.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ProductOptionValues.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @product_option_values@.
+--
+-- Uses rel8 for simple queries and raw SQL (hasql-interpolate) for cross-table joins.
+module Effects.Database.Tables.ProductOptionValues
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    ProductOptionValue (..),
+    productOptionValueSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Insert Type
+    Insert (..),
+
+    -- * Queries
+    getByOptionTypeId,
+    getByProductId,
+    insertOptionValue,
+    deleteOptionValue,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Util (nextId)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..), interp, sql)
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Insert)
+import Rel8 qualified
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for product option value primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @product_option_values@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data ProductOptionValue f = ProductOptionValue
+  { povId :: Column f Id,
+    povOptionTypeId :: Column f ProductOptionTypes.Id,
+    povValue :: Column f Text,
+    povSortOrder :: Column f Int64
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (ProductOptionValue f)
+
+deriving stock instance (f ~ Result) => Eq (ProductOptionValue f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (ProductOptionValue Result)
+
+
+-- | Display instance for ProductOptionValue Result.
+instance Display (ProductOptionValue Result) where
+  displayBuilder optionValue =
+    "ProductOptionValue { id = "
+      <> displayBuilder optionValue.povId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @ProductOptionValue Result@.
+type Model = ProductOptionValue Result
+
+-- | Table schema connecting the Haskell type to the database table.
+productOptionValueSchema :: TableSchema (ProductOptionValue Name)
+productOptionValueSchema =
+  TableSchema
+    { name = "product_option_values",
+      columns =
+        ProductOptionValue
+          { povId = "id",
+            povOptionTypeId = "option_type_id",
+            povValue = "value",
+            povSortOrder = "sort_order"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Insert Type
+
+-- | Insert type for creating new product option values.
+data Insert = Insert
+  { oviOptionTypeId :: ProductOptionTypes.Id,
+    oviValue :: Text,
+    oviSortOrder :: Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get all option values for a given option type, ordered by sort_order.
+getByOptionTypeId :: ProductOptionTypes.Id -> Hasql.Statement () [Model]
+getByOptionTypeId optionTypeId =
+  run $
+    select $
+      orderBy (povSortOrder >$< asc) do
+        value <- each productOptionValueSchema
+        where_ $ povOptionTypeId value ==. lit optionTypeId
+        pure value
+
+-- | Get all option values for a product, joining through option_types.
+--
+-- Results are ordered by option type sort_order then option value sort_order.
+getByProductId :: Products.Id -> Hasql.Statement () [Model]
+getByProductId productId =
+  interp
+    False
+    [sql|
+      SELECT pov.id, pov.option_type_id, pov.value, pov.sort_order
+      FROM product_option_values pov
+      JOIN product_option_types pot ON pot.id = pov.option_type_id
+      WHERE pot.product_id = #{productId}
+      ORDER BY pot.sort_order, pov.sort_order
+    |]
+
+-- | Insert a new product option value.
+insertOptionValue :: Insert -> Hasql.Statement () Id
+insertOptionValue Insert {..} =
+  run1 $
+    insert
+        Rel8.Insert
+          { into = productOptionValueSchema,
+            rows =
+              values
+                [ ProductOptionValue
+                    { povId = nextId "product_option_values_id_seq",
+                      povOptionTypeId = lit oviOptionTypeId,
+                      povValue = lit oviValue,
+                      povSortOrder = lit oviSortOrder
+                    }
+                ],
+            onConflict = Abort,
+            returning = Returning povId
+          }
+
+-- | Delete a product option value by ID.
+deleteOptionValue :: Id -> Hasql.Statement () (Maybe Id)
+deleteOptionValue optionValueId =
+  fmap listToMaybe $
+    run $
+      delete
+        Rel8.Delete
+          { from = productOptionValueSchema,
+            using = pure (),
+            deleteWhere = \_ value -> povId value ==. lit optionValueId,
+            returning = Returning povId
+          }

--- a/lib/kpbj-database/src/Effects/Database/Tables/ProductVariantOptions.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ProductVariantOptions.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Database queries for @product_variant_options@.
+--
+-- This is a join table with a composite primary key (variant_id, option_value_id).
+-- All queries use hasql-interpolate since Rel8 doesn't handle composite PKs cleanly.
+module Effects.Database.Tables.ProductVariantOptions
+  ( -- * Result Type
+    VariantOption (..),
+
+    -- * Queries
+    insertVariantOption,
+    getByVariantId,
+    getByProductId,
+    deleteByVariantId,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Text.Display (Display (..))
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, interp, sql)
+import Hasql.Statement qualified as Hasql
+
+--------------------------------------------------------------------------------
+-- Result Type
+
+-- | A single row from @product_variant_options@.
+data VariantOption = VariantOption
+  { voVariantId :: ProductVariants.Id,
+    voOptionValueId :: ProductOptionValues.Id
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (DecodeRow)
+
+
+-- | Display instance for logging.
+instance Display VariantOption where
+  displayBuilder vo =
+    "VariantOption { variant_id = "
+      <> displayBuilder vo.voVariantId
+      <> ", option_value_id = "
+      <> displayBuilder vo.voOptionValueId
+      <> " }"
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Insert a new variant-option association.
+insertVariantOption ::
+  ProductVariants.Id ->
+  ProductOptionValues.Id ->
+  Hasql.Statement () ()
+insertVariantOption variantId optionValueId =
+  interp
+    True
+    [sql|
+      INSERT INTO product_variant_options (variant_id, option_value_id)
+      VALUES (#{variantId}, #{optionValueId})
+      ON CONFLICT DO NOTHING
+    |]
+
+-- | Get all option value IDs for a given variant.
+getByVariantId :: ProductVariants.Id -> Hasql.Statement () [ProductOptionValues.Id]
+getByVariantId variantId =
+  interp
+    False
+    [sql|
+      SELECT option_value_id
+      FROM product_variant_options
+      WHERE variant_id = #{variantId}
+    |]
+
+-- | Get all variant-option rows for all active variants of a product.
+--
+-- Joins through @product_variants@ to filter by @product_id@ and exclude
+-- soft-deleted variants.
+getByProductId :: Products.Id -> Hasql.Statement () [VariantOption]
+getByProductId productId =
+  interp
+    False
+    [sql|
+      SELECT pvo.variant_id, pvo.option_value_id
+      FROM product_variant_options pvo
+      JOIN product_variants pv ON pv.id = pvo.variant_id
+      WHERE pv.product_id = #{productId}
+        AND pv.deleted_at IS NULL
+    |]
+
+
+-- | Delete all option associations for a variant.
+deleteByVariantId :: ProductVariants.Id -> Hasql.Statement () ()
+deleteByVariantId variantId =
+  interp
+    True
+    [sql|
+      DELETE FROM product_variant_options
+      WHERE variant_id = #{variantId}
+    |]

--- a/lib/kpbj-database/src/Effects/Database/Tables/ProductVariants.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/ProductVariants.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @product_variants@.
+--
+-- Uses rel8 for simple queries.
+module Effects.Database.Tables.ProductVariants
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    ProductVariant (..),
+    productVariantSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Insert Type
+    Insert (..),
+
+    -- * Queries
+    getByProductId,
+    getById,
+    insertVariant,
+    updateVariant,
+    softDeleteVariant,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import Domain.Types.Cents (Cents)
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Util (nextId)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..))
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Insert)
+import Rel8 qualified
+import Rel8.Expr.Time (now)
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for product variant primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @product_variants@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data ProductVariant f = ProductVariant
+  { pvId :: Column f Id,
+    pvProductId :: Column f Products.Id,
+    pvLabel :: Column f Text,
+    pvPriceCents :: Column f (Maybe Cents),
+    pvInventoryCount :: Column f Int64,
+    pvSku :: Column f (Maybe Text),
+    pvWeightOz :: Column f (Maybe Int64),
+    pvSortOrder :: Column f Int64,
+    pvCreatedAt :: Column f UTCTime,
+    pvDeletedAt :: Column f (Maybe UTCTime)
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (ProductVariant f)
+
+deriving stock instance (f ~ Result) => Eq (ProductVariant f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (ProductVariant Result)
+
+
+-- | Display instance for ProductVariant Result.
+instance Display (ProductVariant Result) where
+  displayBuilder variant =
+    "ProductVariant { id = "
+      <> displayBuilder variant.pvId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @ProductVariant Result@.
+type Model = ProductVariant Result
+
+-- | Table schema connecting the Haskell type to the database table.
+productVariantSchema :: TableSchema (ProductVariant Name)
+productVariantSchema =
+  TableSchema
+    { name = "product_variants",
+      columns =
+        ProductVariant
+          { pvId = "id",
+            pvProductId = "product_id",
+            pvLabel = "label",
+            pvPriceCents = "price_cents",
+            pvInventoryCount = "inventory_count",
+            pvSku = "sku",
+            pvWeightOz = "weight_oz",
+            pvSortOrder = "sort_order",
+            pvCreatedAt = "created_at",
+            pvDeletedAt = "deleted_at"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Insert Type
+
+-- | Insert type for creating or updating product variants.
+data Insert = Insert
+  { viProductId :: Products.Id,
+    viLabel :: Text,
+    viPriceCents :: Maybe Cents,
+    viInventoryCount :: Int64,
+    viSku :: Maybe Text,
+    viWeightOz :: Maybe Int64,
+    viSortOrder :: Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get all variants for a product, ordered by sort_order.
+getByProductId :: Products.Id -> Hasql.Statement () [Model]
+getByProductId productId =
+  run $
+    select $
+      orderBy (pvSortOrder >$< asc) do
+        variant <- each productVariantSchema
+        where_ $ pvProductId variant ==. lit productId
+        where_ $ isNull (pvDeletedAt variant)
+        pure variant
+
+-- | Get a product variant by ID.
+getById :: Id -> Hasql.Statement () (Maybe Model)
+getById variantId = fmap listToMaybe $ run $ select do
+  variant <- each productVariantSchema
+  where_ $ pvId variant ==. lit variantId
+  pure variant
+
+-- | Insert a new product variant.
+insertVariant :: Insert -> Hasql.Statement () (Maybe Id)
+insertVariant Insert {..} =
+  fmap listToMaybe $
+    run $
+      insert
+        Rel8.Insert
+          { into = productVariantSchema,
+            rows =
+              values
+                [ ProductVariant
+                    { pvId = nextId "product_variants_id_seq",
+                      pvProductId = lit viProductId,
+                      pvLabel = lit viLabel,
+                      pvPriceCents = lit viPriceCents,
+                      pvInventoryCount = lit viInventoryCount,
+                      pvSku = lit viSku,
+                      pvWeightOz = lit viWeightOz,
+                      pvSortOrder = lit viSortOrder,
+                      pvCreatedAt = now,
+                      pvDeletedAt = lit Nothing
+                    }
+                ],
+            onConflict = Abort,
+            returning = Returning pvId
+          }
+
+-- | Update an existing product variant.
+updateVariant :: Id -> Insert -> Hasql.Statement () (Maybe Id)
+updateVariant variantId Insert {..} =
+  fmap listToMaybe $
+    run $
+      update
+        Rel8.Update
+          { target = productVariantSchema,
+            from = pure (),
+            set = \_ variant ->
+              variant
+                { pvLabel = lit viLabel,
+                  pvPriceCents = lit viPriceCents,
+                  pvInventoryCount = lit viInventoryCount,
+                  pvSku = lit viSku,
+                  pvWeightOz = lit viWeightOz,
+                  pvSortOrder = lit viSortOrder
+                },
+            updateWhere = \_ variant -> pvId variant ==. lit variantId,
+            returning = Returning pvId
+          }
+
+-- | Soft-delete a variant by setting deleted_at.
+softDeleteVariant :: Id -> Hasql.Statement () (Maybe Id)
+softDeleteVariant variantId =
+  fmap listToMaybe $
+    run $
+      update
+        Rel8.Update
+          { target = productVariantSchema,
+            from = pure (),
+            set = \_ variant ->
+              variant { pvDeletedAt = nullify now },
+            updateWhere = \_ variant -> pvId variant ==. lit variantId,
+            returning = Returning pvId
+          }

--- a/lib/kpbj-database/src/Effects/Database/Tables/Products.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/Products.hs
@@ -1,0 +1,266 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @products@.
+--
+-- Uses rel8 for simple queries and raw SQL (hasql-interpolate) for complex joins.
+module Effects.Database.Tables.Products
+  ( -- * Id Type
+    Id (..),
+
+    -- * Table Definition
+    Product (..),
+    productSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Insert Type
+    Insert (..),
+
+    -- * Queries
+    getAll,
+    getById,
+    getBySlug,
+    insertProduct,
+    updateProduct,
+    deactivateProduct,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import Domain.Types.Cents (Cents)
+import Effects.Database.Tables.Util (nextId)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, DecodeValue (..), EncodeValue (..), interp, sql)
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8 hiding (Insert)
+import Rel8 qualified
+import Rel8.Expr.Time (now)
+import Servant qualified
+
+--------------------------------------------------------------------------------
+-- Id Type
+
+-- | Newtype wrapper for product primary keys.
+--
+-- Provides type safety to prevent mixing up IDs from different tables.
+newtype Id = Id {unId :: Int64}
+  deriving stock (Generic)
+  deriving anyclass (DecodeRow)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+  deriving newtype (ToJSON, FromJSON, Display)
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @products@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+data Product f = Product
+  { pId :: Column f Id,
+    pName :: Column f Text,
+    pSlug :: Column f Text,
+    pDescription :: Column f Text,
+    pBasePriceCents :: Column f Cents,
+    pWeightOz :: Column f Int64,
+    pCategory :: Column f (Maybe Text),
+    pInventoryCount :: Column f Int64,
+    pIsActive :: Column f Bool,
+    pSortOrder :: Column f Int64,
+    pCreatedAt :: Column f UTCTime,
+    pUpdatedAt :: Column f UTCTime
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (Product f)
+
+deriving stock instance (f ~ Result) => Eq (Product f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (Product Result)
+
+
+-- | Display instance for Product Result.
+instance Display (Product Result) where
+  displayBuilder p =
+    "Product { id = "
+      <> displayBuilder p.pId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @Product Result@.
+type Model = Product Result
+
+-- | Table schema connecting the Haskell type to the database table.
+productSchema :: TableSchema (Product Name)
+productSchema =
+  TableSchema
+    { name = "products",
+      columns =
+        Product
+          { pId = "id",
+            pName = "name",
+            pSlug = "slug",
+            pDescription = "description",
+            pBasePriceCents = "base_price_cents",
+            pWeightOz = "weight_oz",
+            pCategory = "category",
+            pInventoryCount = "inventory_count",
+            pIsActive = "is_active",
+            pSortOrder = "sort_order",
+            pCreatedAt = "created_at",
+            pUpdatedAt = "updated_at"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Insert Type
+
+-- | Insert type for creating new products.
+data Insert = Insert
+  { piName :: Text,
+    piSlug :: Text,
+    piDescription :: Text,
+    piBasePriceCents :: Cents,
+    piWeightOz :: Int64,
+    piCategory :: Maybe Text,
+    piInventoryCount :: Int64,
+    piIsActive :: Bool,
+    piSortOrder :: Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get all products ordered by sort_order.
+--
+-- Uses the @products_with_inventory@ view which replaces product-level
+-- inventory with the sum of active variant inventories when variants exist.
+getAll :: Hasql.Statement () [Model]
+getAll = interp False
+  [sql|
+    SELECT id, name, slug, description, base_price_cents,
+           weight_oz, category, inventory_count,
+           is_active, sort_order, created_at, updated_at
+    FROM products_with_inventory
+    ORDER BY sort_order ASC
+  |]
+
+-- | Get product by ID.
+--
+-- Uses the @products_with_inventory@ view for effective inventory.
+getById :: Id -> Hasql.Statement () (Maybe Model)
+getById productId = interp False
+  [sql|
+    SELECT id, name, slug, description, base_price_cents,
+           weight_oz, category, inventory_count,
+           is_active, sort_order, created_at, updated_at
+    FROM products_with_inventory
+    WHERE id = #{productId}
+  |]
+
+-- | Get product by slug.
+--
+-- Uses the @products_with_inventory@ view for effective inventory.
+getBySlug :: Text -> Hasql.Statement () (Maybe Model)
+getBySlug slug = interp False
+  [sql|
+    SELECT id, name, slug, description, base_price_cents,
+           weight_oz, category, inventory_count,
+           is_active, sort_order, created_at, updated_at
+    FROM products_with_inventory
+    WHERE slug = #{slug}
+  |]
+
+-- | Insert a new product.
+insertProduct :: Insert -> Hasql.Statement () (Maybe Id)
+insertProduct Insert {..} =
+  fmap listToMaybe $
+    run $
+      insert
+        Rel8.Insert
+          { into = productSchema,
+            rows =
+              values
+                [ Product
+                    { pId = nextId "products_id_seq",
+                      pName = lit piName,
+                      pSlug = lit piSlug,
+                      pDescription = lit piDescription,
+                      pBasePriceCents = lit piBasePriceCents,
+                      pWeightOz = lit piWeightOz,
+                      pCategory = lit piCategory,
+                      pInventoryCount = lit piInventoryCount,
+                      pIsActive = lit piIsActive,
+                      pSortOrder = lit piSortOrder,
+                      pCreatedAt = now,
+                      pUpdatedAt = now
+                    }
+                ],
+            onConflict = Abort,
+            returning = Returning pId
+          }
+
+-- | Update a product.
+updateProduct :: Id -> Insert -> Hasql.Statement () (Maybe Id)
+updateProduct productId Insert {..} =
+  fmap listToMaybe $
+    run $
+      update
+        Rel8.Update
+          { target = productSchema,
+            from = pure (),
+            set = \_ p ->
+              p
+                { pName = lit piName,
+                  pSlug = lit piSlug,
+                  pDescription = lit piDescription,
+                  pBasePriceCents = lit piBasePriceCents,
+                  pWeightOz = lit piWeightOz,
+                  pCategory = lit piCategory,
+                  pInventoryCount = lit piInventoryCount,
+                  pIsActive = lit piIsActive,
+                  pSortOrder = lit piSortOrder,
+                  pUpdatedAt = now
+                },
+            updateWhere = \_ p -> pId p ==. lit productId,
+            returning = Returning pId
+          }
+
+-- | Deactivate a product by setting is_active to false.
+deactivateProduct :: Id -> Hasql.Statement () (Maybe Id)
+deactivateProduct productId =
+  fmap listToMaybe $
+    run $
+      update
+        Rel8.Update
+          { target = productSchema,
+            from = pure (),
+            set = \_ p ->
+              p
+                { pIsActive = lit False,
+                  pUpdatedAt = now
+                },
+            updateWhere = \_ p -> pId p ==. lit productId,
+            returning = Returning pId
+          }

--- a/lib/kpbj-database/src/Effects/Database/Tables/StoreSettings.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/StoreSettings.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Database table definition and queries for @store_settings@.
+--
+-- This is a single-row table (id = 1). Uses hasql-interpolate for all queries
+-- since Rel8 update/insert patterns don't work cleanly for singleton tables.
+module Effects.Database.Tables.StoreSettings
+  ( -- * Table Definition
+    StoreSetting (..),
+    storeSettingSchema,
+
+    -- * Model (Result alias)
+    Model,
+
+    -- * Update Type
+    UpdateSettings (..),
+
+    -- * Queries
+    getSettings,
+    updateSettings,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Int (Int64)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import Data.Text.Display (Display (..))
+import Data.Time (UTCTime)
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeRow, interp, sql)
+import Hasql.Statement qualified as Hasql
+import OrphanInstances.Rel8 ()
+import Rel8
+
+--------------------------------------------------------------------------------
+-- Table Definition
+
+-- | The @store_settings@ table definition using rel8's higher-kinded data pattern.
+--
+-- The type parameter @f@ determines the context:
+--
+-- - @Expr@: SQL expressions for building queries
+-- - @Result@: Decoded Haskell values from query results
+-- - @Name@: Column names for schema definition
+--
+-- Note: @ssId@ is a plain @Int64@ (not a newtype) because this is a single-row
+-- table with a sentinel id = 1.
+data StoreSetting f = StoreSetting
+  { ssId :: Column f Int64,
+    ssTaxRate :: Column f Scientific,
+    ssShipFromName :: Column f Text,
+    ssShipFromAddressLine1 :: Column f Text,
+    ssShipFromCity :: Column f Text,
+    ssShipFromState :: Column f Text,
+    ssShipFromZip :: Column f Text,
+    ssShipFromCountry :: Column f Text,
+    ssOrderNotificationEmail :: Column f Text,
+    ssUpdatedAt :: Column f UTCTime
+  }
+  deriving stock (Generic)
+  deriving anyclass (Rel8able)
+
+deriving stock instance (f ~ Result) => Show (StoreSetting f)
+
+deriving stock instance (f ~ Result) => Eq (StoreSetting f)
+
+-- | DecodeRow instance for hasql-interpolate raw SQL compatibility.
+instance DecodeRow (StoreSetting Result)
+
+
+-- | Display instance for StoreSetting Result.
+instance Display (StoreSetting Result) where
+  displayBuilder settings =
+    "StoreSetting { id = "
+      <> displayBuilder settings.ssId
+      <> " }"
+
+-- | Type alias for backwards compatibility.
+--
+-- @Model@ is the same as @StoreSetting Result@.
+type Model = StoreSetting Result
+
+-- | Table schema connecting the Haskell type to the database table.
+storeSettingSchema :: TableSchema (StoreSetting Name)
+storeSettingSchema =
+  TableSchema
+    { name = "store_settings",
+      columns =
+        StoreSetting
+          { ssId = "id",
+            ssTaxRate = "tax_rate",
+            ssShipFromName = "ship_from_name",
+            ssShipFromAddressLine1 = "ship_from_address_line1",
+            ssShipFromCity = "ship_from_city",
+            ssShipFromState = "ship_from_state",
+            ssShipFromZip = "ship_from_zip",
+            ssShipFromCountry = "ship_from_country",
+            ssOrderNotificationEmail = "order_notification_email",
+            ssUpdatedAt = "updated_at"
+          }
+    }
+
+--------------------------------------------------------------------------------
+-- Update Type
+
+-- | Parameters for updating store settings.
+data UpdateSettings = UpdateSettings
+  { usTaxRate :: Scientific,
+    usShipFromName :: Text,
+    usShipFromAddressLine1 :: Text,
+    usShipFromCity :: Text,
+    usShipFromState :: Text,
+    usShipFromZip :: Text,
+    usShipFromCountry :: Text,
+    usOrderNotificationEmail :: Text
+  }
+  deriving stock (Generic, Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Get the single settings row.
+getSettings :: Hasql.Statement () (Maybe Model)
+getSettings =
+  interp
+    False
+    [sql|
+      SELECT
+        id,
+        tax_rate,
+        ship_from_name,
+        ship_from_address_line1,
+        ship_from_city,
+        ship_from_state,
+        ship_from_zip,
+        ship_from_country,
+        order_notification_email,
+        updated_at
+      FROM store_settings
+      WHERE id = 1
+    |]
+
+-- | Update all mutable settings fields.
+--
+-- Always operates on the single row (id = 1). The @updated_at@ timestamp is
+-- set to @now()@ automatically.
+updateSettings :: UpdateSettings -> Hasql.Statement () ()
+updateSettings UpdateSettings {..} =
+  interp
+    True
+    [sql|
+      UPDATE store_settings SET
+        tax_rate = #{usTaxRate},
+        ship_from_name = #{usShipFromName},
+        ship_from_address_line1 = #{usShipFromAddressLine1},
+        ship_from_city = #{usShipFromCity},
+        ship_from_state = #{usShipFromState},
+        ship_from_zip = #{usShipFromZip},
+        ship_from_country = #{usShipFromCountry},
+        order_notification_email = #{usOrderNotificationEmail},
+        updated_at = now()
+      WHERE id = 1
+    |]

--- a/lib/kpbj-database/test/Domain/Types/CentsSpec.hs
+++ b/lib/kpbj-database/test/Domain/Types/CentsSpec.hs
@@ -1,0 +1,114 @@
+module Domain.Types.CentsSpec (spec) where
+
+--------------------------------------------------------------------------------
+
+import Data.Scientific (Scientific)
+import Domain.Types.Cents (Cents (..), centsToDollars, dollarsToCents, formatDisplay)
+import Hedgehog (assert, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Hspec
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "Domain.Types.Cents" $ do
+  describe "dollarsToCents" $ do
+    it "converts whole dollars" $ do
+      dollarsToCents (10 :: Scientific) `shouldBe` Cents 1000
+      dollarsToCents (0 :: Scientific) `shouldBe` Cents 0
+      dollarsToCents (1 :: Scientific) `shouldBe` Cents 100
+
+    it "converts dollars and cents" $ do
+      dollarsToCents (24.99 :: Scientific) `shouldBe` Cents 2499
+      dollarsToCents (0.01 :: Scientific) `shouldBe` Cents 1
+      dollarsToCents (0.50 :: Scientific) `shouldBe` Cents 50
+      dollarsToCents (99.99 :: Scientific) `shouldBe` Cents 9999
+
+    it "rounds half-cents to nearest" $ do
+      dollarsToCents (10.075 :: Scientific) `shouldBe` Cents 1008
+      dollarsToCents (10.005 :: Scientific) `shouldBe` Cents 1000
+      dollarsToCents (10.995 :: Scientific) `shouldBe` Cents 1100
+
+    it "handles exact decimal values that are tricky for Double" $ do
+      -- Scientific represents these exactly, unlike IEEE 754
+      dollarsToCents (0.10 :: Scientific) `shouldBe` Cents 10
+      dollarsToCents (0.20 :: Scientific) `shouldBe` Cents 20
+      dollarsToCents (0.30 :: Scientific) `shouldBe` Cents 30
+
+  describe "centsToDollars" $ do
+    it "converts to exact Scientific values" $ do
+      (centsToDollars (Cents 2499) :: Scientific) `shouldBe` 24.99
+      (centsToDollars (Cents 0) :: Scientific) `shouldBe` 0
+      (centsToDollars (Cents 1) :: Scientific) `shouldBe` 0.01
+      (centsToDollars (Cents 50) :: Scientific) `shouldBe` 0.50
+      (centsToDollars (Cents 100) :: Scientific) `shouldBe` 1.00
+
+  describe "formatDisplay" $ do
+    it "formats with $ prefix and two decimal places" $ do
+      formatDisplay (Cents 2499) `shouldBe` "$24.99"
+      formatDisplay (Cents 0) `shouldBe` "$0.00"
+      formatDisplay (Cents 1) `shouldBe` "$0.01"
+      formatDisplay (Cents 100) `shouldBe` "$1.00"
+      formatDisplay (Cents 50) `shouldBe` "$0.50"
+      formatDisplay (Cents 1000) `shouldBe` "$10.00"
+
+  describe "round-trip: dollarsToCents . centsToDollars" $ do
+    it "is identity for non-negative cents" $ hedgehog $ do
+      cents <- forAll $ Gen.integral (Range.linear 0 10000000)
+      let c = Cents cents
+          roundTripped = dollarsToCents (centsToDollars c :: Scientific)
+      roundTripped === c
+
+  describe "round-trip: centsToDollars . dollarsToCents" $ do
+    it "preserves two-decimal-place Scientific values" $ hedgehog $ do
+      -- Generate cents values and convert to Scientific dollars
+      cents <- forAll $ Gen.integral (Range.linear 0 10000000)
+      let dollars = centsToDollars (Cents cents) :: Scientific
+          roundTripped = centsToDollars (dollarsToCents dollars) :: Scientific
+      roundTripped === dollars
+
+  describe "Num instance" $ do
+    it "supports addition" $ do
+      Cents 100 + Cents 250 `shouldBe` Cents 350
+
+    it "supports multiplication" $ do
+      Cents 500 * 3 `shouldBe` Cents 1500
+
+    it "addition is commutative" $ hedgehog $ do
+      a <- forAll $ Gen.integral (Range.linear 0 10000000)
+      b <- forAll $ Gen.integral (Range.linear 0 10000000)
+      Cents a + Cents b === Cents b + Cents a
+
+    it "addition is associative" $ hedgehog $ do
+      a <- forAll $ Gen.integral (Range.linear 0 1000000)
+      b <- forAll $ Gen.integral (Range.linear 0 1000000)
+      c <- forAll $ Gen.integral (Range.linear 0 1000000)
+      (Cents a + Cents b) + Cents c === Cents a + (Cents b + Cents c)
+
+    it "zero is additive identity" $ hedgehog $ do
+      a <- forAll $ Gen.integral (Range.linear 0 10000000)
+      Cents a + Cents 0 === Cents a
+      Cents 0 + Cents a === Cents a
+
+  describe "dollarsToCents properties" $ do
+    it "result scales linearly with input" $ hedgehog $ do
+      -- dollarsToCents (a + b) == dollarsToCents a + dollarsToCents b
+      -- (for exact Scientific values that are multiples of 0.01)
+      a <- forAll $ Gen.integral (Range.linear 0 1000000)
+      b <- forAll $ Gen.integral (Range.linear 0 1000000)
+      let aDollars = centsToDollars (Cents a) :: Scientific
+          bDollars = centsToDollars (Cents b) :: Scientific
+      dollarsToCents (aDollars + bDollars) === dollarsToCents aDollars + dollarsToCents bDollars
+
+    it "multiplying dollars by 100 gives cents" $ hedgehog $ do
+      cents <- forAll $ Gen.integral (Range.linear 0 10000000)
+      let dollars = centsToDollars (Cents cents) :: Scientific
+      -- dollarsToCents is round . (* 100), so for exact values:
+      dollarsToCents dollars === Cents cents
+
+    it "is non-negative for non-negative input" $ hedgehog $ do
+      dollars <- forAll $ Gen.double (Range.linearFrac 0 100000)
+      let Cents c = dollarsToCents dollars
+      assert (c >= 0)

--- a/lib/kpbj-database/test/Effects/Database/Tables/ProductImagesSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ProductImagesSpec.hs
@@ -1,0 +1,184 @@
+module Effects.Database.Tables.ProductImagesSpec where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.ProductImages qualified as UUT
+import Effects.Database.Tables.Products qualified as Products
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Helpers (insertTestProduct, unwrapInsert)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertJust, assertNothing, assertRight)
+import Test.Gen.Tables.ProductImages (productImageInsertGen)
+import Test.Gen.Tables.Products (productInsertGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+-- | Dummy product ID used during generation; overridden with real ID in the transaction.
+dummyProductId :: Products.Id
+dummyProductId = Products.Id 0
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.ProductImages" $ do
+      describe "Lens Laws" $ do
+        runs 10 . it "insert-select: inserted fields preserved on select" $
+          hedgehog . prop_insertSelect
+
+      describe "Queries" $ do
+        runs 10 . it "getByProductId returns images for correct product" $
+          hedgehog . prop_getByProductId
+        runs 10 . it "getByProductId returns images ordered by sort_order" $
+          hedgehog . prop_getByProductIdOrdered
+
+      describe "Mutations" $ do
+        runs 10 . it "updateImageMeta updates sort_order and alt_text" $
+          hedgehog . prop_updateImageMeta
+        runs 10 . it "deleteImage removes image" $
+          hedgehog . prop_deleteImage
+
+--------------------------------------------------------------------------------
+-- Helpers
+
+assertInsertFieldsMatch :: UUT.Insert -> UUT.Model -> PropertyT IO ()
+assertInsertFieldsMatch insert model = do
+  UUT.iiProductId insert === UUT.piProductId model
+  UUT.iiImagePath insert === UUT.piImagePath model
+  UUT.iiAltText insert === UUT.piAltText model
+  UUT.iiSortOrder insert === UUT.piSortOrder model
+
+--------------------------------------------------------------------------------
+-- Lens Laws
+
+prop_insertSelect :: TestDBConfig -> PropertyT IO ()
+prop_insertSelect cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    imgTemplate <- forAllT (productImageInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let imgInsert = imgTemplate {UUT.iiProductId = productId}
+        imageId <- unwrapInsert (UUT.insertImage imgInsert)
+        selected <- TRX.statement () (UUT.getById imageId)
+        TRX.condemn
+        pure (imageId, imgInsert, selected)
+
+      assert $ do
+        (imageId, imgInsert, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch imgInsert selected
+        UUT.piId selected === imageId
+
+--------------------------------------------------------------------------------
+-- Query tests
+
+prop_getByProductId :: TestDBConfig -> PropertyT IO ()
+prop_getByProductId cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate1 <- forAllT productInsertGen
+    prodTemplate2 <- forAllT productInsertGen
+    imgTemplate1 <- forAllT (productImageInsertGen dummyProductId)
+    imgTemplate2 <- forAllT (productImageInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let p1 = prodTemplate1 {Products.piSlug = Products.piSlug prodTemplate1 <> "1"}
+        let p2 = prodTemplate2 {Products.piSlug = Products.piSlug prodTemplate2 <> "2"}
+        pid1 <- insertTestProduct p1
+        pid2 <- insertTestProduct p2
+
+        _ <- unwrapInsert (UUT.insertImage imgTemplate1 {UUT.iiProductId = pid1})
+        _ <- unwrapInsert (UUT.insertImage imgTemplate2 {UUT.iiProductId = pid2})
+
+        imagesForP1 <- TRX.statement () (UUT.getByProductId pid1)
+        imagesForP2 <- TRX.statement () (UUT.getByProductId pid2)
+        TRX.condemn
+        pure (imagesForP1, imagesForP2)
+
+      assert $ do
+        (imagesForP1, imagesForP2) <- assertRight result
+        length imagesForP1 === 1
+        length imagesForP2 === 1
+
+prop_getByProductIdOrdered :: TestDBConfig -> PropertyT IO ()
+prop_getByProductIdOrdered cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    imgTemplate1 <- forAllT (productImageInsertGen dummyProductId)
+    imgTemplate2 <- forAllT (productImageInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+
+        let imgA = imgTemplate1 {UUT.iiProductId = productId, UUT.iiSortOrder = 2}
+        let imgB = imgTemplate2 {UUT.iiProductId = productId, UUT.iiSortOrder = 1}
+        idA <- unwrapInsert (UUT.insertImage imgA)
+        idB <- unwrapInsert (UUT.insertImage imgB)
+
+        images <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure (idA, idB, images)
+
+      assert $ do
+        (idA, idB, images) <- assertRight result
+        length images === 2
+        -- B (sort_order=1) should come before A (sort_order=2)
+        map UUT.piId images === [idB, idA]
+
+--------------------------------------------------------------------------------
+-- Mutation tests
+
+prop_updateImageMeta :: TestDBConfig -> PropertyT IO ()
+prop_updateImageMeta cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    imgTemplate <- forAllT (productImageInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        imageId <- unwrapInsert (UUT.insertImage imgTemplate {UUT.iiProductId = productId})
+
+        TRX.statement () (UUT.updateImageMeta imageId 42 "new alt text")
+        selected <- TRX.statement () (UUT.getById imageId)
+        TRX.condemn
+        pure selected
+
+      assert $ do
+        mSelected <- assertRight result
+        selected <- assertJust mSelected
+        UUT.piSortOrder selected === 42
+        UUT.piAltText selected === "new alt text"
+
+prop_deleteImage :: TestDBConfig -> PropertyT IO ()
+prop_deleteImage cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    imgTemplate <- forAllT (productImageInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        imageId <- unwrapInsert (UUT.insertImage imgTemplate {UUT.iiProductId = productId})
+
+        deleteResult <- TRX.statement () (UUT.deleteImage imageId)
+        afterDelete <- TRX.statement () (UUT.getById imageId)
+        TRX.condemn
+        pure (imageId, deleteResult, afterDelete)
+
+      assert $ do
+        (imageId, deleteResult, afterDelete) <- assertRight result
+        deletedId <- assertJust deleteResult
+        deletedId === imageId
+        assertNothing afterDelete
+        pure ()

--- a/lib/kpbj-database/test/Effects/Database/Tables/ProductOptionTypesSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ProductOptionTypesSpec.hs
@@ -1,0 +1,142 @@
+module Effects.Database.Tables.ProductOptionTypesSpec where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.ProductOptionTypes qualified as UUT
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Effects.Database.Tables.Products qualified as Products
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Helpers (insertTestProduct)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertRight, assertSingleton)
+import Test.Gen.Tables.ProductOptionTypes (productOptionTypeInsertGen)
+import Test.Gen.Tables.ProductOptionValues (productOptionValueInsertGen)
+import Test.Gen.Tables.Products (productInsertGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+dummyProductId :: Products.Id
+dummyProductId = Products.Id 0
+
+dummyOptionTypeId :: UUT.Id
+dummyOptionTypeId = UUT.Id 0
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.ProductOptionTypes" $ do
+      describe "Queries" $ do
+        runs 10 . it "insert and getByProductId round-trip" $
+          hedgehog . prop_insertAndGet
+        runs 10 . it "getByProductId returns options ordered by sort_order" $
+          hedgehog . prop_getByProductIdOrdered
+
+      describe "Cascade Delete" $ do
+        runs 10 . it "deleteByProductId cascades to option values" $
+          hedgehog . prop_deleteByProductIdCascades
+        runs 10 . it "deleteOptionType cascades to option values" $
+          hedgehog . prop_deleteOptionTypeCascades
+
+--------------------------------------------------------------------------------
+
+prop_insertAndGet :: TestDBConfig -> PropertyT IO ()
+prop_insertAndGet cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let optInsert = optTemplate {UUT.otiProductId = productId}
+        optId <- TRX.statement () (UUT.insertOptionType optInsert)
+        options <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure (optId, optInsert, options)
+
+      assert $ do
+        (optId, optInsert, options) <- assertRight result
+        opt <- assertSingleton options
+        UUT.potId opt === optId
+        UUT.potName opt === UUT.otiName optInsert
+        UUT.potSortOrder opt === UUT.otiSortOrder optInsert
+
+prop_getByProductIdOrdered :: TestDBConfig -> PropertyT IO ()
+prop_getByProductIdOrdered cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    opt1 <- forAllT (productOptionTypeInsertGen dummyProductId)
+    opt2 <- forAllT (productOptionTypeInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let o1 = opt1 {UUT.otiProductId = productId, UUT.otiSortOrder = 2}
+        let o2 = opt2 {UUT.otiProductId = productId, UUT.otiSortOrder = 1}
+        idA <- TRX.statement () (UUT.insertOptionType o1)
+        idB <- TRX.statement () (UUT.insertOptionType o2)
+        options <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure (idA, idB, options)
+
+      assert $ do
+        (idA, idB, options) <- assertRight result
+        length options === 2
+        map UUT.potId options === [idB, idA]
+
+prop_deleteByProductIdCascades :: TestDBConfig -> PropertyT IO ()
+prop_deleteByProductIdCascades cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    valTemplate <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        optId <- TRX.statement () (UUT.insertOptionType optTemplate {UUT.otiProductId = productId})
+
+        _ <- TRX.statement () (ProductOptionValues.insertOptionValue valTemplate {ProductOptionValues.oviOptionTypeId = optId})
+
+        _ <- TRX.statement () (UUT.deleteByProductId productId)
+
+        optionsAfter <- TRX.statement () (UUT.getByProductId productId)
+        valuesAfter <- TRX.statement () (ProductOptionValues.getByOptionTypeId optId)
+        TRX.condemn
+        pure (optionsAfter, valuesAfter)
+
+      assert $ do
+        (optionsAfter, valuesAfter) <- assertRight result
+        length optionsAfter === 0
+        length valuesAfter === 0
+
+prop_deleteOptionTypeCascades :: TestDBConfig -> PropertyT IO ()
+prop_deleteOptionTypeCascades cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    valTemplate <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        optId <- TRX.statement () (UUT.insertOptionType optTemplate {UUT.otiProductId = productId})
+
+        _ <- TRX.statement () (ProductOptionValues.insertOptionValue valTemplate {ProductOptionValues.oviOptionTypeId = optId})
+
+        _ <- TRX.statement () (UUT.deleteOptionType optId)
+
+        valuesAfter <- TRX.statement () (ProductOptionValues.getByOptionTypeId optId)
+        TRX.condemn
+        pure valuesAfter
+
+      assert $ do
+        valuesAfter <- assertRight result
+        length valuesAfter === 0

--- a/lib/kpbj-database/test/Effects/Database/Tables/ProductVariantOptionsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ProductVariantOptionsSpec.hs
@@ -1,0 +1,163 @@
+module Effects.Database.Tables.ProductVariantOptionsSpec where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Effects.Database.Tables.ProductVariantOptions qualified as UUT
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import Effects.Database.Tables.Products qualified as Products
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Helpers (insertTestProduct, unwrapInsert)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertRight)
+import Test.Gen.Tables.ProductOptionTypes (productOptionTypeInsertGen)
+import Test.Gen.Tables.ProductOptionValues (productOptionValueInsertGen)
+import Test.Gen.Tables.ProductVariants (productVariantInsertGen)
+import Test.Gen.Tables.Products (productInsertGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+dummyProductId :: Products.Id
+dummyProductId = Products.Id 0
+
+dummyOptionTypeId :: ProductOptionTypes.Id
+dummyOptionTypeId = ProductOptionTypes.Id 0
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.ProductVariantOptions" $ do
+      describe "Queries" $ do
+        runs 10 . it "insert and getByVariantId round-trip" $
+          hedgehog . prop_insertAndGetByVariantId
+        runs 10 . it "getByProductId returns rows for active variants only" $
+          hedgehog . prop_getByProductIdFiltersDeleted
+        runs 10 . it "ON CONFLICT DO NOTHING on duplicate insert" $
+          hedgehog . prop_duplicateInsertIsIdempotent
+
+      describe "Mutations" $ do
+        runs 10 . it "deleteByVariantId removes all associations for variant" $
+          hedgehog . prop_deleteByVariantId
+
+--------------------------------------------------------------------------------
+
+prop_insertAndGetByVariantId :: TestDBConfig -> PropertyT IO ()
+prop_insertAndGetByVariantId cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    valTemplate <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (ProductVariants.insertVariant varTemplate {ProductVariants.viProductId = productId})
+        optTypeId <- TRX.statement () (ProductOptionTypes.insertOptionType optTemplate {ProductOptionTypes.otiProductId = productId})
+        optValueId <- TRX.statement () (ProductOptionValues.insertOptionValue valTemplate {ProductOptionValues.oviOptionTypeId = optTypeId})
+
+        TRX.statement () (UUT.insertVariantOption variantId optValueId)
+        rows <- TRX.statement () (UUT.getByVariantId variantId)
+        TRX.condemn
+        pure (optValueId, rows)
+
+      assert $ do
+        (optValueId, rows) <- assertRight result
+        length rows === 1
+        rows === [optValueId]
+
+prop_getByProductIdFiltersDeleted :: TestDBConfig -> PropertyT IO ()
+prop_getByProductIdFiltersDeleted cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    v1Template <- forAllT (productVariantInsertGen dummyProductId)
+    v2Template <- forAllT (productVariantInsertGen dummyProductId)
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    val1Template <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+    val2Template <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        v1Id <- unwrapInsert (ProductVariants.insertVariant v1Template {ProductVariants.viProductId = productId, ProductVariants.viSortOrder = 0})
+        v2Id <- unwrapInsert (ProductVariants.insertVariant v2Template {ProductVariants.viProductId = productId, ProductVariants.viSortOrder = 1})
+        optTypeId <- TRX.statement () (ProductOptionTypes.insertOptionType optTemplate {ProductOptionTypes.otiProductId = productId})
+        val1Id <- TRX.statement () (ProductOptionValues.insertOptionValue val1Template {ProductOptionValues.oviOptionTypeId = optTypeId, ProductOptionValues.oviSortOrder = 0})
+        val2Id <- TRX.statement () (ProductOptionValues.insertOptionValue val2Template {ProductOptionValues.oviOptionTypeId = optTypeId, ProductOptionValues.oviSortOrder = 1})
+
+        TRX.statement () (UUT.insertVariantOption v1Id val1Id)
+        TRX.statement () (UUT.insertVariantOption v2Id val2Id)
+
+        -- Soft-delete v2
+        _ <- TRX.statement () (ProductVariants.softDeleteVariant v2Id)
+
+        rows <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure (v1Id, rows)
+
+      assert $ do
+        (v1Id, rows) <- assertRight result
+        length rows === 1
+        map UUT.voVariantId rows === [v1Id]
+
+prop_duplicateInsertIsIdempotent :: TestDBConfig -> PropertyT IO ()
+prop_duplicateInsertIsIdempotent cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    valTemplate <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (ProductVariants.insertVariant varTemplate {ProductVariants.viProductId = productId})
+        optTypeId <- TRX.statement () (ProductOptionTypes.insertOptionType optTemplate {ProductOptionTypes.otiProductId = productId})
+        optValueId <- TRX.statement () (ProductOptionValues.insertOptionValue valTemplate {ProductOptionValues.oviOptionTypeId = optTypeId})
+
+        TRX.statement () (UUT.insertVariantOption variantId optValueId)
+        TRX.statement () (UUT.insertVariantOption variantId optValueId) -- duplicate
+        rows <- TRX.statement () (UUT.getByVariantId variantId)
+        TRX.condemn
+        pure rows
+
+      assert $ do
+        rows <- assertRight result
+        length rows === 1
+
+prop_deleteByVariantId :: TestDBConfig -> PropertyT IO ()
+prop_deleteByVariantId cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+    optTemplate <- forAllT (productOptionTypeInsertGen dummyProductId)
+    val1Template <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+    val2Template <- forAllT (productOptionValueInsertGen dummyOptionTypeId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (ProductVariants.insertVariant varTemplate {ProductVariants.viProductId = productId})
+        optTypeId <- TRX.statement () (ProductOptionTypes.insertOptionType optTemplate {ProductOptionTypes.otiProductId = productId})
+        val1Id <- TRX.statement () (ProductOptionValues.insertOptionValue val1Template {ProductOptionValues.oviOptionTypeId = optTypeId, ProductOptionValues.oviSortOrder = 0})
+        val2Id <- TRX.statement () (ProductOptionValues.insertOptionValue val2Template {ProductOptionValues.oviOptionTypeId = optTypeId, ProductOptionValues.oviSortOrder = 1})
+
+        TRX.statement () (UUT.insertVariantOption variantId val1Id)
+        TRX.statement () (UUT.insertVariantOption variantId val2Id)
+
+        TRX.statement () (UUT.deleteByVariantId variantId)
+        rows <- TRX.statement () (UUT.getByVariantId variantId)
+        TRX.condemn
+        pure rows
+
+      assert $ do
+        rows <- assertRight result
+        length rows === 0

--- a/lib/kpbj-database/test/Effects/Database/Tables/ProductVariantsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ProductVariantsSpec.hs
@@ -1,0 +1,207 @@
+module Effects.Database.Tables.ProductVariantsSpec where
+
+--------------------------------------------------------------------------------
+
+import Data.Maybe (isJust)
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.ProductVariants qualified as UUT
+import Effects.Database.Tables.Products qualified as Products
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog qualified
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Helpers (insertTestProduct, unwrapInsert)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertJust, assertRight)
+import Test.Gen.Tables.Products (productInsertGen)
+import Test.Gen.Tables.ProductVariants (productVariantInsertGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+dummyProductId :: Products.Id
+dummyProductId = Products.Id 0
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.ProductVariants" $ do
+      describe "Lens Laws" $ do
+        runs 10 . it "insert-select: inserted fields preserved on select" $
+          hedgehog . prop_insertSelect
+        runs 10 . it "update-select: updated fields overwrite original on select" $
+          hedgehog . prop_updateSelect
+
+      describe "Queries" $ do
+        runs 10 . it "getByProductId returns active variants only" $
+          hedgehog . prop_getByProductIdFiltersDeleted
+        runs 10 . it "getByProductId returns variants ordered by sort_order" $
+          hedgehog . prop_getByProductIdOrdered
+
+      describe "Mutations" $ do
+        runs 10 . it "softDeleteVariant hides from getByProductId" $
+          hedgehog . prop_softDeleteVariant
+        runs 10 . it "softDeleteVariant: getById still returns the variant" $
+          hedgehog . prop_softDeleteVariantStillExists
+
+--------------------------------------------------------------------------------
+-- Helpers
+
+assertInsertFieldsMatch :: UUT.Insert -> UUT.Model -> PropertyT IO ()
+assertInsertFieldsMatch insert model = do
+  UUT.viProductId insert === UUT.pvProductId model
+  UUT.viLabel insert === UUT.pvLabel model
+  UUT.viPriceCents insert === UUT.pvPriceCents model
+  UUT.viInventoryCount insert === UUT.pvInventoryCount model
+  UUT.viSku insert === UUT.pvSku model
+  UUT.viWeightOz insert === UUT.pvWeightOz model
+  UUT.viSortOrder insert === UUT.pvSortOrder model
+
+--------------------------------------------------------------------------------
+-- Lens Laws
+
+prop_insertSelect :: TestDBConfig -> PropertyT IO ()
+prop_insertSelect cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let varInsert = varTemplate {UUT.viProductId = productId}
+        variantId <- unwrapInsert (UUT.insertVariant varInsert)
+        selected <- TRX.statement () (UUT.getById variantId)
+        TRX.condemn
+        pure (variantId, varInsert, selected)
+
+      assert $ do
+        (variantId, varInsert, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch varInsert selected
+        UUT.pvId selected === variantId
+        UUT.pvDeletedAt selected === Nothing
+
+prop_updateSelect :: TestDBConfig -> PropertyT IO ()
+prop_updateSelect cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    original <- forAllT (productVariantInsertGen dummyProductId)
+    updated <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (UUT.insertVariant original {UUT.viProductId = productId})
+        _ <- TRX.statement () (UUT.updateVariant variantId updated {UUT.viProductId = productId})
+        selected <- TRX.statement () (UUT.getById variantId)
+        TRX.condemn
+        pure (variantId, updated {UUT.viProductId = productId}, selected)
+
+      assert $ do
+        (variantId, updatedInsert, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch updatedInsert selected
+        UUT.pvId selected === variantId
+
+--------------------------------------------------------------------------------
+-- Query tests
+
+prop_getByProductIdFiltersDeleted :: TestDBConfig -> PropertyT IO ()
+prop_getByProductIdFiltersDeleted cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    v1Template <- forAllT (productVariantInsertGen dummyProductId)
+    v2Template <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let v1 = v1Template {UUT.viProductId = productId, UUT.viSortOrder = 0}
+        let v2 = v2Template {UUT.viProductId = productId, UUT.viSortOrder = 1}
+        _v1Id <- unwrapInsert (UUT.insertVariant v1)
+        v2Id <- unwrapInsert (UUT.insertVariant v2)
+
+        _ <- TRX.statement () (UUT.softDeleteVariant v2Id)
+
+        active <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure active
+
+      assert $ do
+        active <- assertRight result
+        length active === 1
+
+prop_getByProductIdOrdered :: TestDBConfig -> PropertyT IO ()
+prop_getByProductIdOrdered cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    v1Template <- forAllT (productVariantInsertGen dummyProductId)
+    v2Template <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        let v1 = v1Template {UUT.viProductId = productId, UUT.viSortOrder = 2}
+        let v2 = v2Template {UUT.viProductId = productId, UUT.viSortOrder = 1}
+        idA <- unwrapInsert (UUT.insertVariant v1)
+        idB <- unwrapInsert (UUT.insertVariant v2)
+
+        variants <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure (idA, idB, variants)
+
+      assert $ do
+        (idA, idB, variants) <- assertRight result
+        length variants === 2
+        map UUT.pvId variants === [idB, idA]
+
+--------------------------------------------------------------------------------
+-- Mutation tests
+
+prop_softDeleteVariant :: TestDBConfig -> PropertyT IO ()
+prop_softDeleteVariant cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (UUT.insertVariant varTemplate {UUT.viProductId = productId})
+
+        _ <- TRX.statement () (UUT.softDeleteVariant variantId)
+
+        active <- TRX.statement () (UUT.getByProductId productId)
+        TRX.condemn
+        pure active
+
+      assert $ do
+        active <- assertRight result
+        length active === 0
+
+prop_softDeleteVariantStillExists :: TestDBConfig -> PropertyT IO ()
+prop_softDeleteVariantStillExists cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate <- forAllT (productVariantInsertGen dummyProductId)
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- insertTestProduct prodTemplate
+        variantId <- unwrapInsert (UUT.insertVariant varTemplate {UUT.viProductId = productId})
+
+        _ <- TRX.statement () (UUT.softDeleteVariant variantId)
+        selected <- TRX.statement () (UUT.getById variantId)
+        TRX.condemn
+        pure (variantId, selected)
+
+      assert $ do
+        (variantId, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        UUT.pvId selected === variantId
+        -- deleted_at should be set
+        Hedgehog.assert (isJust (UUT.pvDeletedAt selected))

--- a/lib/kpbj-database/test/Effects/Database/Tables/ProductsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ProductsSpec.hs
@@ -1,0 +1,306 @@
+module Effects.Database.Tables.ProductsSpec where
+
+--------------------------------------------------------------------------------
+
+import Data.Either (isLeft)
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.Products qualified as UUT
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Helpers (insertTestProduct, unwrapInsert)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertJust, assertNothing, assertRight, (<==))
+import Test.Gen.Tables.Products (productInsertGen)
+import Test.Gen.Tables.ProductVariants (productVariantInsertGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.Products" $ do
+      describe "Lens Laws" $ do
+        runs 10 . it "insert-select: inserted fields preserved on select" $
+          hedgehog . prop_insertSelect
+        runs 10 . it "update-select: updated fields overwrite original on select" $
+          hedgehog . prop_updateSelect
+        runs 10 . it "update-update: second update fully overwrites first" $
+          hedgehog . prop_updateUpdate
+
+      describe "Queries" $ do
+        runs 10 . it "getBySlug returns product by slug" $
+          hedgehog . prop_getBySlug
+        runs 10 . it "getAll returns all products" $
+          hedgehog . prop_getAll
+
+      describe "Mutations" $ do
+        runs 10 . it "deactivateProduct sets is_active to false" $
+          hedgehog . prop_deactivateProduct
+
+      describe "Constraints" $ do
+        runs 10 . it "rejects duplicate slug on insert" $
+          hedgehog . prop_insertDuplicateSlug
+
+      describe "Effective Inventory" $ do
+        runs 10 . it "uses variant inventory sum when variants exist" $
+          hedgehog . prop_effectiveInventoryWithVariants
+        runs 10 . it "uses product inventory when no variants exist" $
+          hedgehog . prop_effectiveInventoryWithoutVariants
+        runs 10 . it "ignores soft-deleted variants in inventory sum" $
+          hedgehog . prop_effectiveInventoryIgnoresDeleted
+
+--------------------------------------------------------------------------------
+-- Helpers
+
+assertInsertFieldsMatch :: UUT.Insert -> UUT.Model -> PropertyT IO ()
+assertInsertFieldsMatch insert model = do
+  UUT.piName insert === UUT.pName model
+  UUT.piSlug insert === UUT.pSlug model
+  UUT.piDescription insert === UUT.pDescription model
+  UUT.piBasePriceCents insert === UUT.pBasePriceCents model
+  UUT.piWeightOz insert === UUT.pWeightOz model
+  UUT.piCategory insert === UUT.pCategory model
+  UUT.piIsActive insert === UUT.pIsActive model
+  UUT.piSortOrder insert === UUT.pSortOrder model
+
+--------------------------------------------------------------------------------
+-- Lens Laws
+
+prop_insertSelect :: TestDBConfig -> PropertyT IO ()
+prop_insertSelect cfg = do
+  arrange (bracketConn cfg) $ do
+    template <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- unwrapInsert (UUT.insertProduct template)
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure (productId, selected)
+
+      assert $ do
+        (productId, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch template selected
+        UUT.pId selected === productId
+        -- No variants, so inventory should match product-level
+        UUT.pInventoryCount selected === UUT.piInventoryCount template
+
+prop_updateSelect :: TestDBConfig -> PropertyT IO ()
+prop_updateSelect cfg = do
+  arrange (bracketConn cfg) $ do
+    original <- forAllT productInsertGen
+    updated <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- unwrapInsert (UUT.insertProduct original)
+        _ <- TRX.statement () (UUT.updateProduct productId updated)
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure (productId, selected)
+
+      assert $ do
+        (productId, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch updated selected
+        UUT.pId selected === productId
+
+prop_updateUpdate :: TestDBConfig -> PropertyT IO ()
+prop_updateUpdate cfg = do
+  arrange (bracketConn cfg) $ do
+    original <- forAllT productInsertGen
+    updateA <- forAllT productInsertGen
+    updateB <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- unwrapInsert (UUT.insertProduct original)
+        _ <- TRX.statement () (UUT.updateProduct productId updateA)
+        _ <- TRX.statement () (UUT.updateProduct productId updateB)
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure (productId, selected)
+
+      assert $ do
+        (productId, mSelected) <- assertRight result
+        selected <- assertJust mSelected
+        assertInsertFieldsMatch updateB selected
+        UUT.pId selected === productId
+
+--------------------------------------------------------------------------------
+-- Query tests
+
+prop_getBySlug :: TestDBConfig -> PropertyT IO ()
+prop_getBySlug cfg = do
+  arrange (bracketConn cfg) $ do
+    template <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        productId <- unwrapInsert (UUT.insertProduct template)
+        bySlug <- TRX.statement () (UUT.getBySlug $ UUT.piSlug template)
+        TRX.condemn
+        pure (productId, bySlug)
+
+      assert $ do
+        (productId, mBySlug) <- assertRight result
+        bySlug <- assertJust mBySlug
+        UUT.pId bySlug === productId
+        UUT.pSlug bySlug === UUT.piSlug template
+
+prop_getAll :: TestDBConfig -> PropertyT IO ()
+prop_getAll cfg = do
+  arrange (bracketConn cfg) $ do
+    template1 <- forAllT productInsertGen
+    template2 <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let p1 = template1 {UUT.piSlug = UUT.piSlug template1 <> "1", UUT.piSortOrder = 0}
+        let p2 = template2 {UUT.piSlug = UUT.piSlug template2 <> "2", UUT.piSortOrder = 1}
+        id1 <- unwrapInsert (UUT.insertProduct p1)
+        id2 <- unwrapInsert (UUT.insertProduct p2)
+        all' <- TRX.statement () UUT.getAll
+        TRX.condemn
+        pure (id1, id2, all')
+
+      assert $ do
+        (id1, id2, all') <- assertRight result
+        length all' === 2
+        let returnedIds = map UUT.pId all'
+        elem id1 returnedIds === True
+        elem id2 returnedIds === True
+
+--------------------------------------------------------------------------------
+-- Mutation tests
+
+prop_deactivateProduct :: TestDBConfig -> PropertyT IO ()
+prop_deactivateProduct cfg = do
+  arrange (bracketConn cfg) $ do
+    template <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let active = template {UUT.piIsActive = True}
+        productId <- unwrapInsert (UUT.insertProduct active)
+        _ <- TRX.statement () (UUT.deactivateProduct productId)
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure selected
+
+      assert $ do
+        mSelected <- assertRight result
+        selected <- assertJust mSelected
+        UUT.pIsActive selected === False
+
+--------------------------------------------------------------------------------
+-- Constraint tests
+
+prop_insertDuplicateSlug :: TestDBConfig -> PropertyT IO ()
+prop_insertDuplicateSlug cfg = do
+  arrange (bracketConn cfg) $ do
+    template1 <- forAllT productInsertGen
+    template2 <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        _ <- unwrapInsert (UUT.insertProduct template1)
+        _ <- unwrapInsert (UUT.insertProduct template2 {UUT.piSlug = UUT.piSlug template1})
+        TRX.condemn
+        pure ()
+
+      assert $ do
+        result <== isLeft
+        pure ()
+
+--------------------------------------------------------------------------------
+-- Effective inventory tests
+
+prop_effectiveInventoryWithVariants :: TestDBConfig -> PropertyT IO ()
+prop_effectiveInventoryWithVariants cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate1 <- forAllT (productVariantInsertGen (UUT.Id 0))
+    varTemplate2 <- forAllT (productVariantInsertGen (UUT.Id 0))
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let prod = prodTemplate {UUT.piInventoryCount = 999}
+        productId <- unwrapInsert (UUT.insertProduct prod)
+
+        let v1 = varTemplate1 {ProductVariants.viProductId = productId, ProductVariants.viInventoryCount = 10, ProductVariants.viSortOrder = 0}
+        let v2 = varTemplate2 {ProductVariants.viProductId = productId, ProductVariants.viInventoryCount = 20, ProductVariants.viSortOrder = 1}
+        _ <- unwrapInsert (ProductVariants.insertVariant v1)
+        _ <- unwrapInsert (ProductVariants.insertVariant v2)
+
+        selected <- TRX.statement () (UUT.getById productId)
+        allProducts <- TRX.statement () UUT.getAll
+        TRX.condemn
+        pure (productId, selected, allProducts)
+
+      assert $ do
+        (productId, mSelected, allProducts) <- assertRight result
+        selected <- assertJust mSelected
+        -- Effective inventory should be sum of variant inventories (10 + 20 = 30), not product-level 999
+        UUT.pInventoryCount selected === 30
+
+        -- Same for getAll
+        let fromAll = filter (\p -> UUT.pId p == productId) allProducts
+        case fromAll of
+          [p] -> UUT.pInventoryCount p === 30
+          _ -> UUT.pInventoryCount selected === 30 -- already checked above
+
+prop_effectiveInventoryWithoutVariants :: TestDBConfig -> PropertyT IO ()
+prop_effectiveInventoryWithoutVariants cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let prod = prodTemplate {UUT.piInventoryCount = 42}
+        productId <- unwrapInsert (UUT.insertProduct prod)
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure selected
+
+      assert $ do
+        mSelected <- assertRight result
+        selected <- assertJust mSelected
+        UUT.pInventoryCount selected === 42
+
+prop_effectiveInventoryIgnoresDeleted :: TestDBConfig -> PropertyT IO ()
+prop_effectiveInventoryIgnoresDeleted cfg = do
+  arrange (bracketConn cfg) $ do
+    prodTemplate <- forAllT productInsertGen
+    varTemplate1 <- forAllT (productVariantInsertGen (UUT.Id 0))
+    varTemplate2 <- forAllT (productVariantInsertGen (UUT.Id 0))
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        let prod = prodTemplate {UUT.piInventoryCount = 999}
+        productId <- unwrapInsert (UUT.insertProduct prod)
+
+        let v1 = varTemplate1 {ProductVariants.viProductId = productId, ProductVariants.viInventoryCount = 10, ProductVariants.viSortOrder = 0}
+        let v2 = varTemplate2 {ProductVariants.viProductId = productId, ProductVariants.viInventoryCount = 20, ProductVariants.viSortOrder = 1}
+        _ <- unwrapInsert (ProductVariants.insertVariant v1)
+        v2Id <- unwrapInsert (ProductVariants.insertVariant v2)
+
+        -- Soft-delete variant 2
+        _ <- TRX.statement () (ProductVariants.softDeleteVariant v2Id)
+
+        selected <- TRX.statement () (UUT.getById productId)
+        TRX.condemn
+        pure selected
+
+      assert $ do
+        mSelected <- assertRight result
+        selected <- assertJust mSelected
+        -- Only active variant counts: 10 (variant 2 is deleted)
+        UUT.pInventoryCount selected === 10

--- a/lib/kpbj-database/test/Effects/Database/Tables/StoreSettingsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/StoreSettingsSpec.hs
@@ -1,0 +1,69 @@
+module Effects.Database.Tables.StoreSettingsSpec where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Class (MonadDB (..))
+import Effects.Database.Tables.StoreSettings qualified as UUT
+import Hasql.Transaction qualified as TRX
+import Hasql.Transaction.Sessions qualified as TRX
+import Hedgehog (PropertyT, (===))
+import Hedgehog.Internal.Property (forAllT)
+import Test.Database.Monad (TestDBConfig, bracketConn, withTestDB)
+import Test.Database.Property (act, arrange, assert, runs)
+import Test.Database.Property.Assert (assertJust, assertRight)
+import Test.Gen.Tables.StoreSettings (storeSettingsUpdateGen)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec =
+  withTestDB $
+    describe "Effects.Database.Tables.StoreSettings" $ do
+      describe "Queries" $ do
+        runs 5 . it "getSettings returns the pre-seeded settings row" $
+          hedgehog . prop_getSettings
+        runs 10 . it "update-get round-trip: updated fields match" $
+          hedgehog . prop_updateGetRoundTrip
+
+--------------------------------------------------------------------------------
+
+-- | The migration seeds a default row with id=1.
+prop_getSettings :: TestDBConfig -> PropertyT IO ()
+prop_getSettings cfg = do
+  arrange (bracketConn cfg) $ do
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        settings <- TRX.statement () UUT.getSettings
+        TRX.condemn
+        pure settings
+
+      assert $ do
+        mSettings <- assertRight result
+        settings <- assertJust mSettings
+        UUT.ssId settings === 1
+
+prop_updateGetRoundTrip :: TestDBConfig -> PropertyT IO ()
+prop_updateGetRoundTrip cfg = do
+  arrange (bracketConn cfg) $ do
+    updateData <- forAllT storeSettingsUpdateGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        TRX.statement () (UUT.updateSettings updateData)
+        settings <- TRX.statement () UUT.getSettings
+        TRX.condemn
+        pure settings
+
+      assert $ do
+        mSettings <- assertRight result
+        settings <- assertJust mSettings
+        UUT.ssTaxRate settings === UUT.usTaxRate updateData
+        UUT.ssShipFromName settings === UUT.usShipFromName updateData
+        UUT.ssShipFromAddressLine1 settings === UUT.usShipFromAddressLine1 updateData
+        UUT.ssShipFromCity settings === UUT.usShipFromCity updateData
+        UUT.ssShipFromState settings === UUT.usShipFromState updateData
+        UUT.ssShipFromZip settings === UUT.usShipFromZip updateData
+        UUT.ssShipFromCountry settings === UUT.usShipFromCountry updateData
+        UUT.ssOrderNotificationEmail settings === UUT.usOrderNotificationEmail updateData

--- a/lib/kpbj-database/test/Main.hs
+++ b/lib/kpbj-database/test/Main.hs
@@ -3,6 +3,7 @@ module Main where
 --------------------------------------------------------------------------------
 
 import Data.Maybe (fromMaybe)
+import Domain.Types.CentsSpec qualified as Cents
 import Domain.Types.FileUploadSpec qualified as FileUpload
 import Domain.Types.SlugSpec qualified as Slug
 import Domain.Types.StorageBackendSpec qualified as StorageBackend
@@ -15,6 +16,12 @@ import Effects.Database.Tables.EpisodeTrackSpec qualified as EpisodeTrack
 import Effects.Database.Tables.EpisodesSpec qualified as Episodes
 import Effects.Database.Tables.EventsSpec qualified as Events
 import Effects.Database.Tables.PasswordResetTokensSpec qualified as PasswordResetTokens
+import Effects.Database.Tables.ProductImagesSpec qualified as ProductImages
+import Effects.Database.Tables.ProductOptionTypesSpec qualified as ProductOptionTypes
+import Effects.Database.Tables.ProductVariantOptionsSpec qualified as ProductVariantOptions
+import Effects.Database.Tables.ProductVariantsSpec qualified as ProductVariants
+import Effects.Database.Tables.ProductsSpec qualified as Products
+import Effects.Database.Tables.StoreSettingsSpec qualified as StoreSettings
 import Effects.Database.Tables.PlaybackHistorySpec qualified as PlaybackHistory
 import Effects.Database.Tables.ShowBlogPostsSpec qualified as ShowBlogPosts
 import Effects.Database.Tables.ShowBlogTagsSpec qualified as ShowBlogTags
@@ -65,6 +72,7 @@ main = do
 
   -- Pure tests that don't need database
   hspecWith cfg $ parallel $ do
+    Cents.spec
     Slug.spec
     StorageBackend.spec
     FileUpload.spec
@@ -105,3 +113,11 @@ main = do
     -- DB Models - Auth Tokens
     EmailVerificationTokens.spec
     PasswordResetTokens.spec
+
+    -- DB Models - Store Tables
+    Products.spec
+    ProductImages.spec
+    ProductVariants.spec
+    ProductOptionTypes.spec
+    ProductVariantOptions.spec
+    StoreSettings.spec

--- a/lib/kpbj-database/test/Test/Database/Helpers.hs
+++ b/lib/kpbj-database/test/Test/Database/Helpers.hs
@@ -10,6 +10,7 @@ module Test.Database.Helpers
     insertTestEpisode,
     insertTestEphemeralUpload,
     insertTestStationId,
+    insertTestProduct,
     addTestShowHost,
     verifyTestUserEmail,
     unwrapInsert,
@@ -22,6 +23,7 @@ import Effects.Database.Tables.BlogPosts qualified as BlogPosts
 import Effects.Database.Tables.EphemeralUploads qualified as EphemeralUploads
 import Effects.Database.Tables.Episodes qualified as Episodes
 import Effects.Database.Tables.Events qualified as Events
+import Effects.Database.Tables.Products qualified as Products
 import Effects.Database.Tables.ShowBlogPosts qualified as ShowBlogPosts
 import Effects.Database.Tables.ShowHost qualified as ShowHost
 import Effects.Database.Tables.ShowSchedule qualified as ShowSchedule
@@ -99,6 +101,10 @@ insertTestEphemeralUpload = unwrapInsert . EphemeralUploads.insertEphemeralUploa
 -- | Insert a station ID and return the station ID.
 insertTestStationId :: StationIds.Insert -> TRX.Transaction StationIds.Id
 insertTestStationId = unwrapInsert . StationIds.insertStationId
+
+-- | Insert a product and return the product ID.
+insertTestProduct :: Products.Insert -> TRX.Transaction Products.Id
+insertTestProduct = unwrapInsert . Products.insertProduct
 
 -- | Make a user a host of a show.
 addTestShowHost :: Shows.Id -> User.Id -> TRX.Transaction ()

--- a/lib/kpbj-database/test/Test/Gen/Tables/ProductImages.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/ProductImages.hs
@@ -1,0 +1,25 @@
+module Test.Gen.Tables.ProductImages where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Tables.ProductImages qualified as ProductImages
+import Effects.Database.Tables.Products qualified as Products
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genText, genUrl)
+
+--------------------------------------------------------------------------------
+
+productImageInsertGen :: (MonadGen m) => Products.Id -> m ProductImages.Insert
+productImageInsertGen productId = do
+  iiImagePath <- genUrl
+  iiAltText <- genText
+  iiSortOrder <- Gen.int64 (Range.linear 0 100)
+  pure
+    ProductImages.Insert
+      { iiProductId = productId,
+        iiImagePath = iiImagePath,
+        iiAltText = iiAltText,
+        iiSortOrder = iiSortOrder
+      }

--- a/lib/kpbj-database/test/Test/Gen/Tables/ProductOptionTypes.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/ProductOptionTypes.hs
@@ -1,0 +1,23 @@
+module Test.Gen.Tables.ProductOptionTypes where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.Products qualified as Products
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genText)
+
+--------------------------------------------------------------------------------
+
+productOptionTypeInsertGen :: (MonadGen m) => Products.Id -> m ProductOptionTypes.Insert
+productOptionTypeInsertGen productId = do
+  otiName <- genText
+  otiSortOrder <- Gen.int64 (Range.linear 0 100)
+  pure
+    ProductOptionTypes.Insert
+      { otiProductId = productId,
+        otiName = otiName,
+        otiSortOrder = otiSortOrder
+      }

--- a/lib/kpbj-database/test/Test/Gen/Tables/ProductOptionValues.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/ProductOptionValues.hs
@@ -1,0 +1,23 @@
+module Test.Gen.Tables.ProductOptionValues where
+
+--------------------------------------------------------------------------------
+
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genText)
+
+--------------------------------------------------------------------------------
+
+productOptionValueInsertGen :: (MonadGen m) => ProductOptionTypes.Id -> m ProductOptionValues.Insert
+productOptionValueInsertGen optionTypeId = do
+  oviValue <- genText
+  oviSortOrder <- Gen.int64 (Range.linear 0 100)
+  pure
+    ProductOptionValues.Insert
+      { oviOptionTypeId = optionTypeId,
+        oviValue = oviValue,
+        oviSortOrder = oviSortOrder
+      }

--- a/lib/kpbj-database/test/Test/Gen/Tables/ProductVariants.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/ProductVariants.hs
@@ -1,0 +1,32 @@
+module Test.Gen.Tables.ProductVariants where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cents (Cents (..))
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import Effects.Database.Tables.Products qualified as Products
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genText, genShortText)
+
+--------------------------------------------------------------------------------
+
+productVariantInsertGen :: (MonadGen m) => Products.Id -> m ProductVariants.Insert
+productVariantInsertGen productId = do
+  viLabel <- genText
+  viPriceCents <- Gen.maybe (Cents <$> Gen.int64 (Range.linear 0 100000))
+  viInventoryCount <- Gen.int64 (Range.linear 0 10000)
+  viSku <- Gen.maybe genShortText
+  viWeightOz <- Gen.maybe (Gen.int64 (Range.linear 0 1000))
+  viSortOrder <- Gen.int64 (Range.linear 0 100)
+  pure
+    ProductVariants.Insert
+      { viProductId = productId,
+        viLabel = viLabel,
+        viPriceCents = viPriceCents,
+        viInventoryCount = viInventoryCount,
+        viSku = viSku,
+        viWeightOz = viWeightOz,
+        viSortOrder = viSortOrder
+      }

--- a/lib/kpbj-database/test/Test/Gen/Tables/Products.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/Products.hs
@@ -1,0 +1,38 @@
+module Test.Gen.Tables.Products where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cents (Cents (..))
+import Data.Int (Int64)
+import Effects.Database.Tables.Products qualified as Products
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genSlug, genText)
+
+--------------------------------------------------------------------------------
+
+genCents :: (MonadGen m) => m Cents
+genCents = Cents <$> Gen.int64 (Range.linear 0 100000)
+
+genSortOrder :: (MonadGen m) => m Int64
+genSortOrder = Gen.int64 (Range.linear 0 100)
+
+genWeightOz :: (MonadGen m) => m Int64
+genWeightOz = Gen.int64 (Range.linear 0 1000)
+
+genInventoryCount :: (MonadGen m) => m Int64
+genInventoryCount = Gen.int64 (Range.linear 0 10000)
+
+productInsertGen :: (MonadGen m) => m Products.Insert
+productInsertGen = do
+  piName <- genText
+  piSlug <- genSlug
+  piDescription <- genText
+  piBasePriceCents <- genCents
+  piWeightOz <- genWeightOz
+  piCategory <- Gen.maybe genText
+  piInventoryCount <- genInventoryCount
+  piIsActive <- Gen.bool
+  piSortOrder <- genSortOrder
+  pure Products.Insert {..}

--- a/lib/kpbj-database/test/Test/Gen/Tables/StoreSettings.hs
+++ b/lib/kpbj-database/test/Test/Gen/Tables/StoreSettings.hs
@@ -1,0 +1,33 @@
+module Test.Gen.Tables.StoreSettings where
+
+--------------------------------------------------------------------------------
+
+import Data.Scientific (Scientific)
+import Effects.Database.Tables.StoreSettings qualified as StoreSettings
+import Hedgehog (MonadGen (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Gen.Text (genText, genShortText)
+
+--------------------------------------------------------------------------------
+
+-- | Generate a tax rate between 0.00 and 0.20 (0% to 20%).
+genTaxRate :: (MonadGen m) => m Scientific
+genTaxRate = do
+  -- Generate as integer percentage points (0–20), then divide by 100
+  pct <- Gen.integral (Range.linear 0 20) :: (MonadGen m) => m Int
+  pure $ fromIntegral pct / 100
+
+storeSettingsUpdateGen :: (MonadGen m) => m StoreSettings.UpdateSettings
+storeSettingsUpdateGen = do
+  usTaxRate <- genTaxRate
+  usShipFromName <- genText
+  usShipFromAddressLine1 <- genText
+  usShipFromCity <- genShortText
+  usShipFromState <- genShortText
+  usShipFromZip <- Gen.text (Range.singleton 5) Gen.digit
+  usShipFromCountry <- genShortText
+  usOrderNotificationEmail <- do
+    user <- Gen.text (Range.linear 3 10) Gen.alpha
+    pure $ user <> "@example.com"
+  pure StoreSettings.UpdateSettings {..}

--- a/lib/kpbj-types/kpbj-types.cabal
+++ b/lib/kpbj-types/kpbj-types.cabal
@@ -37,6 +37,7 @@ library
     , hasql-interpolate
     , random
     , rel8
+    , scientific
     , servant-server
     , text
     , text-display
@@ -44,6 +45,7 @@ library
     , tz
   exposed-modules:
     Domain.Icecast.Status
+    Domain.Types.Cents
     Domain.Types.Cookie
     Domain.Types.FileStorage
     Domain.Types.FileUpload

--- a/lib/kpbj-types/src/Domain/Types/Cents.hs
+++ b/lib/kpbj-types/src/Domain/Types/Cents.hs
@@ -1,0 +1,47 @@
+module Domain.Types.Cents
+  ( Cents (..),
+    dollarsToCents,
+    centsToDollars,
+    formatDisplay,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int64)
+import Data.Scientific (FPFormat (..), formatScientific)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Display (Display (..))
+import GHC.Generics (Generic)
+import Hasql.Interpolate (DecodeValue (..), EncodeValue (..))
+import Rel8 (DBEq, DBOrd, DBType)
+import Servant qualified
+
+--------------------------------------------------------------------------------
+
+-- | Price in cents. Stored as integer cents to avoid floating-point issues.
+--
+-- Note: The 'Num' instance allows negative values (useful for refunds or
+-- adjustments). Non-negativity for price columns is enforced at the database
+-- level via @CHECK (... >= 0)@ constraints.
+newtype Cents = Cents {unCents :: Int64}
+  deriving stock (Generic)
+  deriving newtype (Show, Eq, Ord, Num, DBType, DBEq, DBOrd)
+  deriving newtype (DecodeValue, EncodeValue)
+  deriving newtype (ToJSON, FromJSON, Display)
+  deriving newtype (Servant.FromHttpApiData, Servant.ToHttpApiData)
+
+-- | Convert a dollar-denominated price to whole cents.
+dollarsToCents :: RealFrac a => a -> Cents
+dollarsToCents = Cents . round . (* 100)
+
+-- | Get a cents price as a fraction of dollars.
+centsToDollars :: Fractional a => Cents -> a
+centsToDollars = (/ 100) . fromIntegral . unCents
+
+-- | Format 'Cents' for display with "$" prefix (e.g. "$24.99").
+formatDisplay :: Cents -> Text
+formatDisplay c =
+  "$" <> Text.pack (formatScientific Fixed (Just 2) (centsToDollars c))

--- a/lib/kpbj-types/src/Domain/Types/FileStorage.hs
+++ b/lib/kpbj-types/src/Domain/Types/FileStorage.hs
@@ -36,6 +36,7 @@ data ResourceType
   | ShowLogo
   | BlogHeroImage
   | EventPosterImage
+  | ProductImage
   | UserAvatar
   | StationIdAudio
   | EphemeralAudio
@@ -66,6 +67,7 @@ resourceTypePath = \case
   ShowLogo -> "logos"
   BlogHeroImage -> "blog-heroes"
   EventPosterImage -> "event-posters"
+  ProductImage -> "store"
   UserAvatar -> "avatars"
   StationIdAudio -> "station-ids"
   EphemeralAudio -> "ephemeral"

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -93,6 +93,7 @@ library
                   , resourcet
                   , servant
                   , servant-multipart
+                  , scientific
                   , servant-server
                   , string-interpolate
                   , tagged
@@ -104,6 +105,7 @@ library
                   , transformers
                   , unliftio
                   , unliftio-core
+                  , unordered-containers
                   , uuid
                   , validation
                   , vector
@@ -208,6 +210,29 @@ library
     API.Dashboard.Events.Slug.Get.Handler
     API.Dashboard.Events.Slug.Get.Route
     API.Dashboard.Events.Slug.Get.Templates.Page
+    API.Dashboard.Store.Orders.Get.Handler
+    API.Dashboard.Store.Orders.Get.Route
+    API.Dashboard.Store.Orders.Get.Templates
+    API.Dashboard.Store.Products.Get.Handler
+    API.Dashboard.Store.Products.Get.Route
+    API.Dashboard.Store.Products.Get.Templates
+    API.Dashboard.Store.Products.Id.Deactivate.Post.Handler
+    API.Dashboard.Store.Products.Id.Deactivate.Post.Route
+    API.Dashboard.Store.Products.Id.Edit.Get.Handler
+    API.Dashboard.Store.Products.Id.Edit.Get.Route
+    API.Dashboard.Store.Products.Id.Edit.Get.Templates.Form
+    API.Dashboard.Store.Products.Id.Edit.Post.Handler
+    API.Dashboard.Store.Products.Id.Edit.Post.Route
+    API.Dashboard.Store.Products.Id.Get.Handler
+    API.Dashboard.Store.Products.Id.Get.Route
+
+    API.Dashboard.Store.Products.Create.Post.Handler
+    API.Dashboard.Store.Products.Create.Post.Route
+    API.Dashboard.Store.Settings.Get.Handler
+    API.Dashboard.Store.Settings.Get.Route
+    API.Dashboard.Store.Settings.Get.Templates
+    API.Dashboard.Store.Settings.Post.Handler
+    API.Dashboard.Store.Settings.Post.Route
     API.Dashboard.StationBlog.Get.Handler
     API.Dashboard.StationBlog.Get.Route
     API.Dashboard.StationBlog.Get.Templates.ItemsFragment
@@ -481,6 +506,7 @@ library
     Design.Theme
     Design.Tokens
     Design.FormStyles
+    Domain.Types.VariantsPayload
     Effects.AWS
     Effects.ContentSanitization
     Effects.Diff

--- a/services/web/lib/lucid-form-builder/lucid-form-builder.cabal
+++ b/services/web/lib/lucid-form-builder/lucid-form-builder.cabal
@@ -15,6 +15,7 @@ library
   default-language: Haskell2010
   default-extensions:
       DataKinds
+      DeriveGeneric
       DerivingStrategies
       FlexibleContexts
       FlexibleInstances
@@ -27,6 +28,8 @@ library
       StrictData
   build-depends:
       base >=4.14 && <5
+    , aeson
+    , bytestring
     , lucid2
     , lucid-htmx-alpine
     , mtl

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder.hs
@@ -67,6 +67,7 @@ module Lucid.Form.Builder
     radioField,
     fileField,
     imageField,
+    imagesField,
     audioField,
     stagedImageField,
     stagedAudioField,
@@ -108,6 +109,8 @@ module Lucid.Form.Builder
     buttonText,
     currentFile,
     aspectRatio,
+    currentImages,
+    previewSize,
 
     -- * Toggle Field Configuration
     onLabel,
@@ -136,6 +139,7 @@ module Lucid.Form.Builder
     -- * Types (re-exports from Types)
     SelectOption (..),
     FormFooterItem (..),
+    ImageData (..),
 
     -- * JS Expressions (for advanced custom validation)
     JSExpr,
@@ -183,6 +187,7 @@ import Lucid.Form.Builder.Core
     formTitle,
     hidden,
     imageField,
+    imagesField,
     numberField,
     passwordField,
     plain,
@@ -207,6 +212,7 @@ import Lucid.Form.Builder.Field
     checked,
     classes,
     currentFile,
+    currentImages,
     customValidation,
     description,
     disabled,
@@ -221,6 +227,7 @@ import Lucid.Form.Builder.Field
     onValue,
     pattern',
     placeholder,
+    previewSize,
     required,
     value,
   )
@@ -231,4 +238,4 @@ import Lucid.Form.Builder.Render
     defaultFormConfig,
     renderForm,
   )
-import Lucid.Form.Builder.Types (FormFooterItem (..), SelectOption (..))
+import Lucid.Form.Builder.Types (FormFooterItem (..), ImageData (..), SelectOption (..))

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Alpine.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Alpine.hs
@@ -61,6 +61,8 @@ needsValidation field = case fType field of
   -- Staged upload fields handle their own validation via inline Alpine.js
   StagedAudioField {} -> False
   StagedImageField {} -> False
+  -- Multi-image field handles its own validation via inline Alpine.js
+  ImagesField {} -> False
   DateTimeField -> hasValidationRules field
   NumberField {} -> hasValidationRules field
   CheckboxField -> hasValidationRules field

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Core.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Core.hs
@@ -226,7 +226,7 @@ imageField name builder =
 -- >   currentImages existingImagesJson
 imagesField :: Text -> FieldBuilder -> FormBuilder
 imagesField name builder =
-  tellField $ buildField name (ImagesField Nothing) builder
+  tellField $ buildField name ImagesField builder
 
 -- | Add an audio upload field with player preview.
 --

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Core.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Core.hs
@@ -43,6 +43,7 @@ module Lucid.Form.Builder.Core
     radioField,
     fileField,
     imageField,
+    imagesField,
     audioField,
     stagedAudioField,
     stagedImageField,
@@ -215,6 +216,17 @@ fileField name accept builder =
 imageField :: Text -> FieldBuilder -> FormBuilder
 imageField name builder =
   tellField $ buildField name (ImageField (Just "image/*")) builder
+
+-- | Add a multi-image upload field with ordering, cropping, and alt text.
+--
+-- > imagesField "product_images" do
+-- >   label "Product Images"
+-- >   maxSize 5
+-- >   previewSize 150
+-- >   currentImages existingImagesJson
+imagesField :: Text -> FieldBuilder -> FormBuilder
+imagesField name builder =
+  tellField $ buildField name (ImagesField Nothing) builder
 
 -- | Add an audio upload field with player preview.
 --

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Field.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Field.hs
@@ -32,6 +32,8 @@ module Lucid.Form.Builder.Field
     buttonText,
     currentFile,
     aspectRatio,
+    currentImages,
+    previewSize,
 
     -- * Toggle Field Configuration
     onLabel,
@@ -116,7 +118,9 @@ mergeConfigs c1 c2 =
       fcOnValue = fcOnValue c2 <|> fcOnValue c1,
       fcOffValue = fcOffValue c2 <|> fcOffValue c1,
       fcChecked = fcChecked c1 || fcChecked c2,
-      fcDescriptionHtml = fcDescriptionHtml c2 <|> fcDescriptionHtml c1
+      fcDescriptionHtml = fcDescriptionHtml c2 <|> fcDescriptionHtml c1,
+      fcPreviewSize = fcPreviewSize c2 <|> fcPreviewSize c1,
+      fcCurrentImages = case fcCurrentImages c2 of [] -> fcCurrentImages c1; imgs -> imgs
     }
 
 -- | Merge two validation configs.
@@ -223,6 +227,18 @@ currentFile url = tellConfig $ \c -> c {fcCurrentValue = Just url}
 -- >   aspectRatio (1, 1)  -- Square
 aspectRatio :: (Int, Int) -> FieldBuilder
 aspectRatio ratio = tellConfig $ \c -> c {fcAspectRatio = Just ratio}
+
+-- | Set the existing images for an imagesField.
+--
+-- The form builder handles JSON serialization internally.
+currentImages :: [ImageData] -> FieldBuilder
+currentImages imgs = tellConfig $ \c -> c {fcCurrentImages = imgs}
+
+-- | Set the preview thumbnail size in pixels for an imagesField.
+--
+-- Controls the width of image thumbnails in the grid. Default is 150.
+previewSize :: Int -> FieldBuilder
+previewSize px = tellConfig $ \c -> c {fcPreviewSize = Just px}
 
 --------------------------------------------------------------------------------
 -- Toggle Field Configuration

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Render.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Render.hs
@@ -29,10 +29,13 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Monad (forM_, unless, when)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BSL
 import Data.Maybe (fromMaybe)
 import Data.String.Interpolate (i)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Lucid qualified
 import Lucid.Alpine
 import Lucid.Base (makeAttributes)
@@ -302,6 +305,7 @@ renderField field = case fType field of
   RadioField -> renderRadioField field
   FileField accept -> renderFileField field accept
   ImageField {} -> renderImageField field
+  ImagesField {} -> renderImagesField field
   AudioField {} -> renderAudioField field
   StagedAudioField url uploadType -> renderStagedAudioField field url uploadType
   StagedImageField url uploadType -> renderStagedImageField field url uploadType
@@ -692,6 +696,21 @@ renderImageField field = do
       (ratioW, ratioH) = fromMaybe (1, 1) (fcAspectRatio cfg)
       aspectRatioStyle :: Text
       aspectRatioStyle = [i|aspect-ratio: #{ratioW} / #{ratioH}|]
+      cropperJs :: Text
+      cropperJs = cropperAlpineJs maxSizeMB ratioDecimal
+        [i|this.isValid = false; this.error = 'File exceeds #{maxSizeMB}MB limit';|]
+        [i|const input = document.getElementById('#{inputIdJs}');
+    const dt = new DataTransfer();
+    dt.items.add(croppedFile);
+    input.files = dt.files;
+    if (this.previewUrl) { URL.revokeObjectURL(this.previewUrl); }
+    this.previewUrl = URL.createObjectURL(croppedFile);
+    this.fileName = croppedFile.name;
+    this.fileSize = croppedFile.size;
+    this.currentCleared = false;
+    this.isValid = true;
+    this.error = '';|]
+        [i|const input = document.getElementById('#{inputIdJs}'); if (input) input.value = '';|]
       ratioText :: Text
       ratioText = [i|#{ratioW}:#{ratioH}|]
       ratioDecimal :: Text
@@ -711,10 +730,6 @@ renderImageField field = do
   isValid: true,
   error: '',
   isDragging: false,
-  showCropper: false,
-  cropper: null,
-  originalFile: null,
-  cropImageUrl: '',
 
   handleFileChange(event) {
     const file = event.target.files?.[0];
@@ -731,84 +746,7 @@ renderImageField field = do
     }
   },
 
-  openCropper(file) {
-    if (file.size > #{maxSizeMB * 1024 * 1024}) {
-      this.isValid = false;
-      this.error = 'File exceeds #{maxSizeMB}MB limit';
-      return;
-    }
-    this.originalFile = file;
-    this.cropImageUrl = URL.createObjectURL(file);
-    this.showCropper = true;
-    this.$nextTick(() => {
-      const img = this.$refs.cropperImage;
-      if (img && typeof Cropper !== 'undefined') {
-        this.cropper = new Cropper(img, {
-          aspectRatio: #{ratioDecimal},
-          viewMode: 1,
-          dragMode: 'move',
-          autoCropArea: 1,
-          restore: false,
-          guides: true,
-          center: true,
-          highlight: false,
-          cropBoxMovable: true,
-          cropBoxResizable: true,
-          toggleDragModeOnDblclick: false,
-        });
-      }
-    });
-  },
-
-  async confirmCrop() {
-    if (!this.cropper) return;
-    const canvas = this.cropper.getCroppedCanvas({
-      maxWidth: 2048,
-      maxHeight: 2048,
-      imageSmoothingEnabled: true,
-      imageSmoothingQuality: 'high',
-    });
-    const blob = await new Promise(resolve => {
-      canvas.toBlob(resolve, 'image/jpeg', 0.92);
-    });
-    const croppedFile = new File([blob], this.originalFile.name, {
-      type: 'image/jpeg',
-      lastModified: Date.now(),
-    });
-    const input = document.getElementById('#{inputIdJs}');
-    const dt = new DataTransfer();
-    dt.items.add(croppedFile);
-    input.files = dt.files;
-    if (this.previewUrl) {
-      URL.revokeObjectURL(this.previewUrl);
-    }
-    this.previewUrl = URL.createObjectURL(croppedFile);
-    this.fileName = croppedFile.name;
-    this.fileSize = croppedFile.size;
-    this.currentCleared = false;
-    this.isValid = true;
-    this.error = '';
-    this.closeCropper();
-  },
-
-  cancelCrop() {
-    const input = document.getElementById('#{inputIdJs}');
-    if (input) input.value = '';
-    this.closeCropper();
-  },
-
-  closeCropper() {
-    if (this.cropper) {
-      this.cropper.destroy();
-      this.cropper = null;
-    }
-    if (this.cropImageUrl) {
-      URL.revokeObjectURL(this.cropImageUrl);
-      this.cropImageUrl = '';
-    }
-    this.showCropper = false;
-    this.originalFile = null;
-  },
+  #{cropperJs}
 
   clearFile() {
     const input = document.getElementById('#{inputIdJs}');
@@ -981,75 +919,230 @@ renderImageField field = do
           "Leave unchanged to keep the current image"
 
       -- Cropper Modal
+      renderCropperModal ratioText
+
+--------------------------------------------------------------------------------
+-- Multi-Image Field
+
+-- | Render a multi-image manager with drag-and-drop reordering, cropping, and alt text.
+renderImagesField :: Field -> Lucid.Html ()
+renderImagesField field = do
+  let name = fName field
+      cfg = fConfig field
+      val = fValidation field
+      isReq = vcRequired val
+      labelText = fromMaybe name (fcLabel cfg) <> if isReq then " *" else ""
+      existingImagesJson = Text.decodeUtf8 $ BSL.toStrict $ Aeson.encode (fcCurrentImages cfg)
+      maxSizeMB = fromMaybe 10 (fcMaxSizeMB cfg)
+      thumbSize = fromMaybe 150 (fcPreviewSize cfg)
+      (ratioW, ratioH) = fromMaybe (1, 1) (fcAspectRatio cfg)
+      ratioDecimal :: Text
+      ratioDecimal = [i|#{(fromIntegral ratioW :: Double) / (fromIntegral ratioH :: Double)}|]
+      ratioText :: Text
+      ratioText = [i|#{ratioW}:#{ratioH}|]
+      hintText = fcHint cfg
+      cropperJs :: Text
+      cropperJs = cropperAlpineJs maxSizeMB ratioDecimal
+        [i|this.error = 'File exceeds #{maxSizeMB}MB limit';|]
+        [i|this.images.push({
+      id: null, url: '', alt_text: '', isNew: true,
+      file: croppedFile, previewUrl: URL.createObjectURL(croppedFile),
+      _key: 'new-' + (this._nextKey++),
+    });
+    this.syncFiles();
+    this.validate();|]
+        ""
+
+  -- Alpine.js state for the multi-image manager
+  Lucid.div_
+    [ xData_
+        [i|{
+  images: #{existingImagesJson}.map(img => ({...img, isNew: false, file: null, previewUrl: img.url, _key: 'existing-' + img.id})),
+  _nextKey: 0,
+  deletedIds: [],
+  error: '',
+  dragIdx: null,
+  dropIdx: null,
+  isDragging: false,
+
+  handleFileChange(event) {
+    const file = event.target.files?.[0];
+    if (file && file.type.startsWith('image/')) {
+      this.openCropper(file);
+    }
+    event.target.value = '';
+  },
+
+  handleFileDrop(event) {
+    this.isDragging = false;
+    const files = event.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+    if (files.length > 1) {
+      this.error = 'Please drop one image at a time';
+      return;
+    }
+    const file = files[0];
+    if (file && file.type.startsWith('image/')) {
+      this.openCropper(file);
+    }
+  },
+
+  #{cropperJs}
+
+  removeImage(idx) {
+    const img = this.images[idx];
+    if (!img.isNew && img.id) { this.deletedIds.push(img.id); }
+    if (img.previewUrl && img.isNew) { URL.revokeObjectURL(img.previewUrl); }
+    this.images.splice(idx, 1);
+    this.syncFiles();
+    this.validate();
+  },
+
+  validate() {
+    if (#{if isReq then "true" else "false" :: Text} && this.images.length === 0) {
+      this.error = 'At least one image is required';
+      return false;
+    }
+    this.error = '';
+    return true;
+  },
+
+  handleDragStart(e, idx) { this.dragIdx = idx; e.dataTransfer.effectAllowed = 'move'; },
+  handleDragOver(e, idx) { e.preventDefault(); this.dropIdx = idx; },
+  handleDragDrop(e, idx) {
+    e.preventDefault();
+    if (this.dragIdx === null || this.dragIdx === idx) return;
+    const item = this.images.splice(this.dragIdx, 1)[0];
+    this.images.splice(idx, 0, item);
+    this.dragIdx = null;
+    this.dropIdx = null;
+    this.syncFiles();
+  },
+  handleDragEnd(e) { this.dragIdx = null; this.dropIdx = null; },
+
+  syncFiles() {
+    const input = this.$refs.filesInput;
+    if (!input) return;
+    const dt = new DataTransfer();
+    this.images.filter(img => img.isNew && img.file).forEach(img => {
+      dt.items.add(img.file);
+    });
+    input.files = dt.files;
+  },
+
+  serializeData() {
+    return JSON.stringify(this.images.map((img, idx) => ({
+      id: img.id, sort_order: idx, alt_text: img.alt_text || '',
+    })));
+  },
+
+  serializeDeleted() {
+    return JSON.stringify(this.deletedIds);
+  },
+}|],
+      Lucid.class_ "fb-field"
+    ]
+    $ do
+      -- Label
+      Lucid.label_ [Lucid.class_ "fb-label"] (Lucid.toHtml labelText)
+
+      -- Error display
       Lucid.div_
-        [ xShow_ "showCropper",
-          Lucid.style_ "display: none;",
-          Lucid.class_ "fb-image-crop-modal"
+        [ xShow_ "error",
+          Lucid.class_ "fb-error",
+          Lucid.style_ "display: none;"
+        ]
+        $ Lucid.span_ [xText_ "error"] ""
+
+      -- Image grid
+      Lucid.div_
+        [ Lucid.class_ "fb-images-grid",
+          Lucid.style_ [i|--fb-images-thumb-size: #{thumbSize}px; --fb-images-aspect-ratio: #{ratioW} / #{ratioH};|]
         ]
         $ do
-          -- Backdrop
-          Lucid.div_
-            [ xOnClick_ "cancelCrop()",
-              Lucid.class_ "fb-image-crop-backdrop"
-            ]
-            mempty
+          -- Existing and new image cards
+          Lucid.template_ [xFor_ "(img, idx) in images", xKey_ "img._key"]
+            $ Lucid.div_
+              [ makeAttributes "draggable" "true",
+                xOn_ "dragstart" "handleDragStart($event, idx)",
+                xOn_ "dragover.prevent" "handleDragOver($event, idx)",
+                xOn_ "drop.prevent" "handleDragDrop($event, idx)",
+                xOn_ "dragend" "handleDragEnd($event)",
+                xBindClass_ "{ 'fb-images-card--drag-over': dropIdx === idx }",
+                Lucid.class_ "fb-images-card"
+              ]
+            $ do
+              -- Image preview
+              Lucid.img_
+                [ xBindSrc_ "img.previewUrl || img.url",
+                  Lucid.class_ "fb-images-card-img",
+                  Lucid.alt_ "Image preview"
+                ]
 
-          -- Modal content
-          Lucid.div_ [Lucid.class_ "fb-image-crop-dialog"] $ do
-            -- Header
-            Lucid.div_ [Lucid.class_ "fb-image-crop-header"] $ do
-              Lucid.h3_ [Lucid.class_ "fb-image-crop-title"] $ do
-                "Crop Image"
-                Lucid.span_ [Lucid.class_ "fb-image-crop-ratio"] $
-                  Lucid.toHtml ([i|(#{ratioText} ratio)|] :: Text)
+              -- Remove button
               Lucid.button_
                 [ Lucid.type_ "button",
-                  xOnClick_ "cancelCrop()",
-                  Lucid.class_ "fb-image-crop-close"
+                  xOnClick_ "removeImage(idx)",
+                  Lucid.class_ "fb-images-remove"
                 ]
-                "×"
+                "\215"
 
-            -- Cropper container
-            Lucid.div_ [Lucid.class_ "fb-image-crop-container"] $
-              Lucid.img_
-                [ xRef_ "cropperImage",
-                  xBindSrc_ "cropImageUrl",
-                  Lucid.class_ "fb-image-crop-img",
-                  Lucid.alt_ "Image to crop"
+              -- Alt text input
+              Lucid.input_
+                [ Lucid.type_ "text",
+                  xModel_ "img.alt_text",
+                  Lucid.placeholder_ "Alt text",
+                  Lucid.class_ "fb-images-alt-input"
                 ]
 
-            -- Footer with actions
-            Lucid.div_ [Lucid.class_ "fb-image-crop-footer"] $ do
-              -- Zoom controls
-              Lucid.div_ [Lucid.class_ "fb-image-crop-zoom"] $ do
-                Lucid.button_
-                  [ Lucid.type_ "button",
-                    xOnClick_ "cropper?.zoom(-0.1)",
-                    Lucid.class_ "fb-image-crop-zoom-btn"
-                  ]
-                  "−"
-                Lucid.span_ [Lucid.class_ "fb-image-crop-zoom-label"] "Zoom"
-                Lucid.button_
-                  [ Lucid.type_ "button",
-                    xOnClick_ "cropper?.zoom(0.1)",
-                    Lucid.class_ "fb-image-crop-zoom-btn"
-                  ]
-                  "+"
+          -- Add zone
+          Lucid.div_
+            [ xOnClick_ "$refs.addInput.click()",
+              xOnDragover_ "isDragging = true",
+              xOnDragleave_ "isDragging = false",
+              xOnDrop_ "handleFileDrop($event)",
+              Lucid.class_ "fb-images-add-zone"
+            ]
+            $ Lucid.span_ [Lucid.class_ "fb-images-add-label"] "+ Add Image"
 
-              -- Action buttons
-              Lucid.div_ [Lucid.class_ "fb-image-crop-actions"] $ do
-                Lucid.button_
-                  [ Lucid.type_ "button",
-                    xOnClick_ "cancelCrop()",
-                    Lucid.class_ "fb-image-crop-cancel"
-                  ]
-                  "Cancel"
-                Lucid.button_
-                  [ Lucid.type_ "button",
-                    xOnClick_ "confirmCrop()",
-                    Lucid.class_ "fb-image-crop-confirm"
-                  ]
-                  "Apply Crop"
+      -- Hidden file input for adding images (triggers cropper)
+      Lucid.input_
+        [ Lucid.type_ "file",
+          Lucid.accept_ "image/jpeg,image/jpg,image/png,image/webp,image/gif",
+          xRef_ "addInput",
+          xOnChange_ "handleFileChange($event)",
+          Lucid.style_ "display: none;"
+        ]
+
+      -- Hidden file input that holds all new image files for form submission
+      Lucid.input_
+        [ Lucid.type_ "file",
+          Lucid.name_ (name <> "_files"),
+          makeAttributes "multiple" "multiple",
+          xRef_ "filesInput",
+          Lucid.style_ "display: none;"
+        ]
+
+      -- Hidden metadata (image data JSON)
+      Lucid.input_
+        [ Lucid.type_ "hidden",
+          Lucid.name_ (name <> "_data"),
+          xBindValue_ "serializeData()"
+        ]
+
+      -- Hidden deleted IDs
+      Lucid.input_
+        [ Lucid.type_ "hidden",
+          Lucid.name_ (name <> "_deleted"),
+          xBindValue_ "serializeDeleted()"
+        ]
+
+      -- Cropper Modal
+      renderCropperModal ratioText
+
+      -- Hint text
+      forM_ hintText $ \h ->
+        Lucid.p_ [Lucid.class_ "fb-hint"] (Lucid.toHtml h)
 
 --------------------------------------------------------------------------------
 -- Audio Field
@@ -2218,3 +2311,156 @@ renderToggleField field = do
     -- Hint
     forM_ (fcHint cfg) $ \h ->
       Lucid.p_ [Lucid.class_ "fb-hint"] (Lucid.toHtml h)
+
+--------------------------------------------------------------------------------
+-- Shared Cropper Helpers
+
+-- | Alpine.js state and methods for Cropper.js integration.
+--
+-- Returns a JS fragment to splice into an @x-data@ object. Includes:
+-- @showCropper@, @cropper@, @pendingFile@, @cropImageUrl@ state, and
+-- @openCropper@, @confirmCrop@, @cancelCrop@, @closeCropper@ methods.
+cropperAlpineJs ::
+  -- | Max file size in MB.
+  Int ->
+  -- | Aspect ratio as a decimal (e.g., "1.333").
+  Text ->
+  -- | JS to run when file exceeds size limit.
+  Text ->
+  -- | JS to run after crop with @croppedFile@ in scope.
+  Text ->
+  -- | JS to run on cancel.
+  Text ->
+  Text
+cropperAlpineJs maxSizeMB ratioDecimal onSizeError onConfirmCrop onCancel =
+  [i|
+  showCropper: false,
+  cropper: null,
+  pendingFile: null,
+  cropImageUrl: '',
+
+  openCropper(file) {
+    if (file.size > #{maxSizeMB * 1024 * 1024}) {
+      #{onSizeError}
+      return;
+    }
+    this.pendingFile = file;
+    this.cropImageUrl = URL.createObjectURL(file);
+    this.showCropper = true;
+    this.$nextTick(() => {
+      const img = this.$refs.cropperImage;
+      if (img && typeof Cropper !== 'undefined') {
+        this.cropper = new Cropper(img, {
+          aspectRatio: #{ratioDecimal},
+          viewMode: 1,
+          dragMode: 'move',
+          autoCropArea: 1,
+          restore: false,
+          guides: true,
+          center: true,
+          highlight: false,
+          cropBoxMovable: true,
+          cropBoxResizable: true,
+          toggleDragModeOnDblclick: false,
+        });
+      }
+    });
+  },
+
+  async confirmCrop() {
+    if (!this.cropper) return;
+    const canvas = this.cropper.getCroppedCanvas({
+      maxWidth: 2048, maxHeight: 2048,
+      imageSmoothingEnabled: true, imageSmoothingQuality: 'high',
+    });
+    const blob = await new Promise(resolve => {
+      canvas.toBlob(resolve, 'image/jpeg', 0.92);
+    });
+    const croppedFile = new File([blob], this.pendingFile.name, {
+      type: 'image/jpeg', lastModified: Date.now(),
+    });
+    #{onConfirmCrop}
+    this.closeCropper();
+  },
+
+  cancelCrop() {
+    #{onCancel}
+    this.closeCropper();
+  },
+
+  closeCropper() {
+    if (this.cropper) { this.cropper.destroy(); this.cropper = null; }
+    if (this.cropImageUrl) { URL.revokeObjectURL(this.cropImageUrl); this.cropImageUrl = ''; }
+    this.showCropper = false;
+    this.pendingFile = null;
+  },
+|]
+
+-- | Render the shared cropper modal HTML.
+renderCropperModal ::
+  -- | Aspect ratio text for display (e.g., "16:9").
+  Text ->
+  Lucid.Html ()
+renderCropperModal ratioText = do
+  Lucid.div_
+    [ xShow_ "showCropper",
+      Lucid.style_ "display: none;",
+      Lucid.class_ "fb-image-crop-modal"
+    ]
+    $ do
+      Lucid.div_
+        [ xOnClick_ "cancelCrop()",
+          Lucid.class_ "fb-image-crop-backdrop"
+        ]
+        mempty
+
+      Lucid.div_ [Lucid.class_ "fb-image-crop-dialog"] $ do
+        Lucid.div_ [Lucid.class_ "fb-image-crop-header"] $ do
+          Lucid.h3_ [Lucid.class_ "fb-image-crop-title"] $ do
+            "Crop Image"
+            Lucid.span_ [Lucid.class_ "fb-image-crop-ratio"] $
+              Lucid.toHtml ([i|(#{ratioText} ratio)|] :: Text)
+          Lucid.button_
+            [ Lucid.type_ "button",
+              xOnClick_ "cancelCrop()",
+              Lucid.class_ "fb-image-crop-close"
+            ]
+            "\215"
+
+        Lucid.div_ [Lucid.class_ "fb-image-crop-container"] $
+          Lucid.img_
+            [ xRef_ "cropperImage",
+              xBindSrc_ "cropImageUrl",
+              Lucid.class_ "fb-image-crop-img",
+              Lucid.alt_ "Image to crop"
+            ]
+
+        Lucid.div_ [Lucid.class_ "fb-image-crop-footer"] $ do
+          Lucid.div_ [Lucid.class_ "fb-image-crop-zoom"] $ do
+            Lucid.button_
+              [ Lucid.type_ "button",
+                xOnClick_ "cropper?.zoom(-0.1)",
+                Lucid.class_ "fb-image-crop-zoom-btn"
+              ]
+              "\8722"
+            Lucid.span_ [Lucid.class_ "fb-image-crop-zoom-label"] "Zoom"
+            Lucid.button_
+              [ Lucid.type_ "button",
+                xOnClick_ "cropper?.zoom(0.1)",
+                Lucid.class_ "fb-image-crop-zoom-btn"
+              ]
+              "+"
+
+          Lucid.div_ [Lucid.class_ "fb-image-crop-actions"] $ do
+            Lucid.button_
+              [ Lucid.type_ "button",
+                xOnClick_ "cancelCrop()",
+                Lucid.class_ "fb-image-crop-cancel"
+              ]
+              "Cancel"
+            Lucid.button_
+              [ Lucid.type_ "button",
+                xOnClick_ "confirmCrop()",
+                Lucid.class_ "fb-image-crop-confirm"
+              ]
+              "Apply Crop"

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Render.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Render.hs
@@ -697,9 +697,12 @@ renderImageField field = do
       aspectRatioStyle :: Text
       aspectRatioStyle = [i|aspect-ratio: #{ratioW} / #{ratioH}|]
       cropperJs :: Text
-      cropperJs = cropperAlpineJs maxSizeMB ratioDecimal
-        [i|this.isValid = false; this.error = 'File exceeds #{maxSizeMB}MB limit';|]
-        [i|const input = document.getElementById('#{inputIdJs}');
+      cropperJs =
+        cropperAlpineJs
+          maxSizeMB
+          ratioDecimal
+          [i|this.isValid = false; this.error = 'File exceeds #{maxSizeMB}MB limit';|]
+          [i|const input = document.getElementById('#{inputIdJs}');
     const dt = new DataTransfer();
     dt.items.add(croppedFile);
     input.files = dt.files;
@@ -710,7 +713,7 @@ renderImageField field = do
     this.currentCleared = false;
     this.isValid = true;
     this.error = '';|]
-        [i|const input = document.getElementById('#{inputIdJs}'); if (input) input.value = '';|]
+          [i|const input = document.getElementById('#{inputIdJs}'); if (input) input.value = '';|]
       ratioText :: Text
       ratioText = [i|#{ratioW}:#{ratioH}|]
       ratioDecimal :: Text
@@ -942,22 +945,25 @@ renderImagesField field = do
       ratioText = [i|#{ratioW}:#{ratioH}|]
       hintText = fcHint cfg
       cropperJs :: Text
-      cropperJs = cropperAlpineJs maxSizeMB ratioDecimal
-        [i|this.error = 'File exceeds #{maxSizeMB}MB limit';|]
-        [i|this.images.push({
+      cropperJs =
+        cropperAlpineJs
+          maxSizeMB
+          ratioDecimal
+          [i|this.error = 'File exceeds #{maxSizeMB}MB limit';|]
+          [i|this.images.push({
       id: null, url: '', alt_text: '', isNew: true,
       file: croppedFile, previewUrl: URL.createObjectURL(croppedFile),
       _key: 'new-' + (this._nextKey++),
     });
     this.syncFiles();
     this.validate();|]
-        ""
+          ""
 
   -- Alpine.js state for the multi-image manager
   Lucid.div_
     [ xData_
         [i|{
-  images: #{existingImagesJson}.map(img => ({...img, isNew: false, file: null, previewUrl: img.url, _key: 'existing-' + img.id})),
+  images: #{existingImagesJson}.map((img, idx) => ({...img, isNew: false, file: null, previewUrl: img.url, _key: 'existing-' + (img.id ?? idx)})),
   _nextKey: 0,
   deletedIds: [],
   error: '',

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Types.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Types.hs
@@ -157,8 +157,6 @@ data FieldType
       }
   | -- | Multi-image upload with ordering, cropping, and alt text
     ImagesField
-      { ifsAccept :: Maybe Text
-      }
   | -- | Date and time picker
     DateTimeField
   | -- | Numeric input

--- a/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Types.hs
+++ b/services/web/lib/lucid-form-builder/src/Lucid/Form/Builder/Types.hs
@@ -19,6 +19,9 @@ module Lucid.Form.Builder.Types
     FieldConfig (..),
     defaultFieldConfig,
 
+    -- * Images Field Data
+    ImageData (..),
+
     -- * Sections
     Section (..),
 
@@ -35,7 +38,11 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Applicative ((<|>))
+import Data.Aeson (FromJSON (..), ToJSON (..), withObject, (.:), (.:?))
+import Data.Aeson qualified as Aeson
+import Data.Int (Int64)
 import Data.Text (Text)
+import GHC.Generics (Generic)
 import Lucid qualified
 
 --------------------------------------------------------------------------------
@@ -148,6 +155,10 @@ data FieldType
       { sifUploadUrl :: Text,
         sifUploadType :: Text
       }
+  | -- | Multi-image upload with ordering, cropping, and alt text
+    ImagesField
+      { ifsAccept :: Maybe Text
+      }
   | -- | Date and time picker
     DateTimeField
   | -- | Numeric input
@@ -203,7 +214,11 @@ data FieldConfig = FieldConfig
     -- | Initial checked/on state for toggles
     fcChecked :: Bool,
     -- | Rich description (HTML) for checkboxes
-    fcDescriptionHtml :: Maybe (Lucid.Html ())
+    fcDescriptionHtml :: Maybe (Lucid.Html ()),
+    -- | Preview thumbnail width in pixels (imagesField only, default 150)
+    fcPreviewSize :: Maybe Int,
+    -- | Existing images for imagesField
+    fcCurrentImages :: [ImageData]
   }
   deriving stock (Show)
 
@@ -227,7 +242,9 @@ defaultFieldConfig =
       fcOnValue = Nothing,
       fcOffValue = Nothing,
       fcChecked = False,
-      fcDescriptionHtml = Nothing
+      fcDescriptionHtml = Nothing,
+      fcPreviewSize = Nothing,
+      fcCurrentImages = []
     }
 
 --------------------------------------------------------------------------------
@@ -259,6 +276,39 @@ data SelectOption = SelectOption
     soDescription :: Maybe Text
   }
   deriving stock (Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Images Field Data
+
+-- | Data for a single image in an 'imagesField'.
+--
+-- This type is owned by the form builder — it defines the contract between
+-- the handler (which constructs values from domain data) and the Alpine.js
+-- component (which consumes the JSON).
+data ImageData = ImageData
+  { -- | Database ID (Nothing for newly uploaded images)
+    imgId :: Maybe Int64,
+    -- | URL path for display (e.g. "/images/store/2026/03/25/product.jpg")
+    imgUrl :: Text,
+    -- | Accessibility text
+    imgAltText :: Text
+  }
+  deriving stock (Generic, Show, Eq)
+
+instance ToJSON ImageData where
+  toJSON img =
+    Aeson.object
+      [ "id" Aeson..= imgId img,
+        "url" Aeson..= imgUrl img,
+        "alt_text" Aeson..= imgAltText img
+      ]
+
+instance FromJSON ImageData where
+  parseJSON = withObject "ImageData" $ \o ->
+    ImageData
+      <$> o .:? "id"
+      <*> o .: "url"
+      <*> o .: "alt_text"
 
 --------------------------------------------------------------------------------
 -- Validation

--- a/services/web/lib/lucid-htmx-alpine/src/Lucid/HTMX.hs
+++ b/services/web/lib/lucid-htmx-alpine/src/Lucid/HTMX.hs
@@ -167,11 +167,15 @@ hxDisabledElt_ = Lucid.makeAttributes "hx-disabled-elt"
 hxOn_ :: Text -> Lucid.Attributes
 hxOn_ = Lucid.makeAttributesRaw "hx-on"
 
--- | HTMX hx-on:afterRequest attribute (raw attribute syntax).
+-- | HTMX hx-on::after-request attribute.
+--
+-- The double-colon prefix is shorthand for the @htmx:@ event namespace,
+-- so @hx-on::after-request@ listens for @htmx:afterRequest@.
+-- Note: @hx-on::@ attributes require kebab-case event names.
 --
 -- > hxOnAfterRequest_ "handleResponse()"
 hxOnAfterRequest_ :: Text -> Lucid.Attributes
-hxOnAfterRequest_ = Lucid.makeAttributesRaw "hx-on:afterRequest"
+hxOnAfterRequest_ = Lucid.makeAttributesRaw "hx-on::after-request"
 
 --------------------------------------------------------------------------------
 -- Indicators

--- a/services/web/migrations/20260324120000_create_store_tables.sql
+++ b/services/web/migrations/20260324120000_create_store_tables.sql
@@ -1,0 +1,201 @@
+-- Webstore Phase 1: All store tables.
+--
+-- Products with variants, option types/values, images, orders, order items,
+-- and a single-row store settings table.
+
+--------------------------------------------------------------------------------
+-- Domains
+
+CREATE DOMAIN percentage AS NUMERIC CHECK (VALUE >= 0 AND VALUE <= 1);
+
+--------------------------------------------------------------------------------
+-- Products
+
+CREATE TABLE products (
+    id SERIAL8 PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    base_price_cents INT8 NOT NULL CHECK (base_price_cents >= 0),
+    weight_oz INT8 NOT NULL CHECK (weight_oz >= 0),
+    category TEXT,
+    inventory_count INT8 NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    sort_order INT8 NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_products_is_active ON products(is_active);
+
+COMMENT ON TABLE products IS 'Store products with base pricing and inventory';
+
+--------------------------------------------------------------------------------
+-- Product Images
+
+CREATE TABLE product_images (
+    id SERIAL8 PRIMARY KEY,
+    product_id INT8 NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    image_path TEXT NOT NULL,
+    alt_text TEXT NOT NULL DEFAULT '',
+    sort_order INT8 NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_product_images_product_id ON product_images(product_id);
+
+COMMENT ON TABLE product_images IS 'Product images ordered by sort_order; first is hero/thumbnail';
+
+--------------------------------------------------------------------------------
+-- Product Option Types (e.g., "Size", "Color")
+
+CREATE TABLE product_option_types (
+    id SERIAL8 PRIMARY KEY,
+    product_id INT8 NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    sort_order INT8 NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_product_option_types_product_id ON product_option_types(product_id);
+
+COMMENT ON TABLE product_option_types IS 'Product option dimensions like Size, Color';
+
+--------------------------------------------------------------------------------
+-- Product Option Values (e.g., "S", "M", "L")
+
+CREATE TABLE product_option_values (
+    id SERIAL8 PRIMARY KEY,
+    option_type_id INT8 NOT NULL REFERENCES product_option_types(id) ON DELETE CASCADE,
+    value TEXT NOT NULL,
+    sort_order INT8 NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_product_option_values_option_type_id ON product_option_values(option_type_id);
+
+COMMENT ON TABLE product_option_values IS 'Individual values for product option types';
+
+--------------------------------------------------------------------------------
+-- Product Variants (e.g., "M / Black")
+
+CREATE TABLE product_variants (
+    id SERIAL8 PRIMARY KEY,
+    product_id INT8 NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    label TEXT NOT NULL,
+    price_cents INT8 CHECK (price_cents >= 0),
+    inventory_count INT8 NOT NULL DEFAULT 0,
+    sku TEXT,
+    weight_oz INT8 CHECK (weight_oz >= 0),
+    sort_order INT8 NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_product_variants_product_id ON product_variants(product_id);
+CREATE INDEX idx_product_variants_deleted_at ON product_variants(deleted_at);
+
+COMMENT ON TABLE product_variants IS 'Product variants with optional price/weight overrides and per-variant inventory. deleted_at enables soft delete for order history FK integrity.';
+
+-- View that replaces product-level inventory with the sum of active variant
+-- inventories when variants exist. Used by all product queries.
+CREATE VIEW products_with_inventory AS
+  SELECT
+    p.id, p.name, p.slug, p.description, p.base_price_cents,
+    p.weight_oz, p.category,
+    COALESCE(v.total_inventory, p.inventory_count)::int8 AS inventory_count,
+    p.is_active, p.sort_order, p.created_at, p.updated_at
+  FROM products p
+  LEFT JOIN (
+    SELECT product_id, SUM(inventory_count)::int8 AS total_inventory
+    FROM product_variants
+    WHERE deleted_at IS NULL
+    GROUP BY product_id
+  ) v ON v.product_id = p.id;
+
+--------------------------------------------------------------------------------
+-- Product Variant Options (join: variant <-> option value)
+
+CREATE TABLE product_variant_options (
+    variant_id INT8 NOT NULL REFERENCES product_variants(id) ON DELETE CASCADE,
+    option_value_id INT8 NOT NULL REFERENCES product_option_values(id) ON DELETE CASCADE,
+    PRIMARY KEY (variant_id, option_value_id)
+);
+
+COMMENT ON TABLE product_variant_options IS 'Maps variants to their selected option values';
+
+--------------------------------------------------------------------------------
+-- Orders
+
+CREATE TABLE orders (
+    id SERIAL8 PRIMARY KEY,
+    order_number TEXT NOT NULL UNIQUE,
+    email TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'paid', 'shipped', 'completed', 'cancelled', 'refunded')),
+    shipping_first_name TEXT NOT NULL,
+    shipping_last_name TEXT NOT NULL,
+    shipping_address_line1 TEXT NOT NULL,
+    shipping_address_line2 TEXT NOT NULL DEFAULT '',
+    shipping_city TEXT NOT NULL,
+    shipping_state TEXT NOT NULL,
+    shipping_zip TEXT NOT NULL,
+    shipping_country TEXT NOT NULL DEFAULT 'US',
+    shipping_method TEXT NOT NULL,
+    subtotal_cents INT8 NOT NULL CHECK (subtotal_cents >= 0),
+    shipping_cents INT8 NOT NULL CHECK (shipping_cents >= 0),
+    tax_cents INT8 NOT NULL CHECK (tax_cents >= 0),
+    total_cents INT8 NOT NULL CHECK (total_cents >= 0),
+    stripe_payment_intent_id TEXT,
+    paypal_order_id TEXT,
+    payment_method TEXT NOT NULL CHECK (payment_method IN ('stripe', 'paypal')),
+    easypost_shipment_id TEXT,
+    tracking_number TEXT,
+    label_url TEXT,
+    notes TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_orders_status ON orders(status);
+CREATE INDEX idx_orders_email ON orders(email);
+
+COMMENT ON TABLE orders IS 'Store orders with shipping and payment info';
+
+--------------------------------------------------------------------------------
+-- Order Items
+
+CREATE TABLE order_items (
+    id SERIAL8 PRIMARY KEY,
+    order_id INT8 NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    -- RESTRICT (default): products and variants referenced by orders cannot be
+    -- hard-deleted. Products are deactivated instead; variants use soft-delete.
+    product_id INT8 NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+    variant_id INT8 REFERENCES product_variants(id) ON DELETE RESTRICT,
+    product_name TEXT NOT NULL,
+    variant_label TEXT NOT NULL DEFAULT '',
+    quantity INT8 NOT NULL CHECK (quantity > 0),
+    unit_price_cents INT8 NOT NULL CHECK (unit_price_cents >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+
+COMMENT ON TABLE order_items IS 'Snapshot of items at time of purchase';
+
+--------------------------------------------------------------------------------
+-- Store Settings (single-row)
+
+CREATE TABLE store_settings (
+    id INT8 NOT NULL DEFAULT 1 CHECK (id = 1) PRIMARY KEY,
+    tax_rate percentage NOT NULL DEFAULT 0.095,
+    ship_from_name TEXT NOT NULL DEFAULT 'KPBJ 95.9FM',
+    ship_from_address_line1 TEXT NOT NULL DEFAULT '',
+    ship_from_city TEXT NOT NULL DEFAULT '',
+    ship_from_state TEXT NOT NULL DEFAULT 'CA',
+    ship_from_zip TEXT NOT NULL DEFAULT '',
+    ship_from_country TEXT NOT NULL DEFAULT 'US',
+    order_notification_email TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO store_settings (id) VALUES (1) ON CONFLICT DO NOTHING;
+
+COMMENT ON TABLE store_settings IS 'Single-row store configuration for tax rate and shipping origin';

--- a/services/web/src/API.hs
+++ b/services/web/src/API.hs
@@ -29,6 +29,10 @@ module API
     DashboardSitePagesRoutes (..),
     DashboardStreamSettingsRoutes (..),
     DashboardAnalyticsRoutes (..),
+    DashboardStoreRoutes (..),
+    DashboardStoreProductsRoutes (..),
+    DashboardStoreSettingsRoutes (..),
+    DashboardStoreOrdersRoutes (..),
     InviteRoutes (..),
     UploadRoutes (..),
     PlayoutRoutes (..),
@@ -111,6 +115,15 @@ import API.Dashboard.StationIds.Get.Handler qualified as Dashboard.StationIds.Ge
 import API.Dashboard.StationIds.Id.Delete.Handler qualified as Dashboard.StationIds.Id.Delete
 import API.Dashboard.StationIds.New.Get.Handler qualified as Dashboard.StationIds.New.Get
 import API.Dashboard.StationIds.New.Post.Handler qualified as Dashboard.StationIds.New.Post
+import API.Dashboard.Store.Orders.Get.Handler qualified as Dashboard.Store.Orders.Get
+import API.Dashboard.Store.Products.Create.Post.Handler qualified as Dashboard.Store.Products.Create.Post
+import API.Dashboard.Store.Products.Get.Handler qualified as Dashboard.Store.Products.Get
+import API.Dashboard.Store.Products.Id.Deactivate.Post.Handler qualified as Dashboard.Store.Products.Id.Deactivate.Post
+import API.Dashboard.Store.Products.Id.Edit.Get.Handler qualified as Dashboard.Store.Products.Id.Edit.Get
+import API.Dashboard.Store.Products.Id.Edit.Post.Handler qualified as Dashboard.Store.Products.Id.Edit.Post
+import API.Dashboard.Store.Products.Id.Get.Handler qualified as Dashboard.Store.Products.Id.Get
+import API.Dashboard.Store.Settings.Get.Handler qualified as Dashboard.Store.Settings.Get
+import API.Dashboard.Store.Settings.Post.Handler qualified as Dashboard.Store.Settings.Post
 import API.Dashboard.StreamSettings.Episodes.Search.Get.Handler qualified as Dashboard.StreamSettings.Episodes.Search.Get
 import API.Dashboard.StreamSettings.ForceEpisode.Post.Handler qualified as Dashboard.StreamSettings.ForceEpisode.Post
 import API.Dashboard.StreamSettings.Get.Handler qualified as Dashboard.StreamSettings.Get
@@ -342,7 +355,36 @@ server =
           sitePages = dashboardSitePagesRoutes,
           streamSettings = dashboardStreamSettingsRoutes,
           missingEpisodes = Dashboard.MissingEpisodes.Get.handler,
-          analytics = dashboardAnalyticsRoutes
+          analytics = dashboardAnalyticsRoutes,
+          store = dashboardStoreRoutes
+        }
+
+    dashboardStoreRoutes =
+      DashboardStoreRoutes
+        { products = dashboardStoreProductsRoutes,
+          orders = dashboardStoreOrdersRoutes,
+          settings = dashboardStoreSettingsRoutes
+        }
+
+    dashboardStoreProductsRoutes =
+      DashboardStoreProductsRoutes
+        { list = Dashboard.Store.Products.Get.handler,
+          inlineCreate = Dashboard.Store.Products.Create.Post.handler,
+          detail = Dashboard.Store.Products.Id.Get.handler,
+          editGet = Dashboard.Store.Products.Id.Edit.Get.handler,
+          editPost = Dashboard.Store.Products.Id.Edit.Post.handler,
+          deactivate = Dashboard.Store.Products.Id.Deactivate.Post.handler
+        }
+
+    dashboardStoreSettingsRoutes =
+      DashboardStoreSettingsRoutes
+        { get = Dashboard.Store.Settings.Get.handler,
+          post = Dashboard.Store.Settings.Post.handler
+        }
+
+    dashboardStoreOrdersRoutes =
+      DashboardStoreOrdersRoutes
+        { list = Dashboard.Store.Orders.Get.handler
         }
 
     dashboardInvitationsRoutes =

--- a/services/web/src/API/Dashboard/Store/Orders/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Get/Handler.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.Store.Orders.Get.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Orders.Get.Templates (template)
+import API.Links (apiLinks)
+import API.Types (Routes (..))
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleHtmlErrors)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Trans (lift)
+import Data.Either (fromRight)
+import Data.Maybe (listToMaybe)
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Shows qualified as Shows
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+-- | Servant handler: render the orders placeholder page with dashboard chrome.
+handler ::
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler cookie (foldHxReq -> hxRequest) =
+  handleHtmlErrors "Store orders" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to access store orders." userMetadata
+
+    -- Fetch shows for sidebar navigation
+    showsResult <-
+      if UserMetadata.isAdmin userMetadata.mUserRole
+        then execQuery Shows.getAllActiveShows
+        else execQuery (Shows.getShowsForUser (User.mId user))
+    let allShows = fromRight [] showsResult
+        selectedShow = listToMaybe allShows
+
+    lift $
+      renderDashboardTemplate
+        hxRequest
+        userMetadata
+        allShows
+        selectedShow
+        NavStoreOrders
+        Nothing
+        Nothing
+        template

--- a/services/web/src/API/Dashboard/Store/Orders/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Get/Route.hs
@@ -1,0 +1,21 @@
+module API.Dashboard.Store.Orders.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/store/orders"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "orders"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Orders/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Get/Templates.hs
@@ -1,0 +1,18 @@
+module API.Dashboard.Store.Orders.Get.Templates (template) where
+
+--------------------------------------------------------------------------------
+
+import Design (base, class_)
+import Design.Tokens qualified as Tokens
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+-- | Orders placeholder template.
+--
+-- Order management is not yet implemented.
+template :: Lucid.Html ()
+template =
+  Lucid.section_ [class_ $ base [Tokens.bgMain, Tokens.p6]] $ do
+    Lucid.h1_ [class_ $ base [Tokens.text2xl, Tokens.fontBold, Tokens.mb4]] "ORDERS"
+    Lucid.p_ [class_ $ base [Tokens.fgMuted]] "Order management coming soon."

--- a/services/web/src/API/Dashboard/Store/Products/Create/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Create/Post/Handler.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module API.Dashboard.Store.Products.Create.Post.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Products.Create.Post.Route (InlineCreateForm (..))
+import API.Dashboard.Store.Products.Get.Templates (renderProductRow)
+import App.Handler.Combinators (requireAuth, requireRight, requireStaffNotSuspended)
+import App.Handler.Error (HandlerError, handleBannerErrors, throwDatabaseError, throwHandlerFailure)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..), renderBanner)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Domain.Types.Cents qualified as Cents
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.Slug qualified as Slug
+import Effects.ContentSanitization qualified as Sanitize
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Log qualified
+import Lucid qualified
+import Text.Read (readMaybe)
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+-- Validation
+
+-- | Validate the inline create form, returning a 'Products.Insert' or an error message.
+validateInlineCreateForm :: InlineCreateForm -> Either Text Products.Insert
+validateInlineCreateForm form = do
+  -- Sanitize and validate name
+  let sanitizedName = Sanitize.sanitizeTitle form.icfName
+  validName <- case Sanitize.validateContentLength 200 sanitizedName of
+    Left err -> Left (Sanitize.displayContentValidationError err)
+    Right n -> Right n
+
+  -- Parse price
+  basePriceCents <- case readMaybe @Scientific (Text.unpack form.icfBasePriceDollars) of
+    Just d | d >= 0 -> Right (Cents.dollarsToCents d)
+    _ -> Left ("Invalid price: \"" <> form.icfBasePriceDollars <> "\" is not a valid amount")
+
+  -- Parse inventory count
+  inventoryCount <- case form.icfInventoryCount of
+    t | Text.null (Text.strip t) -> Right 0
+    t -> Sanitize.parseNonNegativeInt t
+
+  -- Derive slug from name
+  let Slug.Slug slugText = Slug.mkSlug validName
+
+  -- Sanitize optional category
+  let mCategory =
+        case form.icfCategory of
+          Nothing -> Nothing
+          Just cat ->
+            let sanitized = Sanitize.sanitizePlainText cat
+             in if Text.null (Text.strip sanitized) then Nothing else Just sanitized
+
+  Right
+    Products.Insert
+      { Products.piName = validName,
+        Products.piSlug = slugText,
+        Products.piDescription = "",
+        Products.piBasePriceCents = basePriceCents,
+        Products.piWeightOz = 0,
+        Products.piCategory = mCategory,
+        Products.piInventoryCount = inventoryCount,
+        Products.piIsActive = False,
+        Products.piSortOrder = 0
+      }
+
+--------------------------------------------------------------------------------
+
+-- | Business logic: validate form, insert product, query it back, render row.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  InlineCreateForm ->
+  ExceptT HandlerError AppM (Lucid.Html ())
+action _user _userMetadata form = do
+  -- 1. Validate form
+  productInsert <- requireRight id (validateInlineCreateForm form)
+
+  -- 2. Check for slug conflict
+  mExisting <-
+    fromRightM throwDatabaseError $
+      execQuery (Products.getBySlug productInsert.piSlug)
+  case mExisting of
+    Just _ -> throwHandlerFailure "A product with a similar name already exists. Please choose a different name."
+    Nothing -> pure ()
+
+  -- 3. Insert product
+  mProductId <-
+    fromRightM throwDatabaseError $
+      execQuery (Products.insertProduct productInsert)
+
+  productId <- case mProductId of
+    Just pid -> pure pid
+    Nothing -> throwHandlerFailure "Product insert returned Nothing"
+
+  -- 4. Query the inserted product back to render the row
+  mProduct <-
+    fromRightM throwDatabaseError $
+      execQuery (Products.getById productId)
+
+  productModel <- case mProduct of
+    Just p -> pure p
+    Nothing -> throwHandlerFailure "Inserted product not found after insert"
+
+  -- 5. Log and return row HTML + OOB success banner
+  Log.logInfo "Inline product created successfully" productId
+
+  pure $ do
+    renderProductRow productModel
+    renderBanner Success "Product Created" "Product created successfully."
+
+-- | Servant handler: thin glue composing auth + action.
+handler ::
+  Maybe Cookie ->
+  InlineCreateForm ->
+  AppM (Lucid.Html ())
+handler cookie form =
+  handleBannerErrors "Inline product create" $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to create products." userMetadata
+    action user userMetadata form

--- a/services/web/src/API/Dashboard/Store/Products/Create/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Create/Post/Route.hs
@@ -1,0 +1,51 @@
+module API.Dashboard.Store.Products.Create.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+import Web.FormUrlEncoded (FromForm (..), parseMaybe, parseUnique)
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/store/products"
+--
+-- Inline create: accepts minimal product info, returns new table row HTML.
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.ReqBody '[Servant.FormUrlEncoded] InlineCreateForm
+    :> Servant.Post '[HTML] (Lucid.Html ())
+
+--------------------------------------------------------------------------------
+
+-- | Form data for inline product creation.
+data InlineCreateForm = InlineCreateForm
+  { icfName :: Text,
+    icfCategory :: Maybe Text,
+    -- | Price in dollars as text (e.g. "24.99"); converted to cents in handler.
+    icfBasePriceDollars :: Text,
+    -- | Inventory count as text; defaults to 0.
+    icfInventoryCount :: Text
+  }
+  deriving (Show)
+
+instance FromForm InlineCreateForm where
+  fromForm form = do
+    name <- parseUnique "name" form
+    category <- parseMaybe "category" form
+    basePriceDollars <- parseUnique "base_price_dollars" form
+    inventoryCount <- parseUnique "inventory_count" form
+    pure
+      InlineCreateForm
+        { icfName = name,
+          icfCategory = category,
+          icfBasePriceDollars = basePriceDollars,
+          icfInventoryCount = inventoryCount
+        }

--- a/services/web/src/API/Dashboard/Store/Products/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Get/Handler.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.Store.Products.Get.Handler (handler, action, ProductListViewData (..)) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Products.Get.Templates (template)
+import API.Links (apiLinks)
+import API.Types (Routes (..))
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (HandlerError, handleHtmlErrors, throwDatabaseError)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Either (fromRight)
+import Data.Maybe (listToMaybe)
+import Design (base, class_)
+import Design.Tokens qualified as Tokens
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Shows qualified as Shows
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Lucid qualified
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | All data needed to render the products list page.
+data ProductListViewData = ProductListViewData
+  { plvUserMetadata :: UserMetadata.Model,
+    plvAllShows :: [Shows.Model],
+    plvSelectedShow :: Maybe Shows.Model,
+    plvProducts :: [Products.Model]
+  }
+
+-- | Business logic: fetch shows for sidebar, fetch all products.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  ExceptT HandlerError AppM ProductListViewData
+action user userMetadata = do
+  -- 1. Fetch shows for sidebar
+  showsResult <-
+    if UserMetadata.isAdmin userMetadata.mUserRole
+      then execQuery Shows.getAllActiveShows
+      else execQuery (Shows.getShowsForUser (User.mId user))
+  let allShows = fromRight [] showsResult
+      selectedShow = listToMaybe allShows
+
+  -- 2. Fetch all products
+  products <- fromRightM throwDatabaseError $ execQuery Products.getAll
+
+  pure
+    ProductListViewData
+      { plvUserMetadata = userMetadata,
+        plvAllShows = allShows,
+        plvSelectedShow = selectedShow,
+        plvProducts = products
+      }
+
+-- | Servant handler: thin glue composing action + render with dashboard chrome.
+handler ::
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler cookie (foldHxReq -> hxRequest) =
+  handleHtmlErrors "Products list" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to access this page." userMetadata
+    vd <- action user userMetadata
+    lift $
+      renderDashboardTemplate
+        hxRequest
+        vd.plvUserMetadata
+        vd.plvAllShows
+        vd.plvSelectedShow
+        NavStoreProducts
+        Nothing
+        (Just actionButton)
+        (template vd.plvProducts)
+
+-- | Action button rendered in the dashboard top bar.
+--
+-- Dispatches a custom 'show-create' event that the template listens for
+-- via @\@show-create.window@ to toggle the inline create row.
+actionButton :: Lucid.Html ()
+actionButton =
+  Lucid.button_
+    [ Lucid.type_ "button",
+      Lucid.onclick_ "window.dispatchEvent(new CustomEvent('show-create'))",
+      class_ $ base [Tokens.bgAlt, Tokens.fgPrimary, Tokens.px4, Tokens.py2, Tokens.textSm, Tokens.fontBold, Tokens.hoverBg]
+    ]
+    "+ NEW"

--- a/services/web/src/API/Dashboard/Store/Products/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Get/Route.hs
@@ -1,0 +1,21 @@
+module API.Dashboard.Store.Products.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/store/products"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Products/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Get/Templates.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module API.Dashboard.Store.Products.Get.Templates (template, renderProductRow) where
+
+--------------------------------------------------------------------------------
+
+import API.Links (dashboardStoreProductsLinks, rootLink)
+import API.Types (DashboardStoreProductsRoutes (..))
+import Component.Table
+  ( ColumnAlign (..),
+    ColumnHeader (..),
+    IndexTableConfig (..),
+    clickableCellAttrs,
+    renderIndexTable,
+    rowAttrs,
+  )
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Data.Text.Display (display)
+import Design (base, class_)
+import Design.Theme qualified as Theme
+import Design.Tokens qualified as Tokens
+import Domain.Types.Cents qualified as Cents
+import Effects.Database.Tables.Products qualified as Products
+import Lucid qualified
+import Lucid.Alpine (xData_, xOnClick_, xOn_, xShow_)
+import Lucid.HTMX (hxInclude_, hxOnAfterRequest_, hxPost_, hxSwap_, hxTarget_)
+
+--------------------------------------------------------------------------------
+
+-- | Products list template.
+template :: [Products.Model] -> Lucid.Html ()
+template products =
+  Lucid.div_
+    [ xData_ "{ showCreate: false }",
+      xOn_ "show-create.window" "showCreate = true",
+      xOn_ "hide-create.window" "showCreate = false"
+    ]
+    $ Lucid.section_ [class_ $ base [Tokens.bgMain, "rounded", "overflow-hidden", Tokens.mb8]]
+    $ renderIndexTable
+      IndexTableConfig
+        { itcBodyId = "products-table-body",
+          itcHeaders =
+            [ ColumnHeader "Name" AlignLeft,
+              ColumnHeader "Category" AlignLeft,
+              ColumnHeader "Price" AlignLeft,
+              ColumnHeader "Inventory" AlignLeft,
+              ColumnHeader "Status" AlignLeft
+            ],
+          itcNextPageUrl = Nothing,
+          itcPaginationConfig = Nothing
+        }
+      ( do
+          mapM_ renderProductRow products
+          renderInlineCreateRow
+      )
+
+renderProductRow :: Products.Model -> Lucid.Html ()
+renderProductRow productModel =
+  let productId = productModel.pId
+      productIdText = display productId
+      rowId = [i|product-row-#{productIdText}|] :: Text
+      editUrl = rootLink $ dashboardStoreProductsLinks.editGet productId
+   in Lucid.tr_ (rowAttrs rowId) $ do
+        Lucid.td_ (clickableCellAttrs editUrl) $
+          Lucid.span_ [Lucid.class_ Tokens.fontBold] $
+            Lucid.toHtml productModel.pName
+
+        Lucid.td_ (clickableCellAttrs editUrl) $
+          Lucid.div_ [Lucid.class_ Tokens.textSm] $
+            maybe (Lucid.toHtml ("\x2014" :: Text)) Lucid.toHtml productModel.pCategory
+
+        Lucid.td_ (clickableCellAttrs editUrl) $
+          Lucid.div_ [Lucid.class_ Tokens.textSm] $
+            Lucid.toHtml (Cents.formatDisplay productModel.pBasePriceCents)
+
+        Lucid.td_ (clickableCellAttrs editUrl) $
+          Lucid.div_ [Lucid.class_ Tokens.textSm] $
+            Lucid.toHtml (display productModel.pInventoryCount)
+
+        Lucid.td_ (clickableCellAttrs editUrl) $
+          renderStatusBadge productModel.pIsActive
+
+-- | Inline create row shown when showCreate Alpine state is true.
+--
+-- The tr itself carries the hx-post/hx-target/hx-swap attributes.
+-- HTMX collects all named inputs within the element when a submit button is clicked.
+renderInlineCreateRow :: Lucid.Html ()
+renderInlineCreateRow =
+  Lucid.tr_
+    [ Lucid.id_ "inline-create-row",
+      xShow_ "showCreate",
+      class_ $ base ["border-b", Theme.borderMuted]
+    ]
+    $ do
+      -- Name
+      Lucid.td_ [class_ $ base [Tokens.p2]] $
+        Lucid.input_
+          [ Lucid.type_ "text",
+            Lucid.name_ "name",
+            Lucid.placeholder_ "Product name",
+            Lucid.required_ "true",
+            class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, "w-full"]
+          ]
+      -- Category
+      Lucid.td_ [class_ $ base [Tokens.p2]] $
+        Lucid.input_
+          [ Lucid.type_ "text",
+            Lucid.name_ "category",
+            Lucid.placeholder_ "Category",
+            class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, "w-full"]
+          ]
+      -- Price
+      Lucid.td_ [class_ $ base [Tokens.p2]] $
+        Lucid.input_
+          [ Lucid.type_ "number",
+            Lucid.name_ "base_price_dollars",
+            Lucid.step_ "0.01",
+            Lucid.min_ "0",
+            Lucid.placeholder_ "0.00",
+            class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, "w-full"]
+          ]
+      -- Inventory
+      Lucid.td_ [class_ $ base [Tokens.p2]] $
+        Lucid.input_
+          [ Lucid.type_ "number",
+            Lucid.name_ "inventory_count",
+            Lucid.value_ "0",
+            Lucid.min_ "0",
+            class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, "w-full"]
+          ]
+      -- Actions (in the Status column position)
+      Lucid.td_ [class_ $ base [Tokens.p2]] $
+        Lucid.div_ [class_ $ base ["flex", "gap-2", "items-center"]] $ do
+          Lucid.button_
+            [ Lucid.type_ "button",
+              hxPost_ (rootLink dashboardStoreProductsLinks.inlineCreate),
+              hxTarget_ "#inline-create-row",
+              hxSwap_ "beforebegin",
+              hxInclude_ "closest tr",
+              hxOnAfterRequest_ "if(event.detail.successful){ window.dispatchEvent(new Event('hide-create')); this.closest('tr').querySelectorAll('input').forEach(i => i.value = i.defaultValue) }",
+              class_ $ base [Tokens.bgAlt, Tokens.fgPrimary, Tokens.px4, Tokens.py2, Tokens.textSm, Tokens.fontBold, Tokens.hoverBg]
+            ]
+            "SAVE"
+          Lucid.button_
+            [ Lucid.type_ "button",
+              xOnClick_ "showCreate = false",
+              class_ $ base [Theme.fgMuted, Tokens.hoverBg, Tokens.textSm, "px-2", "py-1"]
+            ]
+            "\xd7"
+
+renderStatusBadge :: Bool -> Lucid.Html ()
+renderStatusBadge isActive =
+  let (bgClass, textClass, statusText) =
+        if isActive
+          then (Tokens.successBg, Tokens.successText, "Active") :: (Text, Text, Text)
+          else (Tokens.warningBg, Tokens.warningText, "Inactive")
+   in Lucid.span_
+        [class_ $ base ["inline-block", "px-3", "py-1", Tokens.textSm, Tokens.fontBold, "rounded", bgClass, textClass]]
+        $ Lucid.toHtml statusText

--- a/services/web/src/API/Dashboard/Store/Products/Id/Deactivate/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Deactivate/Post/Handler.hs
@@ -1,0 +1,38 @@
+module API.Dashboard.Store.Products.Id.Deactivate.Post.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleBannerErrors, throwDatabaseError, throwNotFound)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..), renderBanner)
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Products qualified as Products
+import Log qualified
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+-- | Servant handler: set product is_active = false, remove row from list.
+--
+-- Uses Pattern C: empty response removes the row from the products table,
+-- plus OOB banner confirming the action.
+handler ::
+  Products.Id ->
+  Maybe Cookie ->
+  AppM (Lucid.Html ())
+handler productId cookie =
+  handleBannerErrors "Product deactivate" $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to deactivate products." userMetadata
+
+    execQuery (Products.deactivateProduct productId) >>= \case
+      Left err -> throwDatabaseError err
+      Right Nothing -> throwNotFound "Product"
+      Right (Just _) -> Log.logInfo "Product deactivated successfully" productId
+
+    pure $ do
+      Lucid.toHtmlRaw ("" :: Text)
+      renderBanner Success "Product Deactivated" "The product has been deactivated and is no longer visible in the store."

--- a/services/web/src/API/Dashboard/Store/Products/Id/Deactivate/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Deactivate/Post/Route.hs
@@ -1,0 +1,22 @@
+module API.Dashboard.Store.Products.Id.Deactivate.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Effects.Database.Tables.Products qualified as Products
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/store/products/:productId/deactivate"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Capture "productId" Products.Id
+    :> "deactivate"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Post '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Handler.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.Store.Products.Id.Edit.Get.Handler
+  ( handler,
+    action,
+    ProductEditViewData (..),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Products.Id.Edit.Get.Templates.Form (template)
+import API.Links (apiLinks)
+import API.Types (Routes (..))
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (HandlerError, handleHtmlErrors, throwDatabaseError, throwNotFound)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Reader (asks)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BSL
+import Data.Either (fromRight)
+import Data.Has qualified as Has
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Domain.Types.StorageBackend (StorageBackend, buildMediaUrl)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.ProductImages qualified as ProductImages
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Effects.Database.Tables.ProductVariantOptions qualified as ProductVariantOptions
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.Shows qualified as Shows
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Log qualified
+import Lucid qualified
+import Lucid.Form.Builder (ImageData (..))
+import Utils (fromMaybeM, fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | All data needed to render the product edit form.
+data ProductEditViewData = ProductEditViewData
+  { pevUserMetadata :: UserMetadata.Model,
+    pevAllShows :: [Shows.Model],
+    pevSelectedShow :: Maybe Shows.Model,
+    pevProduct :: Products.Model,
+    pevImages :: [ImageData],
+    pevOptionsVariantsJson :: Text,
+    pevHasVariants :: Bool
+  }
+
+-- | Servant handler: thin glue composing action + render with dashboard chrome.
+handler ::
+  Products.Id ->
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler productId cookie (foldHxReq -> hxRequest) =
+  handleHtmlErrors "Product edit form" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to edit products." userMetadata
+    vd <- action user userMetadata productId
+    lift $
+      renderDashboardTemplate
+        hxRequest
+        vd.pevUserMetadata
+        vd.pevAllShows
+        vd.pevSelectedShow
+        NavStoreProducts
+        Nothing
+        Nothing
+        (template vd.pevUserMetadata vd.pevProduct vd.pevImages vd.pevHasVariants vd.pevOptionsVariantsJson)
+
+--------------------------------------------------------------------------------
+
+-- | Business logic: fetch product and all related data.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  Products.Id ->
+  ExceptT HandlerError AppM ProductEditViewData
+action user userMetadata productId = do
+  -- 1. Fetch shows for sidebar
+  showsResult <-
+    if UserMetadata.isAdmin userMetadata.mUserRole
+      then execQuery Shows.getAllActiveShows
+      else execQuery (Shows.getShowsForUser (User.mId user))
+  let allShows = fromRight [] showsResult
+      selectedShow = listToMaybe allShows
+
+  -- 2. Fetch product
+  productModel <- fromMaybeM (throwNotFound "Product") $ fromRightM throwDatabaseError $ execQuery (Products.getById productId)
+
+  -- 3. Fetch images, option types, option values, variants, and variant-option join rows
+  images <- fromRightM throwDatabaseError $ execQuery (ProductImages.getByProductId productId)
+  optionTypes <- fromRightM throwDatabaseError $ execQuery (ProductOptionTypes.getByProductId productId)
+  optionValues <- fromRightM throwDatabaseError $ execQuery (ProductOptionValues.getByProductId productId)
+  variants <- fromRightM throwDatabaseError $ execQuery (ProductVariants.getByProductId productId)
+  variantOptions <- fromRightM throwDatabaseError $ execQuery (ProductVariantOptions.getByProductId productId)
+
+  Log.logInfo "Loading product edit form" productId
+
+  storageBackend <- lift $ asks (Has.getter @StorageBackend)
+
+  let optionsVariantsJson = buildOptionsVariantsJson optionTypes optionValues variants variantOptions
+      imageDataList = map (toImageData storageBackend) images
+
+  pure
+    ProductEditViewData
+      { pevUserMetadata = userMetadata,
+        pevAllShows = allShows,
+        pevSelectedShow = selectedShow,
+        pevProduct = productModel,
+        pevImages = imageDataList,
+        pevOptionsVariantsJson = optionsVariantsJson,
+        pevHasVariants = not (null variants)
+      }
+
+-- | Serialize options, variants, and their mappings as JSON for the Alpine.js component.
+--
+-- Produces a JSON object with:
+--
+-- - @options@: array of @{name, values}@ objects
+-- - @variants@: array of @{id, option_values, price_cents, inventory_count, sku, weight_oz}@ objects
+-- - @deletedVariantIds@: empty array (initial state)
+buildOptionsVariantsJson ::
+  [ProductOptionTypes.Model] ->
+  [ProductOptionValues.Model] ->
+  [ProductVariants.Model] ->
+  [ProductVariantOptions.VariantOption] ->
+  Text
+buildOptionsVariantsJson optionTypes optionValues variants variantOptions =
+  Text.decodeUtf8 $ BSL.toStrict $ Aeson.encode jsonObj
+  where
+    -- Pre-build lookup maps for O(1) access
+    valuesByType :: Map.Map ProductOptionTypes.Id [ProductOptionValues.Model]
+    valuesByType = Map.fromListWith (<>) [(v.povOptionTypeId, [v]) | v <- optionValues]
+
+    valueById :: Map.Map ProductOptionValues.Id Text
+    valueById = Map.fromList [(v.povId, v.povValue) | v <- optionValues]
+
+    optValueIdsByVariant :: Map.Map ProductVariants.Id [ProductOptionValues.Id]
+    optValueIdsByVariant = Map.fromListWith (<>) [(vo.voVariantId, [vo.voOptionValueId]) | vo <- variantOptions]
+
+    jsonObj =
+      Aeson.object
+        [ "options" Aeson..= map buildOption optionTypes,
+          "variants" Aeson..= map buildVariant variants,
+          "deletedVariantIds" Aeson..= ([] :: [Int])
+        ]
+
+    buildOption ot =
+      let valuesForType = fromMaybe [] $ Map.lookup ot.potId valuesByType
+       in Aeson.object
+            [ "name" Aeson..= ot.potName,
+              "values" Aeson..= map (.povValue) valuesForType
+            ]
+
+    buildVariant v =
+      let variantOptValueIds = fromMaybe [] $ Map.lookup v.pvId optValueIdsByVariant
+          variantOptValues = mapMaybe (`Map.lookup` valueById) variantOptValueIds
+       in Aeson.object
+            [ "id" Aeson..= v.pvId,
+              "option_values" Aeson..= variantOptValues,
+              "price_cents" Aeson..= v.pvPriceCents,
+              "inventory_count" Aeson..= v.pvInventoryCount,
+              "sku" Aeson..= v.pvSku,
+              "weight_oz" Aeson..= v.pvWeightOz
+            ]
+
+-- | Convert a database image record to the form builder's 'ImageData' type.
+toImageData :: StorageBackend -> ProductImages.Model -> ImageData
+toImageData backend img =
+  ImageData
+    { imgId = Just (ProductImages.unId img.piId),
+      imgUrl = buildMediaUrl backend img.piImagePath,
+      imgAltText = img.piAltText
+    }

--- a/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Route.hs
@@ -1,0 +1,24 @@
+module API.Dashboard.Store.Products.Id.Edit.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Effects.Database.Tables.Products qualified as Products
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/store/products/:productId/edit"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Capture "productId" Products.Id
+    :> "edit"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Templates/Form.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Edit/Get/Templates/Form.hs
@@ -1,0 +1,449 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module API.Dashboard.Store.Products.Id.Edit.Get.Templates.Form
+  ( template,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import API.Links (dashboardStoreProductsLinks, rootLink)
+import API.Types (DashboardStoreProductsRoutes (..))
+import Data.Int (Int64)
+import Data.Scientific (FPFormat (..), formatScientific)
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Display (display)
+import Design (base, class_)
+import Design.Tokens qualified as Tokens
+import Domain.Types.Cents qualified as Cents
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Lucid qualified
+import Lucid.Alpine
+import Lucid.Base (makeAttributes)
+import Lucid.Form.Builder
+import Lucid.HTMX
+
+--------------------------------------------------------------------------------
+-- URL helpers
+
+productsListUrl :: Text
+productsListUrl = rootLink dashboardStoreProductsLinks.list
+
+productEditPostUrl :: Products.Id -> Text
+productEditPostUrl pid = rootLink $ dashboardStoreProductsLinks.editPost pid
+
+--------------------------------------------------------------------------------
+
+-- | Product edit page template with three sections plus Alpine.js options/variants component.
+template ::
+  UserMetadata.Model ->
+  Products.Model ->
+  -- | Existing images for the imagesField
+  [ImageData] ->
+  -- | Whether the product currently has variants
+  Bool ->
+  -- | JSON string for options/variants Alpine.js state
+  Text ->
+  Lucid.Html ()
+template userMeta productModel existingImages hasVariants optionsVariantsJson = do
+  renderPageHeader productModel userMeta
+  renderProductForm productModel existingImages hasVariants optionsVariantsJson
+
+--------------------------------------------------------------------------------
+-- Page header
+
+renderPageHeader :: Products.Model -> UserMetadata.Model -> Lucid.Html ()
+renderPageHeader productModel userMeta =
+  Lucid.section_ [class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.p6, Tokens.mb8, Tokens.fullWidth]] $
+    Lucid.div_ [class_ $ base ["flex", "items-center", "justify-between"]] $ do
+      Lucid.div_ $ do
+        Lucid.h1_ [class_ $ base [Tokens.text2xl, Tokens.fontBold, Tokens.mb2]] "EDIT PRODUCT"
+        Lucid.div_ [class_ $ base [Tokens.fgMuted, Tokens.textSm]] $ do
+          Lucid.strong_ "Product: "
+          Lucid.toHtml productModel.pName
+          " \x2022 "
+          Lucid.strong_ "Editor: "
+          Lucid.toHtml userMeta.mDisplayName
+      Lucid.a_
+        [ Lucid.href_ productsListUrl,
+          hxGet_ productsListUrl,
+          hxTarget_ "#main-content",
+          hxPushUrl_ "true",
+          class_ $ base [Tokens.infoText, Tokens.hoverBg, Tokens.textSm, "underline"]
+        ]
+        "VIEW PRODUCTS"
+
+--------------------------------------------------------------------------------
+-- Section 1: Basic Info Form
+
+-- | Single form containing basic info, options/variants, and submit button.
+--
+-- The options/variants section is embedded via @plain@ as an Alpine.js
+-- component with its own @x-data@ scope.  Its hidden input
+-- (@variants_json@) is inside this form so it gets submitted.
+renderProductForm :: Products.Model -> [ImageData] -> Bool -> Text -> Lucid.Html ()
+renderProductForm productModel existingImages hasVariants optionsVariantsJson =
+  renderForm config form
+  where
+    postUrl = productEditPostUrl productModel.pId
+
+    config :: FormConfig
+    config =
+      defaultFormConfig
+        { fcAction = postUrl,
+          fcMethod = "post",
+          fcHtmxTarget = Just "#main-content",
+          fcHtmxSwap = Just "innerHTML"
+        }
+
+    form :: FormBuilder
+    form = do
+      section "BASIC INFO" $ do
+        textField "name" $ do
+          label "Product Name"
+          placeholder "e.g. KPBJ Tote Bag"
+          value productModel.pName
+          required
+          maxLength 200
+
+        textareaField "description" 6 $ do
+          label "Description"
+          placeholder "Describe the product..."
+          value productModel.pDescription
+          maxLength 5000
+
+      section "PRICING & SHIPPING" $ do
+        numberField "base_price_dollars" Nothing Nothing Nothing $ do
+          label "Price ($)"
+          placeholder "e.g. 24.99"
+          value (Text.pack $ formatScientific Fixed (Just 2) (Cents.centsToDollars productModel.pBasePriceCents))
+          hint "Enter the price in dollars (e.g. 24.99)"
+          required
+
+        numberField "weight_oz" Nothing Nothing Nothing $ do
+          label "Weight (oz)"
+          placeholder "e.g. 8"
+          value (display productModel.pWeightOz)
+          hint "Shipping weight in ounces"
+
+      section "INVENTORY" $ do
+        numberField "inventory_count" (Just 0) Nothing Nothing $ do
+          label "Inventory Count"
+          value (display productModel.pInventoryCount)
+          when hasVariants disabled
+          hint
+            ( if hasVariants
+                then "Inventory is tracked per variant. This field is ignored."
+                else "Stock count for this product."
+            )
+
+      -- Product images (multi-image field with cropping and reorder)
+      imagesField "product_images" $ do
+        label "Product Images"
+        maxSize 5
+        aspectRatio (1, 1)
+        previewSize 120
+        currentImages existingImages
+        hint "First image is the hero/thumbnail. Drag to reorder."
+
+      -- Options & variants Alpine.js component (embedded in the form
+      -- so the hidden variants_json input is submitted with the form)
+      plain $
+        renderOptionsAndVariants productModel optionsVariantsJson
+
+      section "ORGANISATION" $ do
+        textField "category" $ do
+          label "Category"
+          placeholder "e.g. apparel, vinyl, accessories"
+          maybe (pure ()) value productModel.pCategory
+          hint "Optional \x2014 used for filtering"
+          maxLength 100
+
+        numberField "sort_order" Nothing Nothing Nothing $ do
+          label "Sort Order"
+          value (display productModel.pSortOrder)
+          hint "Lower numbers appear first (default 0)"
+
+      footerToggle "is_active" $ do
+        offLabel "Inactive"
+        onLabel "Active"
+        offValue ""
+        onValue "on"
+        when productModel.pIsActive checked
+        hint "Toggle to make this product visible in the store"
+
+      cancelButton productsListUrl "CANCEL"
+      submitButton "UPDATE PRODUCT"
+
+--------------------------------------------------------------------------------
+-- Options & Variants (Alpine.js component)
+
+-- | Combined Alpine.js component for managing product options and variants.
+--
+-- Replaces the old server-rendered option types (section 3) and variants (section 4)
+-- with a single client-side component that:
+--
+-- 1. Lets staff add/remove option types and their values
+-- 2. Auto-generates the cartesian product of variants
+-- 3. Allows editing price, inventory, SKU, and weight per variant
+-- 4. Serializes the full state as JSON in a hidden input for form submission
+renderOptionsAndVariants :: Products.Model -> Text -> Lucid.Html ()
+renderOptionsAndVariants productModel optionsVariantsJson =
+  Lucid.section_
+    [ Lucid.class_ "fb-section",
+      xData_ (alpineState optionsVariantsJson productModel.pBasePriceCents productModel.pWeightOz)
+    ]
+    $ do
+      Lucid.h2_ [Lucid.class_ "fb-section-title"] "OPTIONS & VARIANTS"
+
+      -- Options area
+      renderOptionsArea
+
+      -- Add option button
+      renderAddOptionButton
+
+      -- Variants table
+      renderVariantsTable
+
+      -- Hidden input serializing the Alpine state as JSON for form submission
+      Lucid.input_
+        [ Lucid.type_ "hidden",
+          Lucid.name_ "variants_json",
+          xBindValue_ "serializeForSubmit()"
+        ]
+
+-- | Alpine.js state for the options/variants component.
+alpineState :: Text -> Cents.Cents -> Int64 -> Text
+alpineState optionsJson basePriceCents weightOz =
+  [i|{
+  ...#{optionsJson},
+  productBasePrice: #{basePriceCents},
+  productWeight: #{weightOz},
+  newValueInputs: {},
+
+  addOption() {
+    this.options.push({name: '', values: []});
+  },
+  removeOption(idx) {
+    const removed = this.options.splice(idx, 1)[0];
+    this.variants.forEach(v => {
+      if (v.id) this.deletedVariantIds.push(v.id);
+    });
+    this.regenerateVariants();
+  },
+  addValue(optIdx, value) {
+    if (!value.trim()) return;
+    this.options[optIdx].values.push(value.trim());
+    this.newValueInputs[optIdx] = '';
+    this.regenerateVariants();
+  },
+  removeValue(optIdx, valIdx) {
+    const removed = this.options[optIdx].values.splice(valIdx, 1)[0];
+    this.variants.filter(v => v.option_values.includes(removed)).forEach(v => {
+      if (v.id) this.deletedVariantIds.push(v.id);
+    });
+    this.regenerateVariants();
+  },
+  regenerateVariants() {
+    if (this.options.length === 0 || this.options.every(o => o.values.length === 0)) {
+      this.variants = [];
+      return;
+    }
+    const combos = this.cartesian(this.options.map(o => o.values));
+    const oldVariants = [...this.variants];
+    this.variants = combos.map(combo => {
+      const existing = oldVariants.find(v =>
+        JSON.stringify(v.option_values) === JSON.stringify(combo)
+      );
+      if (existing) return {...existing, option_values: combo};
+      return {id: null, option_values: combo, price_cents: null, inventory_count: 0, sku: null, weight_oz: null};
+    });
+  },
+  cartesian(arrays) {
+    if (arrays.length === 0) return [];
+    return arrays.reduce((acc, arr) =>
+      acc.flatMap(combo => arr.map(val => [...combo, val])),
+      [[]]
+    );
+  },
+  deleteVariant(idx) {
+    const v = this.variants[idx];
+    if (v.id) this.deletedVariantIds.push(v.id);
+    this.variants.splice(idx, 1);
+  },
+  formatPrice(cents) {
+    if (cents === null || cents === undefined) return '';
+    return (cents / 100).toFixed(2);
+  },
+  parsePriceCents(dollarStr) {
+    if (!dollarStr || dollarStr.trim() === '') return null;
+    const val = parseFloat(dollarStr);
+    if (isNaN(val)) return null;
+    return Math.round(val * 100);
+  },
+  serializeForSubmit() {
+    const cleanVariants = this.variants.map(v => ({
+      id: v.id,
+      option_values: v.option_values,
+      price_cents: v.price_cents === '' || v.price_cents === null ? null : Number(v.price_cents),
+      inventory_count: Number(v.inventory_count) || 0,
+      sku: v.sku === '' ? null : v.sku,
+      weight_oz: v.weight_oz === '' || v.weight_oz === null ? null : Number(v.weight_oz)
+    }));
+    return JSON.stringify({
+      options: this.options,
+      variants: cleanVariants,
+      deleted_variant_ids: this.deletedVariantIds
+    });
+  }
+}|]
+
+-- | Render the options area with dynamic x-for loops.
+renderOptionsArea :: Lucid.Html ()
+renderOptionsArea =
+  Lucid.div_ [class_ $ base ["space-y-4", Tokens.mb4]] $
+    Lucid.template_
+      [xFor_ "(opt, optIdx) in options", xKey_ "optIdx"]
+      renderOptionRow
+
+-- | Render a single option row with name input, value tags, and add value input.
+renderOptionRow :: Lucid.Html ()
+renderOptionRow =
+  Lucid.div_ [class_ $ base [Tokens.border2, Tokens.p4]] $ do
+    -- Option name + remove button
+    Lucid.div_ [class_ $ base ["flex", "items-center", "justify-between", Tokens.mb2]] $ do
+      Lucid.input_
+        [ Lucid.type_ "text",
+          Lucid.placeholder_ "Option name (e.g. Size, Color)",
+          xModel_ "opt.name",
+          class_ $ base ["flex-1", Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, Tokens.fontBold]
+        ]
+      Lucid.button_
+        [ Lucid.type_ "button",
+          xOnClick_ "removeOption(optIdx)",
+          class_ $ base [Tokens.errorText, Tokens.hoverBg, Tokens.textSm, Tokens.fontBold, "px-2", "py-1", "ml-2"]
+        ]
+        "REMOVE"
+
+    -- Existing values as tags
+    Lucid.div_ [class_ $ base ["flex", "flex-wrap", "gap-2", "mb-3"]]
+      $ Lucid.template_
+        [xFor_ "(val, valIdx) in opt.values", xKey_ "valIdx"]
+      $ Lucid.span_
+        [class_ $ base ["inline-flex", "items-center", "gap-1", Tokens.border2, "px-2", "py-1", Tokens.textSm]]
+      $ do
+        Lucid.span_ [xText_ "val"] mempty
+        Lucid.button_
+          [ Lucid.type_ "button",
+            xOnClick_ "removeValue(optIdx, valIdx)",
+            class_ $ base [Tokens.errorText, "ml-1", Tokens.textSm]
+          ]
+          "\xd7"
+
+    -- Add value input
+    Lucid.div_ [class_ $ base ["flex", "gap-2", "items-end"]] $ do
+      Lucid.input_
+        [ Lucid.type_ "text",
+          Lucid.placeholder_ "Add value...",
+          xModel_ "newValueInputs[optIdx]",
+          xOn_ "keydown.enter.prevent" "addValue(optIdx, newValueInputs[optIdx] || '')",
+          class_ $ base [Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, Tokens.p2, Tokens.textSm, "flex-1"]
+        ]
+      Lucid.button_
+        [ Lucid.type_ "button",
+          xOnClick_ "addValue(optIdx, newValueInputs[optIdx] || '')",
+          class_ $ base [Tokens.bgAlt, Tokens.fgPrimary, Tokens.px3, Tokens.py2, Tokens.textSm, Tokens.fontBold, Tokens.hoverBg]
+        ]
+        "ADD VALUE"
+
+-- | Render the add option button.
+renderAddOptionButton :: Lucid.Html ()
+renderAddOptionButton =
+  Lucid.div_ [class_ $ base [Tokens.mb4]] $
+    Lucid.button_
+      [ Lucid.type_ "button",
+        xOnClick_ "addOption()",
+        class_ $ base [Tokens.bgAlt, Tokens.fgPrimary, Tokens.px4, Tokens.py2, Tokens.textSm, Tokens.fontBold, Tokens.hoverBg, "w-full"]
+      ]
+      "+ ADD OPTION TYPE"
+
+-- | Render the auto-generated variants table.
+renderVariantsTable :: Lucid.Html ()
+renderVariantsTable =
+  Lucid.div_ [xShow_ "variants.length > 0"] $ do
+    Lucid.h3_ [class_ $ base [Tokens.textSm, Tokens.fontBold, Tokens.fgMuted, Tokens.mb2]] "GENERATED VARIANTS"
+    Lucid.table_ [class_ $ base ["w-full", Tokens.textSm, Tokens.border2]] $ do
+      Lucid.thead_ $
+        Lucid.tr_ [class_ $ base [Tokens.bgAlt]] $ do
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] "Variant"
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] "Price ($)"
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] "Inventory"
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] "SKU"
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] "Weight (oz)"
+          Lucid.th_ [class_ $ base [Tokens.p2, "text-left", Tokens.fontBold]] ""
+      Lucid.tbody_ $
+        Lucid.template_
+          [xFor_ "(variant, vIdx) in variants", xKey_ "vIdx"]
+          renderVariantRow
+
+-- | Render a single variant row in the table.
+renderVariantRow :: Lucid.Html ()
+renderVariantRow =
+  Lucid.tr_ [class_ $ base [Tokens.border2]] $ do
+    -- Variant label (computed from option_values)
+    Lucid.td_ [class_ $ base [Tokens.p2, Tokens.fontBold]] $
+      Lucid.span_ [xText_ "variant.option_values.join(' / ')"] mempty
+
+    -- Price ($) input
+    Lucid.td_ [class_ $ base [Tokens.p2]] $
+      Lucid.input_
+        [ Lucid.type_ "number",
+          makeAttributes "step" "0.01",
+          makeAttributes "min" "0",
+          Lucid.placeholder_ "Base price",
+          xBindValue_ "formatPrice(variant.price_cents)",
+          xOnChange_ "variant.price_cents = parsePriceCents($event.target.value)",
+          class_ $ base ["w-24", Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, "p-1", Tokens.textSm]
+        ]
+
+    -- Inventory input
+    Lucid.td_ [class_ $ base [Tokens.p2]] $
+      Lucid.input_
+        [ Lucid.type_ "number",
+          makeAttributes "min" "0",
+          xModel_ "variant.inventory_count",
+          class_ $ base ["w-20", Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, "p-1", Tokens.textSm]
+        ]
+
+    -- SKU input
+    Lucid.td_ [class_ $ base [Tokens.p2]] $
+      Lucid.input_
+        [ Lucid.type_ "text",
+          Lucid.placeholder_ "SKU",
+          xModel_ "variant.sku",
+          class_ $ base ["w-24", Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, "p-1", Tokens.textSm]
+        ]
+
+    -- Weight (oz) input
+    Lucid.td_ [class_ $ base [Tokens.p2]] $
+      Lucid.input_
+        [ Lucid.type_ "number",
+          makeAttributes "min" "0",
+          Lucid.placeholder_ "Base",
+          xBindValue_ "variant.weight_oz === null ? '' : variant.weight_oz",
+          xOnChange_ "variant.weight_oz = $event.target.value === '' ? null : parseInt($event.target.value, 10)",
+          class_ $ base ["w-20", Tokens.bgMain, Tokens.fgPrimary, Tokens.border2, "p-1", Tokens.textSm]
+        ]
+
+    -- Delete button
+    Lucid.td_ [class_ $ base [Tokens.p2]] $
+      Lucid.button_
+        [ Lucid.type_ "button",
+          xOnClick_ "deleteVariant(vIdx)",
+          class_ $ base [Tokens.errorText, Tokens.textSm, Tokens.fontBold, "px-2", "py-1"]
+        ]
+        "\xd7"

--- a/services/web/src/API/Dashboard/Store/Products/Id/Edit/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Edit/Post/Handler.hs
@@ -1,0 +1,493 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module API.Dashboard.Store.Products.Id.Edit.Post.Handler (handler, action) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Products.Id.Edit.Post.Route (EditProductForm (..))
+import API.Links (apiLinks, dashboardStoreProductsLinks, rootLink)
+import API.Types (DashboardStoreProductsRoutes (..), Routes (..))
+import App.Handler.Combinators (requireAuth, requireRight, requireStaffNotSuspended)
+import App.Handler.Error (HandlerError, handleRedirectErrors, throwDatabaseError, throwNotFound, throwValidationError)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..))
+import Component.Flash (FlashMessage (..), flashCookie)
+import Control.Monad (foldM, forM, forM_, unless, void, when)
+import Control.Monad.Reader (asks)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Aeson (FromJSON (..), (.:), (.:?))
+import Data.Aeson qualified as Aeson
+import Data.Bifunctor (first)
+import Data.Foldable (fold)
+import Data.Has (getter)
+import Data.Int (Int64)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text.Encoding
+import Domain.Types.Cents qualified as Cents
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.FileUpload (uploadResultStoragePath)
+import Domain.Types.VariantsPayload (OptionPayload (..), VariantPayload (..), VariantsPayload (..))
+import Effects.ContentSanitization qualified as Sanitize
+import Effects.Database.Execute (execQuery, execTransaction)
+import Effects.Database.Tables.ProductImages qualified as ProductImages
+import Effects.Database.Tables.ProductOptionTypes qualified as ProductOptionTypes
+import Effects.Database.Tables.ProductOptionValues qualified as ProductOptionValues
+import Effects.Database.Tables.ProductVariantOptions qualified as ProductVariantOptions
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import Effects.Database.Tables.Products qualified as Products
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Effects.FileUpload (uploadProductImage)
+import Effects.StagedUploadCleanup (deleteFile)
+import Hasql.Transaction qualified as HT
+import Log qualified
+import Servant qualified
+import Servant.Multipart (FileData, Mem)
+import Text.Read (readMaybe)
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | Servant handler: thin glue composing action + building redirect response.
+handler ::
+  Products.Id ->
+  Maybe Cookie ->
+  EditProductForm ->
+  AppM (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
+handler productId cookie editForm =
+  handleRedirectErrors "Product update" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to edit products." userMetadata
+
+    vd <- action user userMetadata productId editForm
+    pure $ Servant.addHeader vd.eprRedirectUrl $ Servant.addHeader (flashCookie (Just vd.eprFlash)) Servant.NoContent
+
+--------------------------------------------------------------------------------
+-- Validation
+
+parseNonNull :: Text -> Maybe Text
+parseNonNull txt =
+  if Text.null (Text.strip txt) then Nothing else Just txt
+
+-- | Strip whitespace if the description is otherwise empty.
+parseDescription :: Text -> Text
+parseDescription = fold . parseNonNull
+
+parsePrice :: Text -> Either Text Cents.Cents
+parsePrice dollars =
+  case readMaybe @Scientific (Text.unpack dollars) of
+    Just d | d >= 0 -> Right (Cents.dollarsToCents d)
+    _ -> Left ("Invalid price: \"" <> dollars <> "\" is not a valid amount")
+
+-- | Validate the edit product form, returning a Products.Insert or an error.
+--
+-- The slug is preserved from the existing product (immutable after creation).
+validateEditForm ::
+  -- | Existing product slug to preserve.
+  Text ->
+  EditProductForm ->
+  Either Text Products.Insert
+validateEditForm existingSlug form = do
+  -- Sanitize and validate name
+  let sanitizedName = Sanitize.sanitizeTitle form.epfName
+  validName <- first Sanitize.displayContentValidationError $ Sanitize.validateContentLength 200 sanitizedName
+
+  -- Sanitize description (empty allowed)
+  let sanitizedDescription = Sanitize.sanitizeUserContent form.epfDescription
+      description = parseDescription sanitizedDescription
+
+  -- Parse price
+  basePriceCents <- parsePrice form.epfBasePriceDollars
+
+  -- Parse weight, inventory count, and sort order (0 if blank/invalid)
+  let weightOz = Sanitize.parseIntDefault0 form.epfWeightOz
+      -- Absent when field is disabled (variants exist) — default to 0
+      inventoryCount = maybe 0 Sanitize.parseIntDefault0 form.epfInventoryCount
+      sortOrder = Sanitize.parseIntDefault0 form.epfSortOrder
+
+  -- Sanitize optional category
+  let mCategory = form.epfCategory >>= parseNonNull . Sanitize.sanitizePlainText
+
+  -- Parse is_active: "on" means True, absent means False
+  let isActive = form.epfIsActive == Just "on"
+
+  Right
+    Products.Insert
+      { Products.piName = validName,
+        Products.piSlug = existingSlug,
+        Products.piDescription = description,
+        Products.piBasePriceCents = basePriceCents,
+        Products.piWeightOz = weightOz,
+        Products.piCategory = mCategory,
+        Products.piInventoryCount = inventoryCount,
+        Products.piIsActive = isActive,
+        Products.piSortOrder = sortOrder
+      }
+
+--------------------------------------------------------------------------------
+
+-- | All data needed to build the post-update redirect.
+data EditProductRedirectData = EditProductRedirectData
+  { eprRedirectUrl :: Text,
+    eprFlash :: FlashMessage
+  }
+
+-- | Business logic: fetch product, validate form, update, build redirect data.
+--
+-- All preparation (validation, file uploads) happens first, then all DB
+-- mutations run in a single transaction so a failure in variants or images
+-- does not leave a partially-updated product.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  Products.Id ->
+  EditProductForm ->
+  ExceptT HandlerError AppM EditProductRedirectData
+action _user _userMetadata productId editForm = do
+  -- 1. Verify the product exists
+  mProduct <- fromRightM throwDatabaseError $ execQuery (Products.getById productId)
+  existingProduct <- case mProduct of
+    Nothing -> throwNotFound "Product"
+    Just p -> pure p
+
+  -- 2. Validate form data (preserve existing slug)
+  productInsert <- requireRight id (validateEditForm existingProduct.pSlug editForm)
+
+  -- 3. Prepare variants (parse, sanitize, validate — no DB writes)
+  mVariantsPayload <- case editForm.epfVariantsJson of
+    Nothing -> pure Nothing
+    Just json -> Just <$> prepareVariants json
+
+  -- 4. Prepare images (validate deletions, upload new files — no DB writes)
+  (failedUploads, imagesToDelete, imageIdsToDelete, metaUpdates, newInserts) <-
+    prepareImageUpdates productId existingProduct.pSlug editForm
+
+  -- 5. Run ALL DB mutations in a single transaction
+  fromRightM throwDatabaseError $
+    execTransaction $ do
+      void $ HT.statement () (Products.updateProduct productId productInsert)
+      forM_ mVariantsPayload (variantsTransaction productId)
+      imageTransaction productId imageIdsToDelete metaUpdates newInserts
+
+  Log.logInfo "Successfully updated product" productId
+
+  -- 6. Delete old image files from storage (after transaction succeeded)
+  forM_ imagesToDelete $ \(_imageId, imagePath) -> do
+    storageBackend <- lift $ asks getter
+    mAwsEnv <- lift $ asks getter
+    deleted <- lift $ deleteFile storageBackend mAwsEnv imagePath
+    if deleted
+      then Log.logInfo "Deleted product image file" imagePath
+      else Log.logInfo "Failed to delete product image file (may not exist)" imagePath
+
+  -- Redirect back to the edit page with a flash
+  let redirectUrl = rootLink $ dashboardStoreProductsLinks.editGet productId
+      flash
+        | failedUploads > 0 =
+            FlashMessage Warning "Product Updated" $
+              "Product saved, but " <> Text.pack (show failedUploads) <> " image(s) failed to upload."
+        | otherwise =
+            FlashMessage Success "Product Updated" "Product details have been saved."
+
+  pure $ EditProductRedirectData redirectUrl flash
+
+--------------------------------------------------------------------------------
+-- Image handling
+
+-- | JSON metadata for a single image from the frontend imagesField component.
+data ImageMetadata = ImageMetadata
+  { imId :: Maybe Int64,
+    imSortOrder :: Int64,
+    imAltText :: Text
+  }
+
+instance FromJSON ImageMetadata where
+  parseJSON = Aeson.withObject "ImageMetadata" $ \o ->
+    ImageMetadata
+      <$> o .:? "id"
+      <*> o .: "sort_order"
+      <*> o .: "alt_text"
+
+-- | Prepare image updates: validate deletions, upload new files.
+--
+-- No DB writes happen here. Returns all data needed for 'imageTransaction'
+-- and post-transaction file cleanup.
+prepareImageUpdates ::
+  Products.Id ->
+  -- | Product slug for generating filenames.
+  Text ->
+  EditProductForm ->
+  ExceptT HandlerError AppM (Int, [(ProductImages.Id, Text)], [ProductImages.Id], [(ProductImages.Id, Int64, Text)], [ProductImages.Insert])
+prepareImageUpdates productId productSlug editForm = do
+  -- 1. Validate deletion list and collect paths to delete (no file I/O yet)
+  imagesToDelete <- case editForm.epfImagesDeleted of
+    Nothing -> pure []
+    Just deletedJson -> do
+      deletedIds <- case Aeson.eitherDecodeStrict (Text.Encoding.encodeUtf8 deletedJson) of
+        Left err -> throwValidationError ("Invalid deleted images JSON: " <> Text.pack err)
+        Right ids -> pure (ids :: [Int64])
+      fmap catMaybes $ forM deletedIds $ \rawId -> do
+        let imageId = ProductImages.Id rawId
+        mImage <- fromRightM throwDatabaseError $ execQuery (ProductImages.getById imageId)
+        case mImage of
+          Nothing -> pure Nothing
+          Just image
+            | image.piProductId /= productId -> do
+                Log.logInfo "Skipping image deletion: image does not belong to product" (Aeson.object ["imageId" Aeson..= rawId, "imageProductId" Aeson..= image.piProductId, "requestProductId" Aeson..= productId])
+                pure Nothing
+            | otherwise ->
+                pure (Just (imageId, image.piImagePath))
+
+  -- 2. Upload new files (I/O — orphan files are harmless if transaction fails)
+  (failedUploads, metaUpdates, newInserts) <- case editForm.epfImagesData of
+    Nothing -> pure (0, [], [])
+    Just imagesJson -> do
+      imageMetaList <- case Aeson.eitherDecodeStrict (Text.Encoding.encodeUtf8 imagesJson) of
+        Left err -> throwValidationError ("Invalid images metadata JSON: " <> Text.pack err)
+        Right metas -> pure (metas :: [ImageMetadata])
+      prepareImageOps productId productSlug imageMetaList editForm.epfImageFiles
+
+  let imageIdsToDelete = map fst imagesToDelete
+  pure (failedUploads, imagesToDelete, imageIdsToDelete, metaUpdates, newInserts)
+
+-- | Prepare image operations by uploading new files, returning DB-ready data.
+--
+-- Separates metadata into updates (existing images) and inserts (new images
+-- with freshly uploaded files). File uploads happen here; DB writes are deferred
+-- to the transaction.
+prepareImageOps ::
+  Products.Id ->
+  -- | Product slug for filenames.
+  Text ->
+  [ImageMetadata] ->
+  -- | New image files (consumed in order for entries without an id).
+  [FileData Mem] ->
+  ExceptT HandlerError AppM (Int, [(ProductImages.Id, Int64, Text)], [ProductImages.Insert])
+prepareImageOps productId productSlug metaList newFiles = do
+  (remainingFiles, failCount, updates, inserts) <- foldM go (newFiles, 0, [], []) metaList
+  -- Warn about leftover files
+  unless (null remainingFiles) $
+    Log.logInfo "Unused image files after processing metadata" (length remainingFiles)
+  pure (failCount, reverse updates, reverse inserts)
+  where
+    go (files, fails, updates, inserts) meta
+      | Just existingId <- meta.imId =
+          -- Existing image: collect metadata update
+          pure (files, fails, (ProductImages.Id existingId, meta.imSortOrder, Sanitize.sanitizePlainText meta.imAltText) : updates, inserts)
+    go ([], fails, updates, inserts) meta = do
+      Log.logInfo "No file available for new image metadata entry" meta.imSortOrder
+      pure ([], fails + 1, updates, inserts)
+    go (fileData : restFiles, fails, updates, inserts) meta = do
+      -- Upload new image file
+      storageBackend <- lift $ asks getter
+      mAwsEnv <- lift $ asks getter
+      uploadResult <- lift $ uploadProductImage storageBackend mAwsEnv productSlug fileData
+      case uploadResult of
+        Left uploadError -> do
+          Log.logInfo "Product image upload failed" (Aeson.object ["error" Aeson..= Text.pack (show uploadError)])
+          pure (restFiles, fails + 1, updates, inserts)
+        Right Nothing ->
+          pure (restFiles, fails + 1, updates, inserts)
+        Right (Just result) -> do
+          let storagePath = Text.pack (uploadResultStoragePath result)
+          Log.logInfo "Product image uploaded successfully" (Aeson.object ["path" Aeson..= storagePath])
+          let ins =
+                ProductImages.Insert
+                  { ProductImages.iiProductId = productId,
+                    ProductImages.iiImagePath = storagePath,
+                    ProductImages.iiAltText = Sanitize.sanitizePlainText meta.imAltText,
+                    ProductImages.iiSortOrder = meta.imSortOrder
+                  }
+          pure (restFiles, fails, updates, ins : inserts)
+
+-- | Transaction that applies all image DB mutations atomically.
+imageTransaction ::
+  Products.Id ->
+  [ProductImages.Id] ->
+  [(ProductImages.Id, Int64, Text)] ->
+  [ProductImages.Insert] ->
+  HT.Transaction ()
+imageTransaction _productId deleteIds metaUpdates newInserts = do
+  -- Delete removed images
+  forM_ deleteIds $ \imageId ->
+    void $ HT.statement () (ProductImages.deleteImage imageId)
+  -- Update existing image metadata
+  forM_ metaUpdates $ \(imageId, sortOrder, altText) ->
+    HT.statement () (ProductImages.updateImageMeta imageId sortOrder altText)
+  -- Insert newly uploaded images
+  forM_ newInserts $ \ins ->
+    void $ HT.statement () (ProductImages.insertImage ins)
+
+--------------------------------------------------------------------------------
+-- Variants handling
+
+-- | Parse, sanitize, and validate the variants JSON payload.
+--
+-- Returns the sanitized payload ready for 'variantsTransaction'.
+-- No database writes happen here.
+prepareVariants ::
+  Text ->
+  ExceptT HandlerError AppM VariantsPayload
+prepareVariants variantsJson = do
+  -- Parse the JSON payload
+  payload <- case Aeson.eitherDecodeStrict (Text.Encoding.encodeUtf8 variantsJson) of
+    Left err -> throwValidationError ("Invalid variants JSON: " <> Text.pack err)
+    Right vp -> pure vp
+
+  -- Sanitize all user-provided text in the payload
+  let sanitizeOption opt =
+        opt
+          { opName = Sanitize.sanitizePlainText opt.opName,
+            opValues = map Sanitize.sanitizePlainText opt.opValues
+          }
+      sanitizeVariant v =
+        v
+          { vplSku = fmap Sanitize.sanitizePlainText v.vplSku,
+            vplOptionValues = map Sanitize.sanitizePlainText v.vplOptionValues
+          }
+      sanitizedPayload =
+        payload
+          { vpOptions = map sanitizeOption payload.vpOptions,
+            vpVariants = map sanitizeVariant payload.vpVariants
+          }
+
+  -- Validate payload size limits
+  when (length sanitizedPayload.vpOptions > 10) $
+    throwValidationError "A product cannot have more than 10 option types"
+  when (length sanitizedPayload.vpVariants > 200) $
+    throwValidationError "A product cannot have more than 200 variants"
+
+  -- Validate the sanitized payload
+  forM_ sanitizedPayload.vpOptions $ \opt -> do
+    when (Text.null (Text.strip opt.opName)) $
+      throwValidationError "Option type name cannot be empty"
+    when (null opt.opValues) $
+      throwValidationError ("Option type \"" <> opt.opName <> "\" must have at least one value")
+    when (length opt.opValues > 50) $
+      throwValidationError ("Option type \"" <> opt.opName <> "\" cannot have more than 50 values")
+    forM_ opt.opValues $ \val ->
+      when (Text.null (Text.strip val)) $
+        throwValidationError ("Option type \"" <> opt.opName <> "\" contains an empty value")
+
+  forM_ sanitizedPayload.vpVariants $ \v -> do
+    when (v.vplInventoryCount < 0) $
+      throwValidationError "Variant inventory count cannot be negative"
+    forM_ v.vplPriceCents $ \price ->
+      when (price < 0) $
+        throwValidationError "Variant price cannot be negative"
+    forM_ v.vplWeightOz $ \weight ->
+      when (weight < 0) $
+        throwValidationError "Variant weight cannot be negative"
+
+  pure sanitizedPayload
+
+-- | Transaction that replaces all options and syncs variants for a product.
+--
+-- This is composed as a 'Hasql.Transaction.Transaction' so that all operations
+-- succeed or fail atomically.
+variantsTransaction ::
+  Products.Id ->
+  VariantsPayload ->
+  HT.Transaction ()
+variantsTransaction productId payload = do
+  -- 1. Delete all existing option types (cascades to values + variant-option join rows)
+  void $ HT.statement () (ProductOptionTypes.deleteByProductId productId)
+
+  -- 2. Insert new option types and their values, building a map from
+  --    (optionName, valueName) -> new ProductOptionValues.Id
+  optionValueMap <- buildOptionValueMap productId payload.vpOptions
+
+  -- 3. Upsert variants (update existing, insert new)
+  let indexedVariants = zip [0 ..] payload.vpVariants
+  forM_ indexedVariants (upsertVariant productId optionValueMap)
+
+  -- 4. Soft-delete removed variants
+  forM_ payload.vpDeletedVariantIds (HT.statement () . ProductVariants.softDeleteVariant)
+
+-- | Insert option types and their values, returning a map from
+-- @(optionTypeIndex, valueName)@ to the newly assigned 'ProductOptionValues.Id'.
+--
+-- Keyed by option type index to avoid collisions when two option types
+-- share a value name (e.g. Fit: "Regular" and Cut: "Regular").
+buildOptionValueMap ::
+  Products.Id ->
+  [OptionPayload] ->
+  HT.Transaction (Map.Map (Int64, Text) ProductOptionValues.Id)
+buildOptionValueMap productId options = do
+  maps <- mapM insertOption (zip [0 ..] options)
+  pure $ Map.unions maps
+  where
+    insertOption (optionIdx, option) = do
+      optionTypeId <-
+        HT.statement () $
+          ProductOptionTypes.insertOptionType
+            ProductOptionTypes.Insert
+              { otiProductId = productId,
+                otiName = option.opName,
+                otiSortOrder = optionIdx
+              }
+      pairs <- mapM (insertValue optionIdx optionTypeId) (zip [0 ..] option.opValues)
+      pure $ Map.fromList pairs
+
+    insertValue optionIdx optionTypeId (sortIdx, valueName) = do
+      valueId <-
+        HT.statement () $
+          ProductOptionValues.insertOptionValue
+            ProductOptionValues.Insert
+              { oviOptionTypeId = optionTypeId,
+                oviValue = valueName,
+                oviSortOrder = sortIdx
+              }
+      pure ((optionIdx, valueName), valueId)
+
+-- | Update an existing variant or insert a new one, then create its
+-- variant-option join rows.
+upsertVariant ::
+  Products.Id ->
+  Map.Map (Int64, Text) ProductOptionValues.Id ->
+  (Int64, VariantPayload) ->
+  HT.Transaction ()
+upsertVariant productId optionValueMap (sortIdx, variant) = do
+  -- Build the label from option values (e.g. "M / Red")
+  let label = Text.intercalate " / " variant.vplOptionValues
+      variantInsert =
+        ProductVariants.Insert
+          { viProductId = productId,
+            viLabel = label,
+            viPriceCents = variant.vplPriceCents,
+            viInventoryCount = variant.vplInventoryCount,
+            viSku = variant.vplSku,
+            viWeightOz = variant.vplWeightOz,
+            viSortOrder = sortIdx
+          }
+
+  -- Get the variant ID (update existing or insert new)
+  mVariantId <- case variant.vplId of
+    Just existingId -> do
+      -- Clear old variant-option join rows for this variant
+      HT.statement () (ProductVariantOptions.deleteByVariantId existingId)
+      -- Update the variant
+      HT.statement () (ProductVariants.updateVariant existingId variantInsert)
+    Nothing ->
+      -- Insert new variant
+      HT.statement () (ProductVariants.insertVariant variantInsert)
+
+  -- Create variant-option join rows
+  case mVariantId of
+    Nothing -> pure ()
+    Just variantId ->
+      mapM_ (linkVariantToOption variantId) (zip [0 ..] variant.vplOptionValues)
+  where
+    linkVariantToOption variantId (optionIdx, valueName) =
+      case Map.lookup (optionIdx, valueName) optionValueMap of
+        -- NOTE: Lookup can fail if the client sends variant option values that
+        -- don't match the declared option types. This is a no-op — the join row
+        -- is simply not created. The variant label still contains the value text.
+        Nothing -> pure ()
+        Just optionValueId ->
+          HT.statement () (ProductVariantOptions.insertVariantOption variantId optionValueId)

--- a/services/web/src/API/Dashboard/Store/Products/Id/Edit/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Edit/Post/Route.hs
@@ -1,0 +1,98 @@
+module API.Dashboard.Store.Products.Id.Edit.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import Effects.Database.Tables.Products qualified as Products
+import Servant ((:>))
+import Servant qualified
+import Servant.Multipart (FileData (..), FromMultipart, Mem, MultipartData (..), MultipartForm, fromMultipart, lookupInput)
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/store/products/:productId/edit"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Capture "productId" Products.Id
+    :> "edit"
+    :> Servant.Header "Cookie" Cookie
+    :> MultipartForm Mem EditProductForm
+    :> Servant.Post '[HTML] (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
+
+--------------------------------------------------------------------------------
+
+-- | Form data for editing an existing product's basic info.
+--
+-- Numeric fields are received as Text and parsed in the handler.
+-- The @is_active@ field is @Just "on"@ when the checkbox is checked and
+-- @Nothing@ when it is unchecked (browsers omit unchecked checkboxes).
+-- The slug is immutable after creation, so it is not included here.
+data EditProductForm = EditProductForm
+  { epfName :: Text,
+    epfDescription :: Text,
+    -- | Price in dollars as text (e.g. "24.99"); converted to cents in handler.
+    epfBasePriceDollars :: Text,
+    -- | Weight in ounces as text.
+    epfWeightOz :: Text,
+    -- | Optional product category.
+    epfCategory :: Maybe Text,
+    -- | "on" when active checkbox is ticked; Nothing when unticked.
+    epfIsActive :: Maybe Text,
+    -- | Sort order as text; defaults to "0".
+    epfSortOrder :: Text,
+    -- | Inventory count as text; for products without variants.
+    -- Absent when the field is disabled (variants exist).
+    epfInventoryCount :: Maybe Text,
+    -- | JSON payload for options + variants. Absent when product has no options.
+    epfVariantsJson :: Maybe Text,
+    -- | JSON metadata for images: [{id, sort_order, alt_text}]
+    epfImagesData :: Maybe Text,
+    -- | JSON array of deleted image IDs
+    epfImagesDeleted :: Maybe Text,
+    -- | New image files from the imagesField
+    epfImageFiles :: [FileData Mem]
+  }
+  deriving (Show)
+
+instance FromMultipart Mem EditProductForm where
+  fromMultipart multipartData = do
+    name <- lookupInput "name" multipartData
+    let lookupOpt key = either (const Nothing) Just (lookupInput key multipartData)
+        description = fromMaybe "" (lookupOpt "description")
+        basePriceDollars = fromMaybe "" (lookupOpt "base_price_dollars")
+        weightOz = fromMaybe "" (lookupOpt "weight_oz")
+        category = lookupOpt "category"
+        isActive = lookupOpt "is_active"
+        sortOrder = fromMaybe "0" (lookupOpt "sort_order")
+        inventoryCount = lookupOpt "inventory_count"
+        variantsJson = lookupOpt "variants_json"
+        imagesData = lookupOpt "product_images_data"
+        imagesDeleted = lookupOpt "product_images_deleted"
+        imageFiles = getAllFiles "product_images_files" multipartData
+    pure
+      EditProductForm
+        { epfName = name,
+          epfDescription = description,
+          epfBasePriceDollars = basePriceDollars,
+          epfWeightOz = weightOz,
+          epfCategory = category,
+          epfIsActive = isActive,
+          epfSortOrder = sortOrder,
+          epfInventoryCount = inventoryCount,
+          epfVariantsJson = variantsJson,
+          epfImagesData = imagesData,
+          epfImagesDeleted = imagesDeleted,
+          epfImageFiles = imageFiles
+        }
+
+-- | Extract all files with a given input name from multipart data.
+--
+-- 'lookupFile' only returns the first match; this helper returns all files
+-- matching the specified field name (needed for multi-file uploads).
+getAllFiles :: Text -> MultipartData Mem -> [FileData Mem]
+getAllFiles fieldName md = filter (\fd -> fdInputName fd == fieldName) (files md)

--- a/services/web/src/API/Dashboard/Store/Products/Id/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Get/Handler.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.Store.Products.Id.Get.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Links (apiLinks, dashboardStoreProductsLinks, rootLink)
+import API.Types (DashboardStoreProductsRoutes (..), Routes (..))
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleHtmlErrors, throwDatabaseError, throwNotFound)
+import App.Monad (AppM)
+import Component.Flash (throwHxRedirect)
+import Control.Monad.Trans (lift)
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Products qualified as Products
+import Lucid qualified
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | Servant handler: verify the product exists, then redirect to its edit page.
+--
+-- The product detail URL exists as a stable redirect target (e.g. after
+-- creation).  All editing is done on the /edit sub-page.
+handler ::
+  Products.Id ->
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler productId cookie (foldHxReq -> _hxRequest) =
+  handleHtmlErrors "Product detail" apiLinks.rootGet $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "You do not have permission to view this page." userMetadata
+
+    -- Verify the product exists; 404 if not
+    mProduct <- fromRightM throwDatabaseError $ execQuery (Products.getById productId)
+    _product <- case mProduct of
+      Nothing -> throwNotFound "Product"
+      Just p -> pure p
+
+    -- Redirect to the edit page
+    lift $ throwHxRedirect (productEditUrl productId) Nothing
+
+--------------------------------------------------------------------------------
+
+-- | Build the edit URL for a product.
+productEditUrl :: Products.Id -> Text
+productEditUrl pid = rootLink $ dashboardStoreProductsLinks.editGet pid

--- a/services/web/src/API/Dashboard/Store/Products/Id/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Id/Get/Route.hs
@@ -1,0 +1,23 @@
+module API.Dashboard.Store.Products.Id.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Effects.Database.Tables.Products qualified as Products
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/store/products/:productId"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "products"
+    :> Servant.Capture "productId" Products.Id
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Settings/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Settings/Get/Handler.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.Store.Settings.Get.Handler (handler, action, SettingsViewData (..)) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Settings.Get.Templates (template)
+import API.Links (apiLinks)
+import API.Types (Routes (..))
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAdminNotSuspended, requireAuth)
+import App.Handler.Error (HandlerError, handleHtmlErrors, throwDatabaseError, throwHandlerFailure)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Either (fromRight)
+import Data.Maybe (listToMaybe)
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.Shows qualified as Shows
+import Effects.Database.Tables.StoreSettings qualified as StoreSettings
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Lucid qualified
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | All data needed to render the store settings page.
+data SettingsViewData = SettingsViewData
+  { svdUserMetadata :: UserMetadata.Model,
+    svdAllShows :: [Shows.Model],
+    svdSelectedShow :: Maybe Shows.Model,
+    svdSettings :: StoreSettings.Model
+  }
+
+-- | Business logic: fetch shows for sidebar, fetch store settings.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  ExceptT HandlerError AppM SettingsViewData
+action user userMetadata = do
+  -- 1. Fetch shows for sidebar
+  showsResult <-
+    if UserMetadata.isAdmin userMetadata.mUserRole
+      then execQuery Shows.getAllActiveShows
+      else execQuery (Shows.getShowsForUser (User.mId user))
+  let allShows = fromRight [] showsResult
+      selectedShow = listToMaybe allShows
+
+  -- 2. Fetch store settings (single-row table, id = 1)
+  settingsResult <- fromRightM throwDatabaseError $ execQuery StoreSettings.getSettings
+  settings <- case settingsResult of
+    Just s -> pure s
+    Nothing -> throwHandlerFailure "Store settings row not found (expected id = 1)"
+
+  pure
+    SettingsViewData
+      { svdUserMetadata = userMetadata,
+        svdAllShows = allShows,
+        svdSelectedShow = selectedShow,
+        svdSettings = settings
+      }
+
+-- | Servant handler: thin glue composing action + render with dashboard chrome.
+handler ::
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler cookie (foldHxReq -> hxRequest) =
+  handleHtmlErrors "Store settings" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireAdminNotSuspended "You do not have permission to access store settings." userMetadata
+    vd <- action user userMetadata
+    lift $
+      renderDashboardTemplate
+        hxRequest
+        vd.svdUserMetadata
+        vd.svdAllShows
+        vd.svdSelectedShow
+        NavStoreSettings
+        Nothing
+        Nothing
+        (template vd.svdSettings)

--- a/services/web/src/API/Dashboard/Store/Settings/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Settings/Get/Route.hs
@@ -1,0 +1,21 @@
+module API.Dashboard.Store.Settings.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/store/settings"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "settings"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Store/Settings/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Settings/Get/Templates.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module API.Dashboard.Store.Settings.Get.Templates (template) where
+
+--------------------------------------------------------------------------------
+
+import API.Links (dashboardStoreSettingsLinks, rootLink)
+import API.Types (DashboardStoreSettingsRoutes (..))
+import Data.Scientific (FPFormat (..), Scientific, formatScientific)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Effects.Database.Tables.StoreSettings qualified as StoreSettings
+import Lucid qualified
+import Lucid.Form.Builder
+
+--------------------------------------------------------------------------------
+
+-- | Store settings form template.
+--
+-- Displays all mutable store_settings fields and submits via HTMX POST.
+-- The form targets /dashboard/store/settings (POST).
+template :: StoreSettings.Model -> Lucid.Html ()
+template settings =
+  renderForm config form
+  where
+    postUrl :: Text
+    postUrl = rootLink dashboardStoreSettingsLinks.post
+
+    config :: FormConfig
+    config =
+      defaultFormConfig
+        { fcAction = postUrl,
+          fcMethod = "post",
+          fcHtmxTarget = Just "#main-content",
+          fcHtmxSwap = Just "innerHTML"
+        }
+
+    -- Display the stored fraction as a percentage for the form (0.095 → "9.500")
+    taxRateAsPercent :: Scientific
+    taxRateAsPercent = settings.ssTaxRate * 100
+
+    taxRateText :: Text
+    taxRateText = Text.pack $ formatScientific Fixed (Just 3) taxRateAsPercent
+
+    form :: FormBuilder
+    form = do
+      formTitle "STORE SETTINGS"
+
+      -- Tax section
+      section "TAX" $ do
+        textField "tax_rate" $ do
+          label "Tax Rate %"
+          placeholder "e.g. 9.500"
+          hint "Enter the tax rate as a percentage (e.g. 9.5 for 9.5%)"
+          value taxRateText
+          pattern' "[0-9]+(\\.[0-9]{1,3})?"
+          required
+
+      -- Shipping origin section
+      section "SHIP FROM ADDRESS" $ do
+        textField "ship_from_name" $ do
+          label "Ship From Name"
+          placeholder "e.g. KPBJ 95.9FM"
+          value settings.ssShipFromName
+          required
+          maxLength 200
+
+        textField "ship_from_address_line1" $ do
+          label "Address Line 1"
+          placeholder "e.g. 1234 Main St"
+          value settings.ssShipFromAddressLine1
+          required
+          maxLength 200
+
+        textField "ship_from_city" $ do
+          label "City"
+          placeholder "e.g. Shadow Hills"
+          value settings.ssShipFromCity
+          required
+          maxLength 100
+
+        textField "ship_from_state" $ do
+          label "State"
+          placeholder "e.g. CA"
+          value settings.ssShipFromState
+          required
+          maxLength 50
+
+        textField "ship_from_zip" $ do
+          label "ZIP Code"
+          placeholder "e.g. 91040"
+          value settings.ssShipFromZip
+          required
+          maxLength 20
+
+        textField "ship_from_country" $ do
+          label "Country"
+          placeholder "e.g. US"
+          value settings.ssShipFromCountry
+          required
+          maxLength 10
+
+      -- Notifications section
+      section "NOTIFICATIONS" $ do
+        textField "order_notification_email" $ do
+          label "Order Notification Email"
+          placeholder "e.g. store@kpbj.fm"
+          value settings.ssOrderNotificationEmail
+          required
+          maxLength 254
+
+      submitButton "SAVE SETTINGS"

--- a/services/web/src/API/Dashboard/Store/Settings/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Settings/Post/Handler.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module API.Dashboard.Store.Settings.Post.Handler (handler, action) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.Store.Settings.Post.Route (SettingsForm (..))
+import API.Links (apiLinks, dashboardStoreSettingsLinks, rootLink)
+import API.Types (DashboardStoreSettingsRoutes (..), Routes (..))
+import App.Handler.Combinators (requireAdminNotSuspended, requireAuth, requireRight)
+import App.Handler.Error (HandlerError, handleRedirectErrors, throwDatabaseError)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..))
+import Component.Flash (FlashMessage (..), flashCookie)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Domain.Types.Cookie (Cookie)
+import Effects.ContentSanitization qualified as Sanitize
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.StoreSettings qualified as StoreSettings
+import Effects.Database.Tables.User qualified as User
+import Effects.Database.Tables.UserMetadata qualified as UserMetadata
+import Log qualified
+import Servant qualified
+import Text.Read (readMaybe)
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | Parse and validate the settings form, producing an UpdateSettings value.
+--
+-- The form sends the tax rate as a percentage (e.g. "9.5" for 9.5%).
+-- We convert to a fraction (0.095) for storage.
+validateSettingsForm :: SettingsForm -> Either Text StoreSettings.UpdateSettings
+validateSettingsForm form = do
+  taxRatePercent <- case readMaybe @Scientific (Text.unpack form.sfTaxRate) of
+    Nothing -> Left ("Invalid tax rate: \"" <> form.sfTaxRate <> "\" is not a valid number")
+    Just d | d < 0 || d > 100 -> Left "Tax rate must be between 0 and 100"
+    Just d -> Right d
+  Right
+    StoreSettings.UpdateSettings
+      { StoreSettings.usTaxRate = taxRatePercent / 100,
+        StoreSettings.usShipFromName = Sanitize.sanitizePlainText form.sfShipFromName,
+        StoreSettings.usShipFromAddressLine1 = Sanitize.sanitizePlainText form.sfShipFromAddressLine1,
+        StoreSettings.usShipFromCity = Sanitize.sanitizePlainText form.sfShipFromCity,
+        StoreSettings.usShipFromState = Sanitize.sanitizePlainText form.sfShipFromState,
+        StoreSettings.usShipFromZip = Sanitize.sanitizePlainText form.sfShipFromZip,
+        StoreSettings.usShipFromCountry = Sanitize.sanitizePlainText form.sfShipFromCountry,
+        StoreSettings.usOrderNotificationEmail = Sanitize.sanitizePlainText form.sfOrderNotificationEmail
+      }
+
+-- | All data needed to build the post-update redirect.
+data SettingsRedirectData = SettingsRedirectData
+  { srdRedirectUrl :: Text,
+    srdFlash :: FlashMessage
+  }
+
+-- | Business logic: validate form, update settings, build redirect data.
+action ::
+  User.Model ->
+  UserMetadata.Model ->
+  SettingsForm ->
+  ExceptT HandlerError AppM SettingsRedirectData
+action _user _userMetadata form = do
+  -- 1. Validate form fields
+  update <- requireRight id (validateSettingsForm form)
+
+  -- 2. Persist settings
+  fromRightM throwDatabaseError $ execQuery (StoreSettings.updateSettings update)
+
+  -- 3. Build redirect data
+  Log.logInfo "Store settings updated successfully" ()
+
+  let redirectUrl = rootLink dashboardStoreSettingsLinks.get
+      flash = FlashMessage Success "Settings Saved" "Store settings have been updated successfully."
+  pure $ SettingsRedirectData redirectUrl flash
+
+-- | Servant handler: thin glue composing action + building redirect response.
+handler ::
+  Maybe Cookie ->
+  SettingsForm ->
+  AppM (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
+handler cookie form =
+  handleRedirectErrors "Store settings update" apiLinks.rootGet $ do
+    (user, userMetadata) <- requireAuth cookie
+    requireAdminNotSuspended "You do not have permission to update store settings." userMetadata
+    vd <- action user userMetadata form
+    pure $ Servant.addHeader vd.srdRedirectUrl $ Servant.addHeader (flashCookie (Just vd.srdFlash)) Servant.NoContent

--- a/services/web/src/API/Dashboard/Store/Settings/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Store/Settings/Post/Route.hs
@@ -1,0 +1,60 @@
+module API.Dashboard.Store.Settings.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+import Web.FormUrlEncoded (FromForm (..))
+import Web.FormUrlEncoded qualified as Form
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/store/settings"
+type Route =
+  "dashboard"
+    :> "store"
+    :> "settings"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.ReqBody '[Servant.FormUrlEncoded] SettingsForm
+    :> Servant.Post '[HTML] (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
+
+--------------------------------------------------------------------------------
+
+-- | Form data for updating store settings.
+data SettingsForm = SettingsForm
+  { sfTaxRate :: Text,
+    sfShipFromName :: Text,
+    sfShipFromAddressLine1 :: Text,
+    sfShipFromCity :: Text,
+    sfShipFromState :: Text,
+    sfShipFromZip :: Text,
+    sfShipFromCountry :: Text,
+    sfOrderNotificationEmail :: Text
+  }
+  deriving (Show)
+
+instance FromForm SettingsForm where
+  fromForm :: Form.Form -> Either Text SettingsForm
+  fromForm form = do
+    taxRate <- Form.parseUnique "tax_rate" form
+    shipFromName <- Form.parseUnique "ship_from_name" form
+    shipFromAddressLine1 <- Form.parseUnique "ship_from_address_line1" form
+    shipFromCity <- Form.parseUnique "ship_from_city" form
+    shipFromState <- Form.parseUnique "ship_from_state" form
+    shipFromZip <- Form.parseUnique "ship_from_zip" form
+    shipFromCountry <- Form.parseUnique "ship_from_country" form
+    orderNotificationEmail <- Form.parseUnique "order_notification_email" form
+    pure
+      SettingsForm
+        { sfTaxRate = taxRate,
+          sfShipFromName = shipFromName,
+          sfShipFromAddressLine1 = shipFromAddressLine1,
+          sfShipFromCity = shipFromCity,
+          sfShipFromState = shipFromState,
+          sfShipFromZip = shipFromZip,
+          sfShipFromCountry = shipFromCountry,
+          sfOrderNotificationEmail = orderNotificationEmail
+        }

--- a/services/web/src/API/Links.hs
+++ b/services/web/src/API/Links.hs
@@ -45,6 +45,10 @@ module API.Links
     dashboardMissingEpisodesLink,
     dashboardAnalyticsLinks,
     dashboardInvitationsLinks,
+    dashboardStoreLinks,
+    dashboardStoreProductsLinks,
+    dashboardStoreSettingsLinks,
+    dashboardStoreOrdersLinks,
     inviteLinks,
     staticAssetLink,
   )
@@ -179,3 +183,19 @@ inviteLinks = apiLinks.invite
 -- | Static asset link by filename.
 staticAssetLink :: Text -> Link
 staticAssetLink = apiLinks.staticGet
+
+-- | Dashboard store route links.
+dashboardStoreLinks :: DashboardStoreRoutes (AsLink Link)
+dashboardStoreLinks = dashboardAdminLinks.store
+
+-- | Dashboard store products route links.
+dashboardStoreProductsLinks :: DashboardStoreProductsRoutes (AsLink Link)
+dashboardStoreProductsLinks = dashboardStoreLinks.products
+
+-- | Dashboard store settings route links.
+dashboardStoreSettingsLinks :: DashboardStoreSettingsRoutes (AsLink Link)
+dashboardStoreSettingsLinks = dashboardStoreLinks.settings
+
+-- | Dashboard store orders route links.
+dashboardStoreOrdersLinks :: DashboardStoreOrdersRoutes (AsLink Link)
+dashboardStoreOrdersLinks = dashboardStoreLinks.orders

--- a/services/web/src/API/Types.hs
+++ b/services/web/src/API/Types.hs
@@ -29,6 +29,10 @@ module API.Types
     DashboardSitePagesRoutes (..),
     DashboardStreamSettingsRoutes (..),
     DashboardAnalyticsRoutes (..),
+    DashboardStoreRoutes (..),
+    DashboardStoreProductsRoutes (..),
+    DashboardStoreSettingsRoutes (..),
+    DashboardStoreOrdersRoutes (..),
     UploadRoutes (..),
     PlayoutRoutes (..),
     AnalyticsRoutes (..),
@@ -107,6 +111,15 @@ import API.Dashboard.StationIds.Get.Route qualified as Dashboard.StationIds.Get
 import API.Dashboard.StationIds.Id.Delete.Route qualified as Dashboard.StationIds.Id.Delete
 import API.Dashboard.StationIds.New.Get.Route qualified as Dashboard.StationIds.New.Get
 import API.Dashboard.StationIds.New.Post.Route qualified as Dashboard.StationIds.New.Post
+import API.Dashboard.Store.Orders.Get.Route qualified as Dashboard.Store.Orders.Get
+import API.Dashboard.Store.Products.Create.Post.Route qualified as Dashboard.Store.Products.Create.Post
+import API.Dashboard.Store.Products.Get.Route qualified as Dashboard.Store.Products.Get
+import API.Dashboard.Store.Products.Id.Deactivate.Post.Route qualified as Dashboard.Store.Products.Id.Deactivate.Post
+import API.Dashboard.Store.Products.Id.Edit.Get.Route qualified as Dashboard.Store.Products.Id.Edit.Get
+import API.Dashboard.Store.Products.Id.Edit.Post.Route qualified as Dashboard.Store.Products.Id.Edit.Post
+import API.Dashboard.Store.Products.Id.Get.Route qualified as Dashboard.Store.Products.Id.Get
+import API.Dashboard.Store.Settings.Get.Route qualified as Dashboard.Store.Settings.Get
+import API.Dashboard.Store.Settings.Post.Route qualified as Dashboard.Store.Settings.Post
 import API.Dashboard.StreamSettings.Episodes.Search.Get.Route qualified as Dashboard.StreamSettings.Episodes.Search.Get
 import API.Dashboard.StreamSettings.ForceEpisode.Post.Route qualified as Dashboard.StreamSettings.ForceEpisode.Post
 import API.Dashboard.StreamSettings.Get.Route qualified as Dashboard.StreamSettings.Get
@@ -377,7 +390,9 @@ data DashboardAdminRoutes mode = DashboardAdminRoutes
     -- | @GET /dashboard/missing-episodes@ - Shows missing episode uploads
     missingEpisodes :: mode :- Dashboard.MissingEpisodes.Get.Route,
     -- | @/dashboard/analytics/...@ - Analytics dashboard routes
-    analytics :: mode :- NamedRoutes DashboardAnalyticsRoutes
+    analytics :: mode :- NamedRoutes DashboardAnalyticsRoutes,
+    -- | @/dashboard/store/...@ - Store management routes
+    store :: mode :- NamedRoutes DashboardStoreRoutes
   }
   deriving stock (Generic)
 
@@ -612,6 +627,52 @@ data DashboardInvitationsRoutes mode = DashboardInvitationsRoutes
     regenerate :: mode :- Dashboard.Invitations.Regenerate.Route,
     -- | @DELETE /dashboard/invitations/:invitationId@ - Revoke invitation
     delete :: mode :- Dashboard.Invitations.Delete.Route
+  }
+  deriving stock (Generic)
+
+-- | Dashboard store management routes under @/dashboard/store@.
+--
+-- For staff and admins to manage the online store: products, orders, and settings.
+data DashboardStoreRoutes mode = DashboardStoreRoutes
+  { -- | @/dashboard/store/products/...@ - Product management routes
+    products :: mode :- NamedRoutes DashboardStoreProductsRoutes,
+    -- | @/dashboard/store/orders/...@ - Order management routes
+    orders :: mode :- NamedRoutes DashboardStoreOrdersRoutes,
+    -- | @/dashboard/store/settings/...@ - Store settings routes
+    settings :: mode :- NamedRoutes DashboardStoreSettingsRoutes
+  }
+  deriving stock (Generic)
+
+-- | Dashboard store product management routes under @/dashboard/store/products@.
+data DashboardStoreProductsRoutes mode = DashboardStoreProductsRoutes
+  { -- | @GET /dashboard/store/products@ - Product list
+    list :: mode :- Dashboard.Store.Products.Get.Route,
+    -- | @POST /dashboard/store/products/create@ - Inline create product
+    inlineCreate :: mode :- Dashboard.Store.Products.Create.Post.Route,
+    -- | @GET /dashboard/store/products/:id@ - Product detail
+    detail :: mode :- Dashboard.Store.Products.Id.Get.Route,
+    -- | @GET /dashboard/store/products/:id/edit@ - Edit product form
+    editGet :: mode :- Dashboard.Store.Products.Id.Edit.Get.Route,
+    -- | @POST /dashboard/store/products/:id/edit@ - Update product
+    editPost :: mode :- Dashboard.Store.Products.Id.Edit.Post.Route,
+    -- | @POST /dashboard/store/products/:id/deactivate@ - Deactivate product
+    deactivate :: mode :- Dashboard.Store.Products.Id.Deactivate.Post.Route
+  }
+  deriving stock (Generic)
+
+-- | Dashboard store settings routes under @/dashboard/store/settings@.
+data DashboardStoreSettingsRoutes mode = DashboardStoreSettingsRoutes
+  { -- | @GET /dashboard/store/settings@ - Store settings page
+    get :: mode :- Dashboard.Store.Settings.Get.Route,
+    -- | @POST /dashboard/store/settings@ - Update store settings
+    post :: mode :- Dashboard.Store.Settings.Post.Route
+  }
+  deriving stock (Generic)
+
+-- | Dashboard store orders routes under @/dashboard/store/orders@.
+newtype DashboardStoreOrdersRoutes mode = DashboardStoreOrdersRoutes
+  { -- | @GET /dashboard/store/orders@ - Order list
+    list :: mode :- Dashboard.Store.Orders.Get.Route
   }
   deriving stock (Generic)
 

--- a/services/web/src/Component/DashboardFrame.hs
+++ b/services/web/src/Component/DashboardFrame.hs
@@ -24,6 +24,9 @@ import API.Links
     dashboardSitePagesLinks,
     dashboardStationBlogLinks,
     dashboardStationIdsLinks,
+    dashboardStoreOrdersLinks,
+    dashboardStoreProductsLinks,
+    dashboardStoreSettingsLinks,
     dashboardStreamSettingsLinks,
     dashboardUsersLinks,
     rootLink,
@@ -108,6 +111,15 @@ dashboardAnalyticsGetUrl = Links.linkURI dashboardAnalyticsLinks.get
 dashboardInvitationsGetUrl :: Links.URI
 dashboardInvitationsGetUrl = Links.linkURI dashboardInvitationsLinks.list
 
+dashboardStoreProductsGetUrl :: Links.URI
+dashboardStoreProductsGetUrl = Links.linkURI dashboardStoreProductsLinks.list
+
+dashboardStoreOrdersGetUrl :: Links.URI
+dashboardStoreOrdersGetUrl = Links.linkURI dashboardStoreOrdersLinks.list
+
+dashboardStoreSettingsGetUrl :: Links.URI
+dashboardStoreSettingsGetUrl = Links.linkURI dashboardStoreSettingsLinks.get
+
 --------------------------------------------------------------------------------
 
 -- | Which navigation item is currently active
@@ -127,6 +139,9 @@ data DashboardNav
   | NavMissingEpisodes
   | NavAnalytics
   | NavInvitations
+  | NavStoreProducts
+  | NavStoreOrders
+  | NavStoreSettings
   deriving (Eq, Show)
 
 -- | Check if navigation requires show context
@@ -147,6 +162,9 @@ isShowScoped = \case
   NavMissingEpisodes -> False
   NavAnalytics -> False
   NavInvitations -> False
+  NavStoreProducts -> False
+  NavStoreOrders -> False
+  NavStoreSettings -> False
 
 -- | Dashboard frame template - full page liquid layout with sidebar
 template ::
@@ -240,6 +258,13 @@ sidebar userMeta activeNav selectedShow =
             when (UserMetadata.isAdmin userMeta.mUserRole) $ do
               staffNavItem "STREAM" NavStreamSettings activeNav
               staffNavItem "ANALYTICS" NavAnalytics activeNav
+        Lucid.div_ [class_ $ base ["border-t", Theme.borderMuted, "mt-4", "pt-4"]] $ do
+          Lucid.span_ [class_ $ base [Tokens.textXs, Tokens.fgMuted, "block", Tokens.px4, Tokens.mb2]] "STORE"
+          Lucid.ul_ [Lucid.class_ "space-y-2"] $ do
+            staffNavItem "PRODUCTS" NavStoreProducts activeNav
+            staffNavItem "ORDERS" NavStoreOrders activeNav
+            when (UserMetadata.isAdmin userMeta.mUserRole) $
+              staffNavItem "SETTINGS" NavStoreSettings activeNav
 
     -- User info at bottom (always visible)
     Lucid.div_ [class_ $ base [Tokens.p4, "border-t", Theme.borderMuted, "shrink-0", "mt-auto"]] $ do
@@ -347,6 +372,9 @@ staffNavUrl = \case
   NavMissingEpisodes -> Just dashboardMissingEpisodesGetUrl
   NavAnalytics -> Just dashboardAnalyticsGetUrl
   NavInvitations -> Just dashboardInvitationsGetUrl
+  NavStoreProducts -> Just dashboardStoreProductsGetUrl
+  NavStoreOrders -> Just dashboardStoreOrdersGetUrl
+  NavStoreSettings -> Just dashboardStoreSettingsGetUrl
   other -> navUrl other Nothing
 
 -- | Get URL for navigation item
@@ -371,6 +399,9 @@ navUrl nav mShow =
         NavMissingEpisodes -> Just dashboardMissingEpisodesGetUrl
         NavAnalytics -> Just dashboardAnalyticsGetUrl
         NavInvitations -> Just dashboardInvitationsGetUrl
+        NavStoreProducts -> Just dashboardStoreProductsGetUrl
+        NavStoreOrders -> Just dashboardStoreOrdersGetUrl
+        NavStoreSettings -> Just dashboardStoreSettingsGetUrl
 
 -- | Top bar with show selector, stats, action button, and back link
 topBar :: DashboardNav -> [Shows.Model] -> Maybe Shows.Model -> Maybe (Lucid.Html ()) -> Maybe (Lucid.Html ()) -> Lucid.Html ()

--- a/services/web/src/Domain/Types/VariantsPayload.hs
+++ b/services/web/src/Domain/Types/VariantsPayload.hs
@@ -1,0 +1,66 @@
+module Domain.Types.VariantsPayload
+  ( VariantsPayload (..),
+    OptionPayload (..),
+    VariantPayload (..),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
+import Data.Int (Int64)
+import Data.Text (Text)
+import Domain.Types.Cents (Cents)
+import Effects.Database.Tables.ProductVariants qualified as ProductVariants
+import GHC.Generics (Generic)
+
+--------------------------------------------------------------------------------
+
+-- | Top-level payload for options + variants JSON from the edit form.
+data VariantsPayload = VariantsPayload
+  { vpOptions :: [OptionPayload],
+    vpVariants :: [VariantPayload],
+    vpDeletedVariantIds :: [ProductVariants.Id]
+  }
+  deriving stock (Generic, Show, Eq)
+
+instance FromJSON VariantsPayload where
+  parseJSON = withObject "VariantsPayload" $ \o ->
+    VariantsPayload
+      <$> o .: "options"
+      <*> o .: "variants"
+      <*> o .: "deleted_variant_ids"
+
+-- | A single option type with its values.
+data OptionPayload = OptionPayload
+  { opName :: Text,
+    opValues :: [Text]
+  }
+  deriving stock (Generic, Show, Eq)
+
+instance FromJSON OptionPayload where
+  parseJSON = withObject "OptionPayload" $ \o ->
+    OptionPayload
+      <$> o .: "name"
+      <*> o .: "values"
+
+-- | A single variant with optional overrides.
+data VariantPayload = VariantPayload
+  { vplId :: Maybe ProductVariants.Id,
+    vplOptionValues :: [Text],
+    vplPriceCents :: Maybe Cents,
+    vplInventoryCount :: Int64,
+    vplSku :: Maybe Text,
+    vplWeightOz :: Maybe Int64
+  }
+  deriving stock (Generic, Show, Eq)
+
+instance FromJSON VariantPayload where
+  parseJSON = withObject "VariantPayload" $ \o ->
+    VariantPayload
+      <$> o .:? "id"
+      <*> o .: "option_values"
+      <*> o .:? "price_cents"
+      <*> o .: "inventory_count"
+      <*> o .:? "sku"
+      <*> o .:? "weight_oz"

--- a/services/web/src/Effects/ContentSanitization.hs
+++ b/services/web/src/Effects/ContentSanitization.hs
@@ -19,14 +19,20 @@ module Effects.ContentSanitization
     validateContentLength,
     ContentValidationError (..),
     displayContentValidationError,
+
+    -- * Numeric Parsing
+    parseIntDefault0,
+    parseNonNegativeInt,
   )
 where
 
 --------------------------------------------------------------------------------
 
+import Data.Int (Int64)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Text.HTML.SanitizeXSS (sanitizeXSS)
+import Text.Read (readMaybe)
 
 --------------------------------------------------------------------------------
 -- Content Validation
@@ -106,6 +112,33 @@ sanitizeTitle title =
 sanitizeDescription :: Text -> Text
 sanitizeDescription desc =
   Text.strip $ sanitizeXSS $ Text.take 1000 desc
+
+--------------------------------------------------------------------------------
+-- Numeric Parsing
+
+-- | Parse a non-negative integer from text, defaulting to 0 on failure.
+--
+-- Use for fields where 0 is a safe default (weight, sort order).
+-- For fields where silent zeroing is dangerous (inventory), use 'parseNonNegativeInt'.
+parseIntDefault0 :: Text -> Int64
+parseIntDefault0 txt =
+  case readMaybe (Text.unpack txt) :: Maybe Int64 of
+    Just n | n >= 0 -> n
+    _ -> 0
+
+-- | Parse a non-negative integer from text, returning an error on failure.
+--
+-- Use for fields where the value matters and silent defaulting would be data loss
+-- (e.g., inventory count).
+parseNonNegativeInt :: Text -> Either Text Int64
+parseNonNegativeInt txt =
+  case readMaybe (Text.unpack txt) :: Maybe Int64 of
+    Just n | n >= 0 -> Right n
+    Just _ -> Left "Value must be non-negative"
+    Nothing -> Left "Invalid number"
+
+--------------------------------------------------------------------------------
+-- Content Sanitization
 
 -- | Sanitize plain text fields
 --

--- a/services/web/src/Effects/FileUpload.hs
+++ b/services/web/src/Effects/FileUpload.hs
@@ -6,6 +6,7 @@ module Effects.FileUpload
     uploadShowLogo,
     uploadBlogHeroImage,
     uploadEventPosterImage,
+    uploadProductImage,
     uploadUserAvatar,
 
     -- * Helper functions
@@ -73,7 +74,7 @@ uploadEpisodeArtwork backend mAwsEnv showSlug mScheduledDate fileData
 
         -- Get time and random seed
         time <- liftIO $ maybe getCurrentTime pure mScheduledDate
-        seed <- liftIO Random.getStdGen
+        seed <- liftIO Random.newStdGen
 
         -- Validate with browser-provided MIME type and file size
         liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize
@@ -128,7 +129,7 @@ uploadShowLogo backend mAwsEnv showSlug fileData
 
         -- Get time and random seed
         time <- liftIO getCurrentTime
-        seed <- liftIO Random.getStdGen
+        seed <- liftIO Random.newStdGen
 
         -- Validate with browser-provided MIME type and file size
         liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize
@@ -182,7 +183,7 @@ uploadBlogHeroImage backend mAwsEnv postSlug fileData
 
         -- Get time and random seed
         time <- liftIO getCurrentTime
-        seed <- liftIO Random.getStdGen
+        seed <- liftIO Random.newStdGen
 
         -- Validate with browser-provided MIME type and file size
         liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize
@@ -236,7 +237,7 @@ uploadEventPosterImage backend mAwsEnv eventSlug fileData
 
         -- Get time and random seed
         time <- liftIO getCurrentTime
-        seed <- liftIO Random.getStdGen
+        seed <- liftIO Random.newStdGen
 
         -- Validate with browser-provided MIME type and file size
         liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize
@@ -252,6 +253,62 @@ uploadEventPosterImage backend mAwsEnv eventSlug fileData
 
         -- Store file using appropriate backend
         objectKey <- ExceptT $ storeFile backend mAwsEnv ImageBucket EventPosterImage dateHier filename content actualMimeType
+
+        pure $
+          Just
+            UploadResult
+              { uploadResultOriginalName = originalName,
+                uploadResultStoragePath = Text.unpack objectKey,
+                uploadResultMimeType = actualMimeType,
+                uploadResultFileSize = fileSize
+              }
+
+-- | Upload an image for a store product.
+--
+-- Validates the image file using both browser-provided MIME type and magic byte detection,
+-- then stores it using the configured storage backend.
+--
+-- Returns 'Nothing' if no file was provided (empty upload).
+-- Product images are optional but when provided must pass validation.
+--
+-- Storage path format: images\/store\/{YYYY}\/{MM}\/{DD}\/{product-slug}_{hash}.{ext}
+uploadProductImage ::
+  (MonadIO m, MonadMask m, Log.MonadLog m) =>
+  -- | Storage backend configuration
+  StorageBackend ->
+  -- | AWS environment (required for S3, Nothing for local)
+  Maybe AWS.Env ->
+  -- | Product slug for filename prefix
+  Text ->
+  -- | Uploaded product image file data
+  FileData Mem ->
+  m (Either UploadError (Maybe UploadResult))
+uploadProductImage backend mAwsEnv productSlug fileData
+  | isEmptyUpload fileData = pure (Right Nothing)
+  | otherwise =
+      withTempUpload fileData $ \tempPath content -> runExceptT $ do
+        let originalName = fdFileName fileData
+            browserMimeType = fdFileCType fileData
+            fileSize = fromIntegral $ BS.length content
+
+        -- Get time and random seed
+        time <- liftIO getCurrentTime
+        seed <- liftIO Random.newStdGen
+
+        -- Validate with browser-provided MIME type and file size
+        liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize
+
+        -- Validate actual file content against magic bytes
+        actualMimeType <- ExceptT $ do
+          either (Left . UnsupportedFileType) Right <$> MimeValidation.validateImageFile tempPath browserMimeType
+
+        -- Generate filename and date hierarchy
+        let dateHier = dateHierarchyFromTime time
+            extension = getExtensionFromMimeType actualMimeType
+            filename = generateUniqueFilename productSlug extension seed
+
+        -- Store file using appropriate backend
+        objectKey <- ExceptT $ storeFile backend mAwsEnv ImageBucket ProductImage dateHier filename content actualMimeType
 
         pure $
           Just
@@ -290,7 +347,7 @@ uploadUserAvatar backend mAwsEnv userId fileData
 
         -- Get time and random seed
         time <- liftIO getCurrentTime
-        seed <- liftIO Random.getStdGen
+        seed <- liftIO Random.newStdGen
 
         -- Validate with browser-provided MIME type and file size
         liftEither $ validateUpload ImageBucket originalName browserMimeType fileSize

--- a/services/web/static/forms.css
+++ b/services/web/static/forms.css
@@ -623,6 +623,80 @@
 }
 
 /* ==========================================================================
+   Multi-Image Picker (imagesField)
+   ========================================================================== */
+
+.fb-images-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--fb-images-thumb-size, 150px), 1fr));
+  gap: 12px;
+}
+
+.fb-images-card {
+  border: 2px solid var(--theme-border-muted);
+  position: relative;
+}
+
+.fb-images-card--drag-over {
+  border-color: var(--theme-accent, var(--theme-border));
+}
+
+.fb-images-card-img {
+  width: 100%;
+  aspect-ratio: var(--fb-images-aspect-ratio, 1 / 1);
+  object-fit: cover;
+  display: block;
+}
+
+.fb-images-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  cursor: pointer;
+  background: var(--theme-bg);
+  border: 1px solid var(--theme-border-muted);
+  line-height: 1;
+  padding: 2px 6px;
+  color: var(--theme-fg);
+  font-family: inherit;
+}
+
+.fb-images-remove:hover {
+  background: var(--theme-hover);
+}
+
+.fb-images-alt-input {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 0.75rem;
+  padding: 4px;
+  border: none;
+  border-top: 1px solid var(--theme-border-muted);
+  background: var(--theme-bg);
+  color: var(--theme-fg);
+  font-family: inherit;
+}
+
+.fb-images-add-zone {
+  border: 2px dashed var(--theme-border-muted);
+  aspect-ratio: var(--fb-images-aspect-ratio, 1 / 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  min-height: var(--fb-images-thumb-size, 150px);
+}
+
+.fb-images-add-zone:hover {
+  border-color: var(--theme-border);
+}
+
+.fb-images-add-label {
+  color: var(--theme-fg-muted);
+  font-size: 0.875rem;
+}
+
+/* ==========================================================================
    Audio Picker
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
- **Product management dashboard** — CRUD for store products with inline creation, full edit page (pricing, inventory, images, options/variants), and deactivation
- **Database schema** — 9 new tables (products, images, option types/values, variants, variant options, orders, order items, store settings) with `products_with_inventory` view
- **Form builder `imagesField`** — Multi-image upload with Cropper.js, drag-and-drop reorder, alt text, shared cropper helpers
- **Store settings** — Admin page for tax rate, ship-from address, notification email
- **Orders placeholder** — Dashboard page for Phase 3 checkout integration
- **`Cents` newtype** — Type-safe price representation with property tests
- **Comprehensive test suite** — Property tests for all DB table modules including generators

## Test plan
- [x] `cabal build all` compiles with no warnings on branch-touched files
- [x] `just test` passes all existing + new property tests
- [x] Product CRUD flow: create, edit details/images/variants, deactivate
- [x] Image uploads work in dev (local storage) and staging (S3)
- [x] Store settings save and load correctly
- [x] Dashboard nav shows Store section for Staff+, Settings for Admin only