### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.12.0] - 2026-05-04
+
 ### Changed
 - **NixOS 25.11 / web-server-core 0.2.0.0** — Bumped `nixpkgs` from `nixos-25.05` to `nixos-25.11` and `web-server-core` to `0.2.0.0`. Dropped now-redundant Haskell package pins (`hasql`, `hasql-pool`, `hasql-transaction`, `text-builder`) that 25.11 ships compatible defaults for, and removed the corresponding `xmlhtml-{qq,lens}` pin to track the new web-server-core revision.
 - **Postgres Connection: Single Env Var** — The five `APP_POSTGRES_{HOST,PORT,DB,USER,PASSWORD}` env vars are gone. `web-server-core` now reads a single `APP_POSTGRES_CONNECTION_STRING` (libpq URL). Updated `nixos/web.nix` (sops template), CI workflow, README, and `.envrc.local` accordingly.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.11.2
+version:            0.12.0
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.12.0

This PR releases version 0.12.0

### What's Changed


### Changed
- **NixOS 25.11 / web-server-core 0.2.0.0** — Bumped `nixpkgs` from `nixos-25.05` to `nixos-25.11` and `web-server-core` to `0.2.0.0`. Dropped now-redundant Haskell package pins (`hasql`, `hasql-pool`, `hasql-transaction`, `text-builder`) that 25.11 ships compatible defaults for, and removed the corresponding `xmlhtml-{qq,lens}` pin to track the new web-server-core revision.
- **Postgres Connection: Single Env Var** — The five `APP_POSTGRES_{HOST,PORT,DB,USER,PASSWORD}` env vars are gone. `web-server-core` now reads a single `APP_POSTGRES_CONNECTION_STRING` (libpq URL). Updated `nixos/web.nix` (sops template), CI workflow, README, and `.envrc.local` accordingly.
- **Login: `loginWithExpiry` for Remember Me** — Replaced the kpbj-side `extendSessionExpiry` UPDATE and custom `mkPersistentCookieSession` with upstream's new `Auth.loginWithExpiry` + `Auth.mkCookieSessionWithMaxAge`, which set the server-side session expiry and the browser cookie `Max-Age` from a single duration value. Behavior unchanged: 30-day session when "Remember Me" is checked, 1-day browser-session cookie otherwise.
- **Staging Droplet: 1 GB → 2 GB RAM, 25 GB → 50 GB Disk** — Bumped `droplet_size_staging` from `s-1vcpu-1gb` to `s-1vcpu-2gb`. The 25.11 closure plus past generations no longer fits on the 25 GB volume; the larger box buys headroom for several more deploys before the next GC. DO grew the block device in place; the partition + ext4 filesystem were grown on staging via `growpart /dev/vda 1` and `resize2fs /dev/vda1`.
- **Nginx Restart Backoff Hardens ACME Race** — Added `RestartSec=10s`, `StartLimitBurst=5`, `StartLimitIntervalSec=60` to `nginx.service` (`nixos/nginx.nix`). On deploy, `switch-to-configuration` restarts nginx concurrently with `acme-*.service` rewriting cert/key files, occasionally catching nginx mid-rewrite (`SSL_CTX_use_PrivateKey ... key values mismatch`). The default 100ms restart back-off is too aggressive to let acme finish its atomic rename; 10s gives it room.

### Added
- **Analytics Dashboard: Referrers, Countries, Cities** — The admin analytics dashboard (`/dashboard/analytics`) now surfaces top-N traffic sources (referrers), countries, and cities from Google Analytics alongside the existing listener and archive-play panels. Three new table sections render in a responsive 3-column grid below the top-episodes list, sourced from the `ga_snapshots` table populated by the new `ga-poller` job. Range buttons (24h/7d/30d/90d) filter all panels consistently.
- **`ga_snapshots` Table** — New table storing per-day, per-dimension session counts pulled from the GA Data API. Columns: `dimension_type` (CHECK constraint: `source`/`country`/`city`), `dimension_value`, `metric_value`, `recorded_at`, `window_start`, `window_end`. Aggregation queries (`getTopReferrers`, `getTopCountries`, `getTopCities`) sum `metric_value` over `window_start >= start AND window_end <= end` and return the top N by sessions.
- **`ga-poller` Cron Job** — New `jobs/ga-poller/` executable that polls the Google Analytics Data API (`runReport`) and writes top-50 session counts per source/country/city into `ga_snapshots`. Uses a Google service-account JWT (RS256, `jose`) exchanged for an OAuth2 access token, with 30-second HTTP timeouts on every call. On first run (empty table) it backfills the past 90 UTC days; thereafter it polls the previous full UTC day. Wired into NixOS as `kpbj-ga-poller.service` + `kpbj-ga-poller.timer` (daily at 01:30 UTC) on prod and staging. New sops secrets `google_analytics_property_id` and `google_analytics_service_account_key` are mounted via `kpbj-ga-poller.env`. **NOTE**: GA's `dateRanges` are day-resolution only, which is why the timer fires daily rather than hourly.
- **`just prod-deploy` Command** — New Justfile recipe that triggers the production deploy workflow on GitHub Actions. The `create-release-tag` workflow auto-tags merged `release/*` PRs but the tag push doesn't reliably fire `deploy-production`, so manually invoking the workflow is the standard path. Pass a tag explicitly (`just prod-deploy v0.11.2`) or run with no arguments to fzf-pick from local `v*` tags (sorted newest-first, fetches first).

---

When merged, a git tag v0.12.0 will be automatically created, which triggers the production deployment.
