### PR TITLE
Release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.11.2] - 2026-05-02
+
 ### Added
 - **"Remember Me" on Login** — The login form's `Remember Me` checkbox previously did nothing: the field was dropped at form parse time, the cookie was always a browser-session cookie (no `Max-Age`/`Expires`), and the server-side session was hardcoded to 1 day. When checked, login now persists the session for 30 days both in `server_sessions.expires_at` and via a `Max-Age=2592000` cookie, so users stay logged in across browser restarts. When unchecked, behavior is unchanged.
 


### PR DESCRIPTION
## Release v0.11.2

This PR releases version 0.11.2

### What's Changed


### Added
- **"Remember Me" on Login** — The login form's `Remember Me` checkbox previously did nothing: the field was dropped at form parse time, the cookie was always a browser-session cookie (no `Max-Age`/`Expires`), and the server-side session was hardcoded to 1 day. When checked, login now persists the session for 30 days both in `server_sessions.expires_at` and via a `Max-Age=2592000` cookie, so users stay logged in across browser restarts. When unchecked, behavior is unchanged.

### Changed
- **Newsletter Signup → Self-Hosted** — Replaced the homepage Google Forms newsletter signup with a self-hosted Postgres-backed signup at `POST /api/newsletter/subscribe`. New `newsletter_subscribers` table stores email + timestamp, duplicate emails are silently swallowed via `ON CONFLICT (email) DO NOTHING`, and the homepage form is now an HTMX-driven swap that replaces itself with a "Thanks for subscribing!" message on success (no top-of-page banner). The registration newsletter checkbox now writes to the same table instead of POSTing to Google Forms.
- **friendly-ghost Environment Tagging** — Alerts now make the environment unmistakable: `subjectPrefix` uppercased to `[KPBJ STAGING]` / `[KPBJ PROD]`, the system prompt requires every alert to begin the SUBJECT with `[STAGING]` / `[PROD]` and the body with `Environment: <env>`. The shared prompt is wrapped per-environment via `pkgs.writeText` so the LLM knows which env it's monitoring.
- **friendly-ghost Prompt: sync-host-emails Context** — Documented in the prompt that `kpbj-sync-host-emails` runs in `--dry-run` on staging against a DB sanitized by `prod-to-staging.sh`, so large `WOULD REMOVE/ADD` diffs there are expected and must not be flagged; in prod it runs live, and sudden large diffs remain flaggable.

### Security
- **Blacklist `algif_aead` Kernel Module** — Mitigation for CVE-2026-31431 ("Copy Fail"). Added `boot.blacklistedKernelModules` and an `install algif_aead /bin/false` modprobe rule to `nixos/common.nix` so the module cannot be autoloaded by the kernel or pulled in via userspace `modprobe` on any KPBJ host (prod, staging, dev).

### Fixed
- **Login Redirect After Successful Sign-In** — The login POST handler built its default redirect URL via `Http.toUrlPiece apiLinks.rootGet`, which returns the empty string for the root link. The resulting empty `HX-Redirect` header caused HTMX to call `location.href = ""`, which the browser interprets as a reload of the current URL — leaving the user on `/user/login` after a successful login and making the persistent header still appear logged-out until a hard refresh. Now prepends `"/"` to match the other branches in the same handler.
- **Already-Authenticated Users on /user/login** — The login GET handler now redirects authenticated users to `/` (or the validated `?redirect=` target) instead of re-rendering the login form, preventing the confusing post-login state where the user lands back on the login page.
- **friendly-ghost Staging Noise** — Broadened staging `ignorePatterns` for `sync-host-emails`. The previous single pattern (`sync-host-emails.*dry.run`) only matched one log line; the actual noisy output (`WOULD REMOVE FROM GOOGLE GROUP`, `WOULD ADD TO GOOGLE GROUP`, `Computed diff`, `====` banners) slipped through and caused the LLM to misread the staging dry-run diff as a prod data-integrity incident.
- **Newsletter Signup Form Entry ID** — Updated the Google Form field ID used by the registration newsletter opt-in (`subscribeToNewsletter`) from `entry.936311333` to `entry.1846700939` to match the form's current schema.
- **Flaky `ShowScheduleMissingEpisodesSpec` Property Tests** — Tests for `getShowsMissingEpisodes` and `getHostsMissingEpisodesOnDay` derived `today` via `utctDay <$> getCurrentTime`, but both queries compute their target dates in `America/Los_Angeles`. During the late-evening UTC window (when PT and UTC sit on different calendar days) the test's day-of-week disagreed with the query's, causing spurious failures. Tests now use a Pacific-time `today` via `Domain.Types.Timezone.utcToPacific`. Also fixes `prop_multipleHostsMultipleRows` hitting `users_email_key` when Hedgehog shrunk both generated emails to the same value — the test now overrides both addresses with a new `mkUniqueEmail` helper in `Test.Gen.EmailAddress`.

---

When merged, a git tag v0.11.2 will be automatically created, which triggers the production deployment.
