### PR TITLE
Webstore Phase 5: Production hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ### Improved
 - **Webstore — Checkout Loading States** — Loading indicators and double-submit prevention on "Get Shipping Rates" and "Proceed to Payment" buttons. "Preparing payment..." message while Stripe iframe mounts.
 - **Webstore — Checkout Error Recovery** — Replaced browser `alert()` on checkout failure with inline error banner. Stripe initialization wrapped in try/catch with fallback to rates step. Fixed stuck "Processing..." button when session creation fails.
-- **Webstore — Dashboard Empty States** — Dashboard orders list shows "No orders yet" when empty, matching the existing pattern used by Events, Blog, Shows, and Users.
+- **Webstore — Dashboard Empty States** — Dashboard orders list and products list show empty state messages when no data exists. Products empty state hides when the inline create form is opened.
 - **Upload Auth Error Message** — Staged upload fields (audio and image) now show a helpful message when authentication fails during upload, guiding the user to refresh/re-login or check browser cookie settings. Previously showed the opaque "Authentication required".
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ### Fixed
 - **PayPal Donate Button Broken** — The Content-Security-Policy `connect-src` directive was missing `https://api.paypal.com`, blocking the PayPal SDK from exchanging an OAuth token to create an order. Added `api.paypal.com` to `connect-src` in `SecurityHeaders.hs`.
+- **Cloudflare WAF Rules** — Fixed WAF rule for non-ASCII percent-encoded bytes to correctly match high-byte patterns in URI paths.
+- **DMARC Reporting** — Added DMARC reporting email address to DNS record so delivery failures are reported back.
 - **Logout 401 Error** — Logout routes used `AuthProtect "cookie-auth"` (Servant auth middleware with 30-minute idle timeout), while all other routes use `Maybe Cookie` with in-handler auth (no idle timeout). After 30+ minutes of dashboard activity, the idle timeout would reject the logout request with 401 before the handler could run. Switched logout to the same `Maybe Cookie` pattern so it always succeeds — expires the session if valid, clears the cookie regardless.
 - **S3 Sync File Extension Preservation** — The prod-to-staging S3 sync script was downloading files to a generic temp path (`transfer`) with no extension, then re-uploading. This could cause incorrect content-type inference on the staging bucket. Now preserves the original file extension during transfer (`transfer.$ext`).
 - **Overnight Replay Detection** — Fixed currently-airing query Case 5 (overnight replay before-midnight portion) not correctly handling episodes whose duration fills or exceeds the time until midnight. The old +12h code fell through to a simple comparison that failed when the replay duration crossed midnight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Webstore — Rate Limiting** — Per-IP rate limiting on public store API endpoints via `wai-rate-limit` with an in-memory backend. `/api/store/shipping-rates` limited to 10 req/min, `/api/store/checkout/create-session` limited to 5 req/min. Client IP extracted from `CF-Connecting-IP` or `X-Forwarded-For` headers. Background thread purges expired entries every 5 minutes.
 - **Webstore — Checkout Flow** — Guest checkout at `/store/checkout` with address form, real-time shipping rate selection (EasyPost), and Stripe Embedded Checkout for payment. Creates a pending order with inventory reservation, redirects to Stripe, and confirms via webhook. Order confirmation page at `/store/orders/confirmation`.
 - **Webstore — Order Emails** — Confirmation and shipping notification emails. Confirmation includes order number, itemized line items, shipping address, and totals. Shipping email includes tracking number when available.
 - **Webstore — Stripe Integration** — New `stripe-http` library with Checkout Session creation, session retrieval, and webhook signature verification (HMAC-SHA256, timing-safe, 300s replay window). Raw body capture via custom Servant `RawBody` content type.
@@ -46,6 +47,9 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 - **Episode Check SMTP Config** — The `kpbj-episode-check` systemd service was missing non-secret SMTP environment variables (`APP_SMTP_SERVER`, `APP_SMTP_PORT`, `APP_SMTP_USERNAME`, `APP_SMTP_FROM_EMAIL`, `APP_SMTP_FROM_NAME`), causing it to fail with "SMTP not configured" on every run. The env file only contained the password. Added an `environment` block sourcing these from the web module config.
 
 ### Improved
+- **Webstore — Checkout Loading States** — Loading indicators and double-submit prevention on "Get Shipping Rates" and "Proceed to Payment" buttons. "Preparing payment..." message while Stripe iframe mounts.
+- **Webstore — Checkout Error Recovery** — Replaced browser `alert()` on checkout failure with inline error banner. Stripe initialization wrapped in try/catch with fallback to rates step. Fixed stuck "Processing..." button when session creation fails.
+- **Webstore — Dashboard Empty States** — Dashboard orders list shows "No orders yet" when empty, matching the existing pattern used by Events, Blog, Shows, and Users.
 - **Upload Auth Error Message** — Staged upload fields (audio and image) now show a helpful message when authentication fails during upload, guiding the user to refresh/re-login or check browser cookie settings. Previously showed the opaque "Authentication required".
 
 ---

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -101,6 +101,7 @@ library
                   , stripe-http
                   , tagged
                   , temporary
+                  , stm
                   , text
                   , text-display
                   , time
@@ -114,6 +115,7 @@ library
                   , vector
                   , wai
                   , wai-extra
+                  , wai-rate-limit
                   , warp
                   , web-server-core
                   , witherable
@@ -565,6 +567,7 @@ library
     Effects.Storage.S3
     Helpers.RelativeTime
     Middleware.NotFound
+    Middleware.RateLimit
     Middleware.SecurityHeaders
     Middleware.ValidateEncoding
     Utils

--- a/services/web/src/API.hs
+++ b/services/web/src/API.hs
@@ -202,6 +202,7 @@ import Component.NotFound (notFoundPage)
 import Data.Has (getter)
 import Lucid qualified
 import Middleware.NotFound (notFoundMiddleware)
+import Middleware.RateLimit (rateLimitMiddleware)
 import Middleware.SecurityHeaders (securityHeadersMiddleware)
 import Middleware.ValidateEncoding (validateEncodingMiddleware)
 import Network.Wai.Handler.Warp qualified as Warp
@@ -224,6 +225,8 @@ runApi = do
 
   App.withAppResources () $ \baseAppCtx ->
     buildCustomContext baseAppCtx configs $ \customCtx -> do
+      rateLimiter <- rateLimitMiddleware
+
       let appCtx = baseAppCtx {appCustom = customCtx}
 
           -- Pre-render the 404 page at startup (no user context)
@@ -235,6 +238,7 @@ runApi = do
           app =
             validateEncodingMiddleware
               . securityHeadersMiddleware
+              . rateLimiter
               . notFoundMiddleware notFoundHtml
               $ App.mkApp @API (const server) servantCtx appCtx
 

--- a/services/web/src/API/Dashboard/Store/Orders/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Get/Templates.hs
@@ -20,6 +20,7 @@ import Data.Text (Text)
 import Data.Text.Display (display)
 import Data.Time (UTCTime, defaultTimeLocale, formatTime)
 import Design (base, class_)
+import Design.Theme qualified as Theme
 import Design.Tokens qualified as Tokens
 import Domain.Types.Cents qualified as Cents
 import Effects.Database.Tables.Orders qualified as Orders
@@ -31,20 +32,23 @@ import Lucid qualified
 template :: [Orders.Model] -> Lucid.Html ()
 template orders =
   Lucid.section_ [class_ $ base [Tokens.bgMain, "rounded", "overflow-hidden", Tokens.mb8]] $
-    renderIndexTable
-      IndexTableConfig
-        { itcBodyId = "orders-table-body",
-          itcHeaders =
-            [ ColumnHeader "Order" AlignLeft,
-              ColumnHeader "Date" AlignLeft,
-              ColumnHeader "Customer" AlignLeft,
-              ColumnHeader "Status" AlignLeft,
-              ColumnHeader "Total" AlignRight
-            ],
-          itcNextPageUrl = Nothing,
-          itcPaginationConfig = Nothing
-        }
-      (mapM_ renderOrderRow orders)
+    if null orders
+      then renderEmptyState
+      else
+        renderIndexTable
+          IndexTableConfig
+            { itcBodyId = "orders-table-body",
+              itcHeaders =
+                [ ColumnHeader "Order" AlignLeft,
+                  ColumnHeader "Date" AlignLeft,
+                  ColumnHeader "Customer" AlignLeft,
+                  ColumnHeader "Status" AlignLeft,
+                  ColumnHeader "Total" AlignRight
+                ],
+              itcNextPageUrl = Nothing,
+              itcPaginationConfig = Nothing
+            }
+          (mapM_ renderOrderRow orders)
 
 renderOrderRow :: Orders.Model -> Lucid.Html ()
 renderOrderRow order =
@@ -88,6 +92,12 @@ statusColors = \case
   Orders.Completed -> (Tokens.successBg, Tokens.successText)
   Orders.Cancelled -> (Tokens.errorBg, Tokens.errorText)
   Orders.Refunded -> (Tokens.warningBg, Tokens.warningText)
+
+renderEmptyState :: Lucid.Html ()
+renderEmptyState = do
+  Lucid.div_ [class_ $ base [Theme.bgAlt, Tokens.border2, Theme.borderMuted, "p-12", "text-center"]] $ do
+    Lucid.p_ [class_ $ base [Tokens.textXl, Theme.fgMuted]] "No orders yet."
+    Lucid.p_ [class_ $ base [Theme.fgMuted, "mt-2"]] "Orders will appear here once customers complete purchases."
 
 formatDate :: UTCTime -> Text
 formatDate t = [i|#{formatTime defaultTimeLocale "%b %-d, %Y" t}|]

--- a/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Templates.hs
@@ -156,7 +156,7 @@ successTemplate ::
 successTemplate trackingNumber mLabelUrl = do
   renderBanner'
   Lucid.div_
-    [ class_ $ base [Tokens.bgAlt, Tokens.p4, Tokens.border2, Tokens.borderDefault, "space-y-2"]
+    [ class_ $ base [Tokens.bgAlt, Tokens.p4, "border", Tokens.borderDefault, "space-y-2"]
     ]
     $ do
       Lucid.p_

--- a/services/web/src/API/Dashboard/Store/Products/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/Store/Products/Get/Templates.hs
@@ -52,7 +52,9 @@ template products =
           itcPaginationConfig = Nothing
         }
       ( do
-          mapM_ renderProductRow products
+          if null products
+            then renderEmptyRow
+            else mapM_ renderProductRow products
           renderInlineCreateRow
       )
 
@@ -149,6 +151,18 @@ renderInlineCreateRow =
               class_ $ base [Theme.fgMuted, Tokens.hoverBg, Tokens.textSm, "px-2", "py-1"]
             ]
             "\xd7"
+
+-- | Empty row shown when no products exist.
+renderEmptyRow :: Lucid.Html ()
+renderEmptyRow =
+  Lucid.tr_ [xShow_ "!showCreate"] $
+    Lucid.td_
+      [ Lucid.colspan_ "5",
+        class_ $ base [Theme.fgMuted, "text-center", "py-12"]
+      ]
+      $ do
+        Lucid.p_ [class_ $ base [Tokens.textXl]] "No products yet."
+        Lucid.p_ [class_ $ base ["mt-2"]] "Click + NEW above to create your first product."
 
 renderStatusBadge :: Bool -> Lucid.Html ()
 renderStatusBadge isActive =

--- a/services/web/src/API/Store/Checkout/Get/Templates.hs
+++ b/services/web/src/API/Store/Checkout/Get/Templates.hs
@@ -88,7 +88,9 @@ template mStripeKey = do
           Lucid.div_ [xShow_ "step === 'address'"] $ do
             renderContactSection
             renderShippingSection
-          Lucid.div_ [xShow_ "step === 'rates'"] renderShippingRatesSection
+          Lucid.div_ [xShow_ "step === 'rates'"] $ do
+            renderCheckoutError
+            renderShippingRatesSection
           Lucid.div_ [xShow_ "step === 'payment'"] renderPaymentSection
 
 --------------------------------------------------------------------------------
@@ -206,14 +208,25 @@ renderShippingSection =
               ]
 
     -- Get Shipping Rates button
-    Lucid.div_ [class_ $ base [Tokens.mt4]] $
-      Lucid.button_
+    Lucid.div_ [class_ $ base [Tokens.mt4]]
+      $ Lucid.button_
         [ Lucid.type_ "button",
           xOn_ "click" "fetchShippingRates()",
-          makeAttributes ":disabled" "!isAddressComplete",
+          makeAttributes ":disabled" "!isAddressComplete || loadingRates",
           class_ $ base [Tokens.buttonPrimary, "w-full", "uppercase", "disabled:opacity-50", "disabled:cursor-not-allowed"]
         ]
-        "Get Shipping Rates"
+      $ Lucid.span_ [xText_ "loadingRates ? 'Loading Rates...' : 'Get Shipping Rates'"] "Get Shipping Rates"
+
+-- | Inline error banner shown on the rates step when session creation fails.
+renderCheckoutError :: Lucid.Html ()
+renderCheckoutError =
+  Lucid.div_
+    [ xShow_ "checkoutError",
+      class_ $ base [Tokens.border2, "border-red-500", Tokens.p4, Tokens.mb4]
+    ]
+    $ Lucid.p_
+      [class_ $ base [Tokens.fgPrimary], xText_ "checkoutError"]
+      mempty
 
 renderShippingRatesSection :: Lucid.Html ()
 renderShippingRatesSection =
@@ -224,7 +237,12 @@ renderShippingRatesSection =
     mempty
 
 renderPaymentSection :: Lucid.Html ()
-renderPaymentSection =
+renderPaymentSection = do
+  Lucid.div_
+    [ xShow_ "loadingPayment",
+      class_ $ base [Tokens.fgMuted, "text-center", Tokens.py8]
+    ]
+    $ Lucid.p_ [] "Preparing payment..."
   Lucid.div_
     [ Lucid.id_ "stripe-checkout",
       class_ $ base [Tokens.mb8]
@@ -362,6 +380,9 @@ checkoutAlpineState mStripeKey =
   },
   step: 'address',
   summaryLoading: false,
+  loadingRates: false,
+  loadingPayment: false,
+  checkoutError: null,
   selectedRateId: null,
   selectedShipmentId: null,
   stripeKey: #{stripeKeyJs mStripeKey},
@@ -382,6 +403,7 @@ checkoutAlpineState mStripeKey =
   },
   fetchShippingRates() {
     if (!this.isAddressComplete) return;
+    this.loadingRates = true;
     const payload = {
       email: this.form.email,
       first_name: this.form.firstName,
@@ -402,14 +424,21 @@ checkoutAlpineState mStripeKey =
     .then(html => {
       document.getElementById('shipping-rates').innerHTML = html;
       this.step = 'rates';
+      this.loadingRates = false;
     })
     .catch(err => {
       document.getElementById('shipping-rates').innerHTML =
         '<div class="border-2 border-red-500 p-4">Failed to load shipping rates. Please try again.</div>';
+      this.loadingRates = false;
     });
+  },
+  resetRatesLoading() {
+    window.dispatchEvent(new CustomEvent('reset-loading'));
   },
   createSession() {
     if (!this.selectedRateId || !this.stripeKey) return;
+    this.loadingPayment = true;
+    this.checkoutError = null;
     const payload = {
       email: this.form.email,
       first_name: this.form.firstName,
@@ -434,12 +463,22 @@ checkoutAlpineState mStripeKey =
     })
     .then(async (data) => {
       this.step = 'payment';
-      const stripe = Stripe(this.stripeKey);
-      this.stripeCheckout = await stripe.initEmbeddedCheckout({ clientSecret: data.client_secret });
-      this.stripeCheckout.mount('\#stripe-checkout');
+      try {
+        const stripe = Stripe(this.stripeKey);
+        this.stripeCheckout = await stripe.initEmbeddedCheckout({ clientSecret: data.client_secret });
+        this.stripeCheckout.mount('\#stripe-checkout');
+        this.loadingPayment = false;
+      } catch (stripeErr) {
+        this.step = 'rates';
+        this.loadingPayment = false;
+        this.checkoutError = 'Payment system failed to load. Please try again.';
+        this.resetRatesLoading();
+      }
     })
     .catch(err => {
-      alert(err.message || 'Something went wrong. Please try again.');
+      this.loadingPayment = false;
+      this.checkoutError = err.message || 'Something went wrong. Please try again.';
+      this.resetRatesLoading();
     });
   }
 }|]

--- a/services/web/src/API/Store/ShippingRates/Post/Templates.hs
+++ b/services/web/src/API/Store/ShippingRates/Post/Templates.hs
@@ -50,6 +50,7 @@ template ::
 template shipment rates subtotal taxRate =
   Lucid.div_
     [ xData_ (ratesAlpineState subtotal taxRate),
+      xOn_ "reset-loading.window" "loading = false",
       class_ $ base [Tokens.border2, Tokens.borderDefault, Tokens.p4]
     ]
     $ do
@@ -95,7 +96,7 @@ template shipment rates subtotal taxRate =
               "\x2190 Back"
             Lucid.button_
               [ Lucid.type_ "button",
-                makeAttributes ":disabled" "selectedRateId === null",
+                makeAttributes ":disabled" "selectedRateId === null || loading",
                 xOn_ "click" "proceedToPayment()",
                 class_ $
                   base
@@ -106,7 +107,7 @@ template shipment rates subtotal taxRate =
                       "disabled:cursor-not-allowed"
                     ]
               ]
-              "Proceed to Payment"
+              $ Lucid.span_ [xText_ "loading ? 'Processing...' : 'Proceed to Payment'"] "Proceed to Payment"
 
 -- | Render a message when no rates are available.
 renderNoRates :: Lucid.Html ()
@@ -241,11 +242,13 @@ ratesAlpineState _subtotal _taxRate =
   [i|{
   selectedRateId: null,
   selectedRatePrice: null,
+  loading: false,
   formatCents(cents) {
     return '$' + (cents / 100).toFixed(2);
   },
   proceedToPayment() {
     if (this.selectedRateId === null) return;
+    this.loading = true;
     this.$dispatch('shipping-rate-selected', {
       rateId: this.selectedRateId,
       ratePrice: this.selectedRatePrice

--- a/services/web/src/Middleware/RateLimit.hs
+++ b/services/web/src/Middleware/RateLimit.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | WAI middleware that rate-limits specific public store API endpoints.
+--
+-- Uses @wai-rate-limit@ with a 'TVar'-backed in-memory store.
+-- Limits are per-client-IP using the @CF-Connecting-IP@ header
+-- (Cloudflare), falling back to @X-Forwarded-For@, then 'remoteHost'.
+--
+-- Rate-limited endpoints:
+--
+--   * @POST \/api\/store\/shipping-rates@ — 10 req/min (hits EasyPost)
+--   * @POST \/api\/store\/checkout\/create-session@ — 5 req/min (creates orders)
+--
+-- All other requests pass through untouched.
+module Middleware.RateLimit
+  ( rateLimitMiddleware,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async qualified as Async
+import Control.Concurrent.STM
+import Control.Monad (forever, void)
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as BS8
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Time (UTCTime, addUTCTime, getCurrentTime)
+import Network.HTTP.Types.Header (HeaderName)
+import Network.Socket (SockAddr)
+import Network.Wai qualified as Wai
+import Network.Wai.RateLimit (rateLimiting)
+import Network.Wai.RateLimit.Backend (Backend (..))
+import Network.Wai.RateLimit.Strategy (Strategy (..), fixedWindow)
+
+--------------------------------------------------------------------------------
+
+-- | Create rate limiting middleware for public store API endpoints.
+--
+-- Must be called once at startup (allocates in-memory state).
+-- The returned 'Wai.Middleware' is safe to use across threads.
+rateLimitMiddleware :: IO Wai.Middleware
+rateLimitMiddleware = do
+  shippingBackend <- newInMemoryBackend
+  sessionBackend <- newInMemoryBackend
+  let shippingLimiter = fixedWindow shippingBackend 60 10 getClientIP
+      sessionLimiter = fixedWindow sessionBackend 60 5 getClientIP
+      combinedStrategy =
+        MkStrategy $ \req ->
+          case (Wai.requestMethod req, Wai.pathInfo req) of
+            ("POST", ["api", "store", "shipping-rates"]) ->
+              strategyOnRequest shippingLimiter req
+            ("POST", ["api", "store", "checkout", "create-session"]) ->
+              strategyOnRequest sessionLimiter req
+            _ -> pure True
+  pure $ rateLimiting combinedStrategy
+
+--------------------------------------------------------------------------------
+-- Client IP extraction
+
+-- | Extract the client IP from the request.
+--
+-- Checks headers in order: @CF-Connecting-IP@ (Cloudflare),
+-- @X-Forwarded-For@ (first entry), then falls back to 'Wai.remoteHost'.
+getClientIP :: Wai.Request -> IO ByteString
+getClientIP req =
+  pure $
+    fromMaybe (sockAddrToBS $ Wai.remoteHost req) $
+      lookup "CF-Connecting-IP" headers
+        <> firstForwardedFor
+  where
+    headers :: [(HeaderName, ByteString)]
+    headers = Wai.requestHeaders req
+
+    firstForwardedFor :: Maybe ByteString
+    firstForwardedFor = do
+      xff <- lookup "X-Forwarded-For" headers
+      -- Take the first (client) IP from the comma-separated list
+      pure $ BS8.strip $ fst $ BS8.break (== ',') xff
+
+    sockAddrToBS :: SockAddr -> ByteString
+    sockAddrToBS = BS8.pack . show
+
+--------------------------------------------------------------------------------
+-- In-memory backend
+
+type Store = TVar (Map ByteString (Integer, UTCTime))
+
+-- | Create a new in-memory rate limiting backend.
+--
+-- Spawns a background thread that purges expired entries every 5 minutes
+-- to prevent unbounded memory growth.
+newInMemoryBackend :: IO (Backend ByteString)
+newInMemoryBackend = do
+  store <- newTVarIO Map.empty
+
+  -- Periodic cleanup of expired entries
+  void $ Async.async $ forever $ do
+    threadDelay (5 * 60 * 1000000)
+    now <- getCurrentTime
+    atomically $ modifyTVar' store (Map.filter (\(_, expiry) -> now <= expiry))
+
+  pure
+    MkBackend
+      { backendGetUsage = getUsage store,
+        backendIncAndGetUsage = incAndGetUsage store,
+        backendExpireIn = expireIn store
+      }
+
+-- | Get current usage for a key. Returns 0 if expired or absent.
+getUsage :: Store -> ByteString -> IO Integer
+getUsage store key = do
+  now <- getCurrentTime
+  atomically $ do
+    m <- readTVar store
+    case Map.lookup key m of
+      Nothing -> pure 0
+      Just (count, expiry)
+        | now > expiry -> do
+            modifyTVar' store (Map.delete key)
+            pure 0
+        | otherwise -> pure count
+
+-- | Atomically increment usage and return the new count.
+-- Expired entries are treated as absent (count starts from 0).
+incAndGetUsage :: Store -> ByteString -> Integer -> IO Integer
+incAndGetUsage store key delta = do
+  now <- getCurrentTime
+  atomically $ do
+    m <- readTVar store
+    let entry = Map.lookup key m
+        current = case entry of
+          Nothing -> 0
+          Just (count, ex)
+            | now > ex -> 0
+            | otherwise -> count
+        new = current + delta
+        -- Preserve existing expiry if still valid; otherwise use a
+        -- placeholder that backendExpireIn will overwrite immediately.
+        newExpiry = case entry of
+          Just (_, e) | now <= e -> e
+          _ -> now
+    writeTVar store (Map.insert key (new, newExpiry) m)
+    pure new
+
+-- | Set a key to expire in the given number of seconds from now.
+expireIn :: Store -> ByteString -> Integer -> IO ()
+expireIn store key seconds = do
+  now <- getCurrentTime
+  let expiry = addUTCTime (fromInteger seconds) now
+  atomically $ modifyTVar' store (Map.adjust (\(count, _) -> (count, expiry)) key)
+
+--------------------------------------------------------------------------------

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -218,7 +218,7 @@ resource "cloudflare_dns_record" "dmarc" {
   zone_id = local.cloudflare_zone_id
   name    = "_dmarc"
   type    = "TXT"
-  content = "\"v=DMARC1; p=none;\""
+  content = "v=DMARC1; p=none; rua=mailto:dmarc-reports@kpbj.fm"
   ttl     = 3600
   comment = "DMARC policy"
 }

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -379,11 +379,24 @@ resource "cloudflare_ruleset" "waf_custom" {
     # are malicious probes (e.g. the \xAD invalid UTF-8 attacks).
     # Scoped to path only; request bodies are untouched so file
     # uploads work normally.
+    #
+    # Uses lower() + contains to enumerate the 8 hex prefixes
+    # (%8x–%fx) instead of regex `matches`, which requires a
+    # Business plan.
     {
       action      = "block"
       description = "Block non-ASCII percent-encoded bytes in URI path"
       enabled     = true
-      expression  = "(http.request.uri.path matches \"%[89a-fA-F][0-9a-fA-F]\")"
+      expression = join(" or ", [
+        "(lower(http.request.uri.path) contains \"%8\")",
+        "(lower(http.request.uri.path) contains \"%9\")",
+        "(lower(http.request.uri.path) contains \"%a\")",
+        "(lower(http.request.uri.path) contains \"%b\")",
+        "(lower(http.request.uri.path) contains \"%c\")",
+        "(lower(http.request.uri.path) contains \"%d\")",
+        "(lower(http.request.uri.path) contains \"%e\")",
+        "(lower(http.request.uri.path) contains \"%f\")",
+      ])
     },
   ]
 }


### PR DESCRIPTION
## Summary
- **Rate limiting** on public store API endpoints (`/api/store/shipping-rates` at 10 req/min, `/api/store/checkout/create-session` at 5 req/min) via `wai-rate-limit` with in-memory backend
- **Checkout loading states** — spinner text and double-submit prevention on "Get Shipping Rates", "Proceed to Payment", and Stripe mount
- **Checkout error recovery** — inline error banner replaces `alert()`, Stripe init wrapped in try/catch, stuck button fix via `reset-loading` event
- **Dashboard empty state** — orders list shows "No orders yet" when empty
- **Cloudflare WAF fix** — corrected non-ASCII percent-encoded byte matching rule
- **DMARC reporting** — added reporting email to DNS record

## Test plan
- [x] Build passes
- [x] Rate limiter returns 429 after limit exceeded (`for i in $(seq 12); do curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:4000/api/store/shipping-rates; done`)
- [x] Visual check: loading states on checkout buttons
- [x] Visual check: empty orders dashboard shows empty state
- [x] Happy-path checkout on staging