### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.11.1] - 2026-04-18
+
 ### Added
 - **Stripe Terraform Provider** — Stripe webhook endpoints are now managed as infrastructure-as-code via the `lukasaron/stripe` Terraform provider. Imported existing prod and staging endpoints. Adding new webhook events is now a one-line change in `stripe.tf` instead of clicking through the Stripe dashboard.
 - **Grafana Alerting → Discord** — Provisioned Grafana alert rules with Discord webhook notifications. 8 rules covering HTTP 5xx, application errors, database FATAL/PANIC, Liquidsoap critical/severe, Icecast errors, webhook errors, batch job failures (token-cleanup, sync-host-emails, episode-check, listener-snapshots, order-cleanup), and friendly-ghost failures. Contact point and notification policy provisioned as code via NixOS. Webhook URL stored in sops.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.11.0
+version:            0.11.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.11.1

This PR releases version 0.11.1

### What's Changed


### Added
- **Stripe Terraform Provider** — Stripe webhook endpoints are now managed as infrastructure-as-code via the `lukasaron/stripe` Terraform provider. Imported existing prod and staging endpoints. Adding new webhook events is now a one-line change in `stripe.tf` instead of clicking through the Stripe dashboard.
- **Grafana Alerting → Discord** — Provisioned Grafana alert rules with Discord webhook notifications. 8 rules covering HTTP 5xx, application errors, database FATAL/PANIC, Liquidsoap critical/severe, Icecast errors, webhook errors, batch job failures (token-cleanup, sync-host-emails, episode-check, listener-snapshots, order-cleanup), and friendly-ghost failures. Contact point and notification policy provisioned as code via NixOS. Webhook URL stored in sops.
- **Service Health Dashboard** — Added Prometheus with the node exporter's systemd collector and a provisioned Grafana dashboard showing up/down status for all KPBJ services and timers. Auto-refreshes every 30 seconds.
- **GitHub Branch Protection** — Added branch protection ruleset and CODEOWNERS file for workflow files via Terraform.

### Changed
- **Default Theme Dark Mode** — Replaced blue-tinted Tailwind `gray` palette with true monochrome `neutral` values and reduced contrast for a softer, more comfortable dark mode.
- **Grafana Alert Descriptions** — Alert rules now include human-readable descriptions and richer Discord messages with environment, unit, and deep-link to relevant Grafana log timespan.
- **Watchdog → friendly-ghost** — Replaced the custom bash watchdog script with [friendly-ghost](https://github.com/solomon-b/friendly-ghost), a Rust-based systemd journal monitor with pre-filtering. Log noise (routine HTTP responses, Liquidsoap track transitions, PostgreSQL autovacuum, bot scanners, pgBackRest info logs) is now filtered via regex ignore patterns *before* reaching the LLM, rather than relying on the LLM prompt to ignore them. Uses Gemini 2.5 Flash via the OpenAI-compatible endpoint. Staging only for now; production remains on the old watchdog.
- **friendly-ghost: Gemini 2.5 Flash → 3.1 Flash Lite** — Switched both prod and staging from `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview` due to persistent 503 errors from the 2.5 Flash model.
- **friendly-ghost: Gemini → DeepSeek** — Switched both prod and staging from `gemini-3.1-flash-lite-preview` to `deepseek-chat` via the DeepSeek API due to continued 503 availability issues with Google's Gemini models.

### Fixed
- **Icecast Configuration Warnings** — Fixed three persistent Icecast warnings: set `<hostname>` per environment (was hardcoded to `localhost`, breaking YP directory listings), removed `<changeowner>` block (unnecessary with systemd `DynamicUser` isolation), and provided `/etc/mime.types` via `mailcap` (NixOS doesn't ship it by default).
- **Episode Reminder Localization** — Schedule queries for upcoming unscheduled show dates and missing-episode reminders used `CURRENT_DATE` (UTC), which rolled over to the next day at 5 PM Pacific. Switched to `CURRENT_TIMESTAMP AT TIME ZONE 'America/Los_Angeles'` so date calculations match the station's local time.
- **Open Redirect on Login** — The `?redirect=` parameter on the login page accepted arbitrary URLs, allowing open redirect attacks. Now validates the redirect target is a relative path.
- **Liquidsoap Crossfade Duration Noise** — Added `crossfade duration is longer` to friendly-ghost ignore patterns and excluded it from the Grafana Liquidsoap alert query. This benign warning fired frequently and created alert noise.
- **CI/CD Security Hardening** — Pinned all third-party GitHub Actions to commit SHAs, fixed a shell injection in the create-release-tag workflow, added `permissions: contents: read` to CI, and added release tag format validation to the production deploy workflow.
- **fail2ban IP whitelist** — Added `ignoreIP` to fail2ban config to prevent deploy IPs from being banned. A single failed SSH auth attempt (wrong username) could trigger a persistent ban that survived reboots via fail2ban's sqlite database, locking out legitimate operators.
- **Empty IPv6 route** — Removed bogus `ipv6.routes = [{ address = ""; prefixLength = 128; }]` from both staging and prod networking configs. These were leftover from nixos-infect and caused `network-addresses-eth0` to fail on boot.

---

When merged, a git tag v0.11.1 will be automatically created, which triggers the production deployment.
