### PR TITLE
feat: Newsletter admin crud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+- **Dedicated `kpbj-fm` DigitalOcean Project** — Added a `digitalocean_project` resource (`terraform/digitalocean.tf`) that groups both droplets (`stream_prod`, `staging`) and all three Spaces buckets (`production-kpbj-storage`, `staging-kpbj-storage`, `kpbj-pgbackrest`) under a dedicated `kpbj-fm` project in the DO control panel. Project assignment is metadata-only on DO's side, so the move is non-destructive — no reboot, no IP change, no downtime. Firewalls and SSH keys are not project-assignable, so they remain unaffiliated.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Newsletter Subscribers Admin CRUD** — Admin dashboard CRUD for newsletter subscribers — list with search/pagination, bulk insert (comma or newline-separated), and per-row delete. New routes under `/dashboard/newsletter-subscribers`, gated by `requireStaffNotSuspended`. Backed by new `getPaginated`, `countAll`, `getById`, and `deleteById` queries on the existing `newsletter_subscribers` table.
+
 ### Changed
 - **Dedicated `kpbj-fm` DigitalOcean Project** — Added a `digitalocean_project` resource (`terraform/digitalocean.tf`) that groups both droplets (`stream_prod`, `staging`) and all three Spaces buckets (`production-kpbj-storage`, `staging-kpbj-storage`, `kpbj-pgbackrest`) under a dedicated `kpbj-fm` project in the DO control panel. Project assignment is metadata-only on DO's side, so the move is non-destructive — no reboot, no IP change, no downtime. Firewalls and SSH keys are not project-assignable, so they remain unaffiliated.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,27 +35,50 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system topology and CI/CD. See [READM
 
 ### HTMX Response Patterns
 
-**Pattern A - Redirect with Banner** (POST success, navigate away):
+Three canonical shapes. Each pairs a return type, a `handle*Errors` wrapper from `App.Handler.Error`, and a success-path response.
+
+**Pattern A — Redirect with flash** (POST success, navigate away).
+
+Route returns redirect headers + `NoContent`:
 ```haskell
-let banner = BannerParams Success "Created" "Item created successfully."
-pure $ Servant.addHeader [i|/#{targetUrl}|] $ redirectWithBanner [i|/#{targetUrl}|] banner
+type Route =
+  ... :> Servant.Post '[HTML]
+        (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
 ```
 
-**Pattern B - Row Update with OOB Banner** (update item in list):
+Handler uses `handleRedirectErrors` and emits the redirect URL + a flash cookie carrying a `FlashMessage`:
+```haskell
+handler cookie form =
+  handleRedirectErrors "Action name" defaultLink $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "..." userMetadata
+    -- ... business logic ...
+    let targetUrl = [i|/#{Links.linkURI $ someLinks.somePage}|] :: Text
+        flash = FlashMessage Success "Created" "Item created successfully."
+    pure $
+      Servant.addHeader targetUrl $
+        Servant.addHeader (flashCookie (Just flash)) Servant.NoContent
+```
+
+`handleRedirectErrors`'s second argument is a `Servant.Link` (not `Text`) used as the fallback redirect target on auth/access failures. Validation errors fall through to an inline OOB error banner instead of redirecting. Imports: `Component.Flash (FlashMessage (..), flashCookie)`, `Component.Banner (BannerType (..))`, `App.Handler.Error (handleRedirectErrors)`.
+
+**Pattern B — Row update with OOB banner** (update item in list, stay on page):
 ```haskell
 pure $ do
   renderItemRow updatedItem
   renderBanner Success "Updated" "Item updated."
 ```
+Wrap with `handleBannerErrors`. Return type is `AppM (Lucid.Html ())`.
 
-**Pattern C - Row Delete with OOB Banner** (remove from list):
+**Pattern C — Row delete with OOB banner** (remove from list):
 ```haskell
 pure $ do
-  Lucid.toHtmlRaw ("" :: Text)  -- removes target element
+  mempty  -- empty body; HTMX removes the target via hx-swap="outerHTML" (or "delete")
   renderBanner Success "Deleted" "Item deleted."
 ```
+Wrap with `handleBannerErrors`. Return type is `AppM (Lucid.Html ())`.
 
-**Errors**: Always return OOB banner only: `pure $ renderBanner Error "Failed" "Error message."`
+**Errors**: don't construct error banners by hand. Use the `handle*Errors` wrappers and the `throw*` helpers in `App.Handler.Error` (`throwDatabaseError`, `throwNotFound`, `throwNotAuthorized`, …). Each wrapper renders the appropriate OOB error banner (Pattern B/C) or redirect-with-flash (Pattern A) automatically.
 
 ### Type-Safe Links (MANDATORY)
 

--- a/lib/kpbj-database/src/Effects/Database/Tables/NewsletterSubscribers.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/NewsletterSubscribers.hs
@@ -18,6 +18,10 @@ module Effects.Database.Tables.NewsletterSubscribers
     -- * Queries
     insert,
     countByEmail,
+    getPaginated,
+    countAll,
+    getById,
+    deleteById,
   )
 where
 
@@ -26,6 +30,7 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Int (Int64)
 import Data.Maybe (listToMaybe)
+import Data.Text (Text)
 import Data.Text.Display (Display (..), RecordInstance (..))
 import Data.Time (UTCTime)
 import Domain.Types.EmailAddress (EmailAddress)
@@ -113,3 +118,80 @@ countByEmail email =
           WHERE email = #{email}
         |]
    in maybe 0 getOneColumn <$> query
+
+-- | Fetch a page of subscribers, optionally filtered by an email substring.
+--
+-- Search uses a case-insensitive @LIKE@ on the email; pass 'Nothing' to skip
+-- the filter. Rows are ordered most-recently-subscribed first.
+getPaginated :: Maybe Text -> Int64 -> Int64 -> Hasql.Statement () [Model]
+getPaginated mSearch limit offset =
+  case mSearch of
+    Nothing ->
+      interp
+        False
+        [sql|
+        SELECT id, email, created_at
+        FROM newsletter_subscribers
+        ORDER BY created_at DESC
+        LIMIT #{limit} OFFSET #{offset}
+      |]
+    Just search ->
+      interp
+        False
+        [sql|
+        SELECT id, email, created_at
+        FROM newsletter_subscribers
+        WHERE email ILIKE '%' || #{search} || '%'
+        ORDER BY created_at DESC
+        LIMIT #{limit} OFFSET #{offset}
+      |]
+
+-- | Count all subscribers, optionally filtered by an email substring.
+--
+-- Mirrors the filter used by 'getPaginated' so callers can compute total
+-- result sets and pagination state.
+countAll :: Maybe Text -> Hasql.Statement () Int64
+countAll mSearch =
+  let query = case mSearch of
+        Nothing ->
+          interp
+            False
+            [sql|
+            SELECT COUNT(*)::INT8
+            FROM newsletter_subscribers
+          |]
+        Just search ->
+          interp
+            False
+            [sql|
+            SELECT COUNT(*)::INT8
+            FROM newsletter_subscribers
+            WHERE email ILIKE '%' || #{search} || '%'
+          |]
+   in maybe 0 getOneColumn <$> query
+
+-- | Look up a single subscriber by primary key.
+getById :: Id -> Hasql.Statement () (Maybe Model)
+getById subId =
+  fmap listToMaybe $
+    interp
+      False
+      [sql|
+      SELECT id, email, created_at
+      FROM newsletter_subscribers
+      WHERE id = #{subId}
+    |]
+
+-- | Delete a subscriber by primary key.
+--
+-- Returns @Just id@ when a row was deleted, @Nothing@ if nothing matched.
+deleteById :: Id -> Hasql.Statement () (Maybe Id)
+deleteById subId =
+  fmap listToMaybe $
+    interp
+      False
+      [sql|
+      DELETE FROM newsletter_subscribers
+      WHERE id = #{subId}
+      RETURNING id
+    |]

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -185,6 +185,17 @@ library
     API.Dashboard.Invitations.Delete.Handler
     API.Dashboard.Invitations.Regenerate.Route
     API.Dashboard.Invitations.Regenerate.Handler
+    API.Dashboard.NewsletterSubscribers.Get.Route
+    API.Dashboard.NewsletterSubscribers.Get.Handler
+    API.Dashboard.NewsletterSubscribers.Get.Templates.Page
+    API.Dashboard.NewsletterSubscribers.Get.Templates.ItemsFragment
+    API.Dashboard.NewsletterSubscribers.Bulk.Get.Route
+    API.Dashboard.NewsletterSubscribers.Bulk.Get.Handler
+    API.Dashboard.NewsletterSubscribers.Bulk.Get.Templates
+    API.Dashboard.NewsletterSubscribers.Bulk.Post.Route
+    API.Dashboard.NewsletterSubscribers.Bulk.Post.Handler
+    API.Dashboard.NewsletterSubscribers.Delete.Route
+    API.Dashboard.NewsletterSubscribers.Delete.Handler
     API.Dashboard.Events.Get.Handler
     API.Dashboard.Events.Get.Route
     API.Dashboard.Events.Get.Templates.ItemsFragment

--- a/services/web/src/API.hs
+++ b/services/web/src/API.hs
@@ -90,6 +90,10 @@ import API.Dashboard.Invitations.New.Get.Handler qualified as Dashboard.Invitati
 import API.Dashboard.Invitations.New.Post.Handler qualified as Dashboard.Invitations.New.Post
 import API.Dashboard.Invitations.Regenerate.Handler qualified as Dashboard.Invitations.Regenerate
 import API.Dashboard.MissingEpisodes.Get.Handler qualified as Dashboard.MissingEpisodes.Get
+import API.Dashboard.NewsletterSubscribers.Bulk.Get.Handler qualified as Dashboard.NewsletterSubscribers.Bulk.Get
+import API.Dashboard.NewsletterSubscribers.Bulk.Post.Handler qualified as Dashboard.NewsletterSubscribers.Bulk.Post
+import API.Dashboard.NewsletterSubscribers.Delete.Handler qualified as Dashboard.NewsletterSubscribers.Delete
+import API.Dashboard.NewsletterSubscribers.Get.Handler qualified as Dashboard.NewsletterSubscribers.Get
 import API.Dashboard.Profile.Edit.Get.Handler qualified as Dashboard.Profile.Edit.Get
 import API.Dashboard.Profile.Edit.Post.Handler qualified as Dashboard.Profile.Edit.Post
 import API.Dashboard.Shows.Get.Handler qualified as Dashboard.Shows.Get
@@ -381,7 +385,16 @@ server =
           streamSettings = dashboardStreamSettingsRoutes,
           missingEpisodes = Dashboard.MissingEpisodes.Get.handler,
           analytics = dashboardAnalyticsRoutes,
-          store = dashboardStoreRoutes
+          store = dashboardStoreRoutes,
+          newsletterSubscribers = dashboardNewsletterSubscribersRoutes
+        }
+
+    dashboardNewsletterSubscribersRoutes =
+      DashboardNewsletterSubscribersRoutes
+        { list = Dashboard.NewsletterSubscribers.Get.handler,
+          bulkGet = Dashboard.NewsletterSubscribers.Bulk.Get.handler,
+          bulkPost = Dashboard.NewsletterSubscribers.Bulk.Post.handler,
+          delete = Dashboard.NewsletterSubscribers.Delete.handler
         }
 
     dashboardStoreRoutes =

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Handler.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.NewsletterSubscribers.Bulk.Get.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.NewsletterSubscribers.Bulk.Get.Templates (template)
+import API.Links (apiLinks)
+import API.Types
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleHtmlErrors)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Trans (lift)
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest, foldHxReq)
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+-- | Handler for GET /dashboard/newsletter-subscribers/bulk.
+handler ::
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  AppM (Lucid.Html ())
+handler cookie (foldHxReq -> hxRequest) =
+  handleHtmlErrors "Newsletter subscribers bulk add form" apiLinks.rootGet $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "Only staff can add newsletter subscribers." userMetadata
+    lift $
+      renderDashboardTemplate
+        hxRequest
+        userMetadata
+        []
+        Nothing
+        NavNewsletterSubscribers
+        Nothing
+        Nothing
+        template

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Route.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Route.hs
@@ -1,0 +1,21 @@
+module API.Dashboard.NewsletterSubscribers.Bulk.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/newsletter-subscribers/bulk"
+type Route =
+  "dashboard"
+    :> "newsletter-subscribers"
+    :> "bulk"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Templates.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Get/Templates.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module API.Dashboard.NewsletterSubscribers.Bulk.Get.Templates
+  ( template,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import API.Links (dashboardNewsletterSubscribersLinks)
+import API.Types
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Lucid qualified
+import Lucid.Form.Builder
+import Servant.Links qualified as Links
+
+--------------------------------------------------------------------------------
+
+-- | Bulk add subscribers form template.
+template :: Lucid.Html ()
+template =
+  renderForm config form
+  where
+    listUri :: Links.URI
+    listUri = Links.linkURI $ dashboardNewsletterSubscribersLinks.list Nothing Nothing
+
+    bulkPostUri :: Links.URI
+    bulkPostUri = Links.linkURI dashboardNewsletterSubscribersLinks.bulkPost
+
+    listUrl :: Text
+    listUrl = [i|/#{listUri}|]
+
+    postUrl :: Text
+    postUrl = [i|/#{bulkPostUri}|]
+
+    config :: FormConfig
+    config =
+      defaultFormConfig
+        { fcAction = postUrl,
+          fcMethod = "post",
+          fcHtmxTarget = Just "#main-content"
+        }
+
+    form :: FormBuilder
+    form = do
+      formTitle "BULK ADD SUBSCRIBERS"
+      formSubtitle "Paste one email per line, or comma-separated."
+
+      textareaField "emails" 12 $ do
+        label "Email Addresses"
+        placeholder "alice@example.com\nbob@example.com, carol@example.com"
+        hint "Duplicates are ignored. Invalid addresses are skipped and reported."
+        required
+
+      cancelButton listUrl "CANCEL"
+      submitButton "ADD SUBSCRIBERS"

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Post/Handler.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module API.Dashboard.NewsletterSubscribers.Bulk.Post.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.NewsletterSubscribers.Bulk.Post.Route (BulkForm (..))
+import API.Links (dashboardNewsletterSubscribersLinks)
+import API.Types
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleRedirectErrors, throwDatabaseError)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..))
+import Component.Flash (FlashMessage (..), flashCookie)
+import Control.Monad (foldM)
+import Data.Set qualified as Set
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.EmailAddress (EmailAddress, isValid, mkEmailAddress)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Log qualified
+import Servant qualified
+import Servant.Links qualified as Links
+
+--------------------------------------------------------------------------------
+
+-- | Handler for POST /dashboard/newsletter-subscribers/bulk.
+handler ::
+  Maybe Cookie ->
+  BulkForm ->
+  AppM (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)
+handler cookie form =
+  handleRedirectErrors "Newsletter subscribers bulk add" dashboardNewsletterSubscribersLinks.bulkGet $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "Only staff can add newsletter subscribers." userMetadata
+
+    let (valid, invalidCount) = parseEmails form.bfEmails
+
+    (added, duplicate) <- foldM insertOne (0 :: Int, 0 :: Int) valid
+
+    Log.logInfo "Bulk added newsletter subscribers" $
+      Text.pack $
+        show (added, duplicate, invalidCount)
+
+    let bannerType = if added > 0 then Success else Info
+        flash = FlashMessage bannerType "Bulk Add Complete" (summary added duplicate invalidCount)
+
+    pure $
+      Servant.addHeader listUrl $
+        Servant.addHeader (flashCookie (Just flash)) Servant.NoContent
+  where
+    listUrl :: Text
+    listUrl =
+      let uri = Links.linkURI $ dashboardNewsletterSubscribersLinks.list Nothing Nothing
+       in [i|/#{uri}|]
+
+    insertOne (added, duplicate) email = do
+      result <- execQuery (NewsletterSubscribers.insert (NewsletterSubscribers.Insert email))
+      case result of
+        Left dbErr -> throwDatabaseError dbErr
+        Right (Just _) -> pure (added + 1, duplicate)
+        Right Nothing -> pure (added, duplicate + 1)
+
+
+-- | Split, trim, dedupe, and validate the pasted email list.
+--
+-- Returns the unique valid 'EmailAddress' values and a count of invalid tokens.
+parseEmails :: Text -> ([EmailAddress], Int)
+parseEmails raw =
+  let tokens =
+        filter (not . Text.null) $
+          map Text.strip $
+            concatMap (Text.splitOn ",") $
+              Text.lines raw
+      uniqueTokens = dedupe tokens
+      (valid, invalid) =
+        foldl'
+          ( \(vs, is) tok ->
+              let candidate = mkEmailAddress tok
+               in if isValid candidate
+                    then (candidate : vs, is)
+                    else (vs, is + 1)
+          )
+          ([], 0 :: Int)
+          uniqueTokens
+   in (reverse valid, invalid)
+
+
+-- | Drop duplicate tokens while preserving the first-seen order.
+dedupe :: [Text] -> [Text]
+dedupe = go Set.empty
+  where
+    go _ [] = []
+    go seen (t : ts)
+      | Set.member t seen = go seen ts
+      | otherwise = t : go (Set.insert t seen) ts
+
+
+-- | Build the user-facing summary string, omitting zero-count phrases.
+summary :: Int -> Int -> Int -> Text
+summary added duplicate invalid =
+  let parts =
+        concat
+          [ [Text.pack (show added) <> " added"],
+            [Text.pack (show duplicate) <> " already subscribed" | duplicate > 0],
+            [Text.pack (show invalid) <> " invalid" | invalid > 0]
+          ]
+   in Text.intercalate ", " parts <> "."

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Post/Route.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Bulk/Post/Route.hs
@@ -1,0 +1,35 @@
+module API.Dashboard.NewsletterSubscribers.Bulk.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import GHC.Generics (Generic)
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+import Web.FormUrlEncoded (FromForm (..))
+import Web.FormUrlEncoded qualified as Form
+
+--------------------------------------------------------------------------------
+
+-- | Form data for bulk-adding newsletter subscribers.
+newtype BulkForm = BulkForm
+  { bfEmails :: Text
+  }
+  deriving stock (Generic, Show)
+
+instance FromForm BulkForm where
+  fromForm form = BulkForm <$> Form.parseUnique @Text "emails" form
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/newsletter-subscribers/bulk"
+type Route =
+  "dashboard"
+    :> "newsletter-subscribers"
+    :> "bulk"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.ReqBody '[Servant.FormUrlEncoded] BulkForm
+    :> Servant.Post '[HTML]
+         (Servant.Headers '[Servant.Header "HX-Redirect" Text, Servant.Header "Set-Cookie" Text] Servant.NoContent)

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Delete/Handler.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Delete/Handler.hs
@@ -1,0 +1,36 @@
+module API.Dashboard.NewsletterSubscribers.Delete.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleBannerErrors, throwDatabaseError, throwNotFound)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..), renderBanner)
+import Domain.Types.Cookie (Cookie)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+-- | Handler for DELETE /dashboard/newsletter-subscribers/:subscriberId.
+--
+-- Removes a newsletter subscriber. Only staff and above can delete subscribers.
+-- Returns an empty body plus an OOB banner; the row is removed via
+-- @hx-swap="outerHTML"@ from the caller.
+handler ::
+  NewsletterSubscribers.Id ->
+  Maybe Cookie ->
+  AppM (Lucid.Html ())
+handler subId cookie =
+  handleBannerErrors "Newsletter subscriber delete" $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "Only staff can delete newsletter subscribers." userMetadata
+    result <- execQuery (NewsletterSubscribers.deleteById subId)
+    case result of
+      Left dbErr -> throwDatabaseError dbErr
+      Right Nothing -> throwNotFound "Subscriber"
+      Right (Just _) -> pure ()
+    pure $ do
+      mempty
+      renderBanner Success "Subscriber Deleted" "The subscriber has been removed."

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Delete/Route.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Delete/Route.hs
@@ -1,0 +1,20 @@
+module API.Dashboard.NewsletterSubscribers.Delete.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "DELETE /dashboard/newsletter-subscribers/:subscriberId"
+type Route =
+  "dashboard"
+    :> "newsletter-subscribers"
+    :> Servant.Capture "subscriberId" NewsletterSubscribers.Id
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Delete '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Handler.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module API.Dashboard.NewsletterSubscribers.Get.Handler (handler) where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.NewsletterSubscribers.Get.Templates.ItemsFragment (renderItemsFragment)
+import API.Dashboard.NewsletterSubscribers.Get.Templates.Page (template)
+import API.Links (apiLinks, dashboardNewsletterSubscribersLinks)
+import API.Types
+import App.Common (renderDashboardTemplate)
+import App.Handler.Combinators (requireAuth, requireStaffNotSuspended)
+import App.Handler.Error (handleHtmlErrors, throwDatabaseError)
+import App.Monad (AppM)
+import Component.DashboardFrame (DashboardNav (..))
+import Control.Monad.Trans (lift)
+import Data.Int (Int64)
+import Data.Maybe (fromMaybe)
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Design (base, class_)
+import Design.Tokens qualified as Tokens
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest (..), foldHxReq)
+import Effects.Database.Execute (execQuery)
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Lucid qualified
+import Lucid.HTMX
+import Servant.Links qualified as Links
+import Utils (fromRightM)
+
+--------------------------------------------------------------------------------
+
+-- | Number of subscribers per page.
+pageSize :: Int64
+pageSize = 50
+
+
+-- | Handler for GET /dashboard/newsletter-subscribers.
+handler ::
+  Maybe Cookie ->
+  Maybe HxRequest ->
+  Maybe Text ->
+  Maybe Int64 ->
+  AppM (Lucid.Html ())
+handler cookie (foldHxReq -> hxRequest) mSearchRaw mPage =
+  handleHtmlErrors "Newsletter subscribers list" apiLinks.rootGet $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireStaffNotSuspended "Only staff can view newsletter subscribers." userMetadata
+
+    let mSearch = normalizeSearch mSearchRaw
+        page = max 1 (fromMaybe 1 mPage)
+        offset = (page - 1) * pageSize
+        isAppendRequest = hxRequest == IsHxRequest && page > 1
+
+    subscribers <- fromRightM throwDatabaseError $ execQuery (NewsletterSubscribers.getPaginated mSearch pageSize offset)
+    total <- fromRightM throwDatabaseError $ execQuery (NewsletterSubscribers.countAll mSearch)
+
+    let hasMore = total > page * pageSize
+
+    if isAppendRequest
+      then pure $ renderItemsFragment subscribers page hasMore mSearch
+      else
+        lift $
+          renderDashboardTemplate
+            hxRequest
+            userMetadata
+            []
+            Nothing
+            NavNewsletterSubscribers
+            Nothing
+            (Just actionButton)
+            (template subscribers total page hasMore mSearch)
+
+
+-- | Drop empty/whitespace-only search strings.
+normalizeSearch :: Maybe Text -> Maybe Text
+normalizeSearch =
+  (>>= \t -> let stripped = Text.strip t in if Text.null stripped then Nothing else Just stripped)
+
+
+-- | "BULK ADD" action button rendered in the dashboard top bar.
+actionButton :: Lucid.Html ()
+actionButton =
+  let bulkUri = Links.linkURI dashboardNewsletterSubscribersLinks.bulkGet
+      bulkUrl :: Text
+      bulkUrl = [i|/#{bulkUri}|]
+   in Lucid.a_
+        [ Lucid.href_ bulkUrl,
+          hxGet_ bulkUrl,
+          hxTarget_ "#main-content",
+          hxPushUrl_ "true",
+          class_ $ base [Tokens.bgAlt, Tokens.fgPrimary, Tokens.px4, Tokens.py2, Tokens.textSm, Tokens.fontBold, Tokens.hoverBg]
+        ]
+        (Lucid.toHtml ("BULK ADD" :: Text))

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Route.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Route.hs
@@ -1,0 +1,24 @@
+module API.Dashboard.NewsletterSubscribers.Get.Route where
+
+--------------------------------------------------------------------------------
+
+import Data.Int (Int64)
+import Data.Text (Text)
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.HxRequest (HxRequest)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "GET /dashboard/newsletter-subscribers"
+type Route =
+  "dashboard"
+    :> "newsletter-subscribers"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Header "HX-Request" HxRequest
+    :> Servant.QueryParam "search" Text
+    :> Servant.QueryParam "page" Int64
+    :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Templates/ItemsFragment.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Templates/ItemsFragment.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Fragment template for infinite scroll append responses.
+--
+-- Renders only the new subscriber rows and the sentinel/end indicator,
+-- without the page wrapper. Used when appending content via HTMX.
+module API.Dashboard.NewsletterSubscribers.Get.Templates.ItemsFragment
+  ( renderItemsFragment,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import API.Dashboard.NewsletterSubscribers.Get.Templates.Page (renderSubscriberRow)
+import API.Links (dashboardNewsletterSubscribersLinks)
+import API.Types
+import Component.Table (renderTableFragment)
+import Data.Int (Int64)
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Lucid qualified
+import Servant.Links qualified as Links
+
+--------------------------------------------------------------------------------
+
+-- | Render just the subscriber rows and sentinel for infinite scroll append.
+renderItemsFragment ::
+  [NewsletterSubscribers.Model] ->
+  Int64 ->
+  Bool ->
+  Maybe Text ->
+  Lucid.Html ()
+renderItemsFragment subscribers currentPage hasMore mSearch =
+  renderTableFragment
+    3
+    "#subscribers-table-body"
+    (if hasMore then Just [i|/#{nextPageUrl}|] else Nothing)
+    (mapM_ renderSubscriberRow subscribers)
+  where
+    nextPageUrl :: Links.URI
+    nextPageUrl = Links.linkURI $ dashboardNewsletterSubscribersLinks.list mSearch (Just (currentPage + 1))

--- a/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Templates/Page.hs
+++ b/services/web/src/API/Dashboard/NewsletterSubscribers/Get/Templates/Page.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module API.Dashboard.NewsletterSubscribers.Get.Templates.Page
+  ( template,
+    renderSubscriberRow,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import API.Links (dashboardNewsletterSubscribersLinks)
+import API.Types
+import Component.Table
+  ( ColumnAlign (..),
+    ColumnHeader (..),
+    IndexTableConfig (..),
+    PaginationConfig (..),
+    renderIndexTable,
+    rowAttrs,
+  )
+import Data.Int (Int64)
+import Data.Maybe (fromMaybe)
+import Data.String.Interpolate (i)
+import Data.Text (Text)
+import Data.Text.Display (display)
+import Data.Time (UTCTime, defaultTimeLocale, formatTime)
+import Design (base, class_)
+import Design.Tokens qualified as Tokens
+import Effects.Database.Tables.NewsletterSubscribers qualified as NewsletterSubscribers
+import Lucid qualified
+import Lucid.HTMX
+import Servant.Links qualified as Links
+
+--------------------------------------------------------------------------------
+
+-- | Newsletter subscribers list template.
+template ::
+  -- | Subscribers on the current page.
+  [NewsletterSubscribers.Model] ->
+  -- | Total subscriber count for the current search filter.
+  Int64 ->
+  -- | Current page number (1-indexed).
+  Int64 ->
+  -- | Whether another page exists.
+  Bool ->
+  -- | Current search term, if any.
+  Maybe Text ->
+  Lucid.Html ()
+template subscribers total currentPage hasMore mSearch = do
+  Lucid.section_ [class_ $ base [Tokens.bgMain, Tokens.mb4]] $
+    renderSearchBar mSearch total
+  Lucid.div_ [Lucid.id_ "subscribers-list"] $
+    Lucid.section_ [class_ $ base [Tokens.bgMain, "rounded", "overflow-hidden", Tokens.mb8]] $
+      if total == 0
+        then renderEmptyState mSearch
+        else
+          renderIndexTable
+            IndexTableConfig
+              { itcBodyId = "subscribers-table-body",
+                itcHeaders =
+                  [ ColumnHeader "Email" AlignLeft,
+                    ColumnHeader "Subscribed On" AlignLeft,
+                    ColumnHeader "" AlignCenter
+                  ],
+                itcNextPageUrl = if hasMore then Just [i|/#{nextPageUrl}|] else Nothing,
+                itcPaginationConfig =
+                  Just
+                    PaginationConfig
+                      { pcPrevPageUrl = if currentPage > 1 then Just [i|/#{prevPageUrl}|] else Nothing,
+                        pcNextPageUrl = if hasMore then Just [i|/#{nextPageUrl}|] else Nothing,
+                        pcCurrentPage = currentPage
+                      }
+              }
+            (mapM_ renderSubscriberRow subscribers)
+  where
+    nextPageUrl :: Links.URI
+    nextPageUrl = Links.linkURI $ dashboardNewsletterSubscribersLinks.list mSearch (Just (currentPage + 1))
+
+    prevPageUrl :: Links.URI
+    prevPageUrl = Links.linkURI $ dashboardNewsletterSubscribersLinks.list mSearch (Just (currentPage - 1))
+
+
+-- | Search input bar that re-fetches the list on submit.
+renderSearchBar :: Maybe Text -> Int64 -> Lucid.Html ()
+renderSearchBar mSearch total =
+  let listUri = Links.linkURI $ dashboardNewsletterSubscribersLinks.list Nothing Nothing
+      listUrl :: Text
+      listUrl = [i|/#{listUri}|]
+   in Lucid.div_ [class_ $ base ["flex", "items-center", "justify-between", Tokens.gap4, Tokens.p4]] $ do
+        Lucid.form_
+          [ hxGet_ listUrl,
+            hxTarget_ "#main-content",
+            hxPushUrl_ "true",
+            class_ $ base ["flex", "items-center", Tokens.gap4, "flex-1"]
+          ]
+          $ do
+            Lucid.input_
+              [ Lucid.type_ "search",
+                Lucid.name_ "search",
+                Lucid.value_ (fromMaybe "" mSearch),
+                Lucid.placeholder_ "Search by email...",
+                class_ $ base ["px-3", "py-2", Tokens.textSm, "border", Tokens.borderMuted, Tokens.bgMain, Tokens.fgPrimary, "w-64"]
+              ]
+            Lucid.button_
+              [ Lucid.type_ "submit",
+                class_ $ base [Tokens.px4, Tokens.py2, Tokens.textSm, Tokens.bgInverse, Tokens.fgInverse, Tokens.fontBold, "hover:opacity-80"]
+              ]
+              "Search"
+        Lucid.span_ [class_ $ base [Tokens.textSm, Tokens.fgMuted]] $
+          Lucid.toHtml $
+            (show total :: String) <> " subscriber" <> (if total == 1 then "" else "s")
+
+
+-- | Render a single subscriber row, with a per-row delete button.
+renderSubscriberRow :: NewsletterSubscribers.Model -> Lucid.Html ()
+renderSubscriberRow subscriber =
+  let subId = NewsletterSubscribers.mId subscriber
+      subIdText = display subId
+      rowId :: Text
+      rowId = [i|subscriber-row-#{subIdText}|]
+      rowSelector :: Text
+      rowSelector = "#" <> rowId
+      deleteUri = Links.linkURI $ dashboardNewsletterSubscribersLinks.delete subId
+      deleteUrl :: Text
+      deleteUrl = [i|/#{deleteUri}|]
+      confirmMessage :: Text
+      confirmMessage =
+        "Delete subscriber \"" <> display (NewsletterSubscribers.mEmail subscriber) <> "\"? This cannot be undone."
+   in Lucid.tr_ (rowAttrs rowId) $ do
+        Lucid.td_ [class_ $ base [Tokens.p4]] $
+          Lucid.span_ [Lucid.class_ Tokens.textSm] $
+            Lucid.toHtml (display (NewsletterSubscribers.mEmail subscriber))
+
+        Lucid.td_ [class_ $ base [Tokens.p4]] $
+          Lucid.span_ [class_ $ base [Tokens.textSm, Tokens.fgMuted]] $
+            Lucid.toHtml (formatDateTime (NewsletterSubscribers.mCreatedAt subscriber))
+
+        Lucid.td_ [class_ $ base [Tokens.p4, "text-center"]] $
+          Lucid.button_
+            [ hxDelete_ deleteUrl,
+              hxTarget_ rowSelector,
+              hxSwap_ "outerHTML",
+              hxConfirm_ confirmMessage,
+              class_ $ base [Tokens.px3, "py-1", Tokens.textSm, Tokens.fontBold, Tokens.errorBg, Tokens.errorText, "border", Tokens.borderMuted, "hover:opacity-80"]
+            ]
+            "Delete"
+
+
+renderEmptyState :: Maybe Text -> Lucid.Html ()
+renderEmptyState mSearch =
+  Lucid.div_ [class_ $ base [Tokens.bgAlt, Tokens.border2, Tokens.borderMuted, "p-12", "text-center"]] $ do
+    case mSearch of
+      Just search ->
+        Lucid.p_ [class_ $ base [Tokens.textXl, Tokens.fgMuted]] $
+          Lucid.toHtml $
+            "No subscribers match \"" <> search <> "\"."
+      Nothing -> do
+        Lucid.p_ [class_ $ base [Tokens.textXl, Tokens.fgMuted]] "No newsletter subscribers yet."
+        Lucid.p_ [class_ $ base [Tokens.fgMuted, "mt-2"]] "Bulk add subscribers to get started."
+
+
+-- | Format a UTC timestamp as a human-readable date string.
+formatDateTime :: UTCTime -> String
+formatDateTime = formatTime defaultTimeLocale "%b %d, %Y"

--- a/services/web/src/API/Links.hs
+++ b/services/web/src/API/Links.hs
@@ -45,6 +45,7 @@ module API.Links
     dashboardMissingEpisodesLink,
     dashboardAnalyticsLinks,
     dashboardInvitationsLinks,
+    dashboardNewsletterSubscribersLinks,
     dashboardStoreLinks,
     dashboardStoreProductsLinks,
     dashboardStoreSettingsLinks,
@@ -178,6 +179,10 @@ dashboardAnalyticsLinks = dashboardAdminLinks.analytics
 -- | Dashboard invitations route links.
 dashboardInvitationsLinks :: DashboardInvitationsRoutes (AsLink Link)
 dashboardInvitationsLinks = dashboardAdminLinks.invitations
+
+-- | Dashboard newsletter subscribers route links.
+dashboardNewsletterSubscribersLinks :: DashboardNewsletterSubscribersRoutes (AsLink Link)
+dashboardNewsletterSubscribersLinks = dashboardAdminLinks.newsletterSubscribers
 
 -- | Invite onboarding route links.
 inviteLinks :: InviteRoutes (AsLink Link)

--- a/services/web/src/API/Types.hs
+++ b/services/web/src/API/Types.hs
@@ -26,6 +26,7 @@ module API.Types
     DashboardShowsRoutes (..),
     DashboardUsersRoutes (..),
     DashboardInvitationsRoutes (..),
+    DashboardNewsletterSubscribersRoutes (..),
     DashboardSitePagesRoutes (..),
     DashboardStreamSettingsRoutes (..),
     DashboardAnalyticsRoutes (..),
@@ -86,6 +87,10 @@ import API.Dashboard.Invitations.New.Get.Route qualified as Dashboard.Invitation
 import API.Dashboard.Invitations.New.Post.Route qualified as Dashboard.Invitations.New.Post
 import API.Dashboard.Invitations.Regenerate.Route qualified as Dashboard.Invitations.Regenerate
 import API.Dashboard.MissingEpisodes.Get.Route qualified as Dashboard.MissingEpisodes.Get
+import API.Dashboard.NewsletterSubscribers.Bulk.Get.Route qualified as Dashboard.NewsletterSubscribers.Bulk.Get
+import API.Dashboard.NewsletterSubscribers.Bulk.Post.Route qualified as Dashboard.NewsletterSubscribers.Bulk.Post
+import API.Dashboard.NewsletterSubscribers.Delete.Route qualified as Dashboard.NewsletterSubscribers.Delete
+import API.Dashboard.NewsletterSubscribers.Get.Route qualified as Dashboard.NewsletterSubscribers.Get
 import API.Dashboard.Profile.Edit.Get.Route qualified as Dashboard.Profile.Edit.Get
 import API.Dashboard.Profile.Edit.Post.Route qualified as Dashboard.Profile.Edit.Post
 import API.Dashboard.Shows.Get.Route qualified as Dashboard.Shows.Get
@@ -417,7 +422,9 @@ data DashboardAdminRoutes mode = DashboardAdminRoutes
     -- | @/dashboard/analytics/...@ - Analytics dashboard routes
     analytics :: mode :- NamedRoutes DashboardAnalyticsRoutes,
     -- | @/dashboard/store/...@ - Store management routes
-    store :: mode :- NamedRoutes DashboardStoreRoutes
+    store :: mode :- NamedRoutes DashboardStoreRoutes,
+    -- | @/dashboard/newsletter-subscribers/...@ - Newsletter subscriber management routes
+    newsletterSubscribers :: mode :- NamedRoutes DashboardNewsletterSubscribersRoutes
   }
   deriving stock (Generic)
 
@@ -652,6 +659,22 @@ data DashboardInvitationsRoutes mode = DashboardInvitationsRoutes
     regenerate :: mode :- Dashboard.Invitations.Regenerate.Route,
     -- | @DELETE /dashboard/invitations/:invitationId@ - Revoke invitation
     delete :: mode :- Dashboard.Invitations.Delete.Route
+  }
+  deriving stock (Generic)
+
+-- | Dashboard newsletter subscriber management routes under @/dashboard/newsletter-subscribers@.
+--
+-- For staff and admins to view, search, bulk-add, and delete homepage
+-- newsletter signups.
+data DashboardNewsletterSubscribersRoutes mode = DashboardNewsletterSubscribersRoutes
+  { -- | @GET /dashboard/newsletter-subscribers@ - Subscriber list with search + pagination
+    list :: mode :- Dashboard.NewsletterSubscribers.Get.Route,
+    -- | @GET /dashboard/newsletter-subscribers/bulk@ - Bulk add form
+    bulkGet :: mode :- Dashboard.NewsletterSubscribers.Bulk.Get.Route,
+    -- | @POST /dashboard/newsletter-subscribers/bulk@ - Submit bulk add
+    bulkPost :: mode :- Dashboard.NewsletterSubscribers.Bulk.Post.Route,
+    -- | @DELETE /dashboard/newsletter-subscribers/:subscriberId@ - Delete subscriber
+    delete :: mode :- Dashboard.NewsletterSubscribers.Delete.Route
   }
   deriving stock (Generic)
 

--- a/services/web/src/Component/DashboardFrame.hs
+++ b/services/web/src/Component/DashboardFrame.hs
@@ -20,6 +20,7 @@ import API.Links
     dashboardInvitationsLinks,
     dashboardLinks,
     dashboardMissingEpisodesLink,
+    dashboardNewsletterSubscribersLinks,
     dashboardShowsLinks,
     dashboardSitePagesLinks,
     dashboardStationBlogLinks,
@@ -111,6 +112,10 @@ dashboardAnalyticsGetUrl = Links.linkURI dashboardAnalyticsLinks.get
 dashboardInvitationsGetUrl :: Links.URI
 dashboardInvitationsGetUrl = Links.linkURI dashboardInvitationsLinks.list
 
+dashboardNewsletterSubscribersGetUrl :: Links.URI
+dashboardNewsletterSubscribersGetUrl =
+  Links.linkURI $ dashboardNewsletterSubscribersLinks.list Nothing Nothing
+
 dashboardStoreProductsGetUrl :: Links.URI
 dashboardStoreProductsGetUrl = Links.linkURI dashboardStoreProductsLinks.list
 
@@ -139,6 +144,7 @@ data DashboardNav
   | NavMissingEpisodes
   | NavAnalytics
   | NavInvitations
+  | NavNewsletterSubscribers
   | NavStoreProducts
   | NavStoreOrders
   | NavStoreSettings
@@ -162,6 +168,7 @@ isShowScoped = \case
   NavMissingEpisodes -> False
   NavAnalytics -> False
   NavInvitations -> False
+  NavNewsletterSubscribers -> False
   NavStoreProducts -> False
   NavStoreOrders -> False
   NavStoreSettings -> False
@@ -249,6 +256,7 @@ sidebar userMeta activeNav selectedShow =
           Lucid.ul_ [Lucid.class_ "space-y-2"] $ do
             staffNavItem "USERS" NavUsers activeNav
             staffNavItem "INVITATIONS" NavInvitations activeNav
+            staffNavItem "NEWSLETTER" NavNewsletterSubscribers activeNav
             staffNavItem "SHOWS" NavShows activeNav
             staffNavItem "STATION BLOG" NavStationBlog activeNav
             staffNavItem "EVENTS" NavEvents activeNav
@@ -372,6 +380,7 @@ staffNavUrl = \case
   NavMissingEpisodes -> Just dashboardMissingEpisodesGetUrl
   NavAnalytics -> Just dashboardAnalyticsGetUrl
   NavInvitations -> Just dashboardInvitationsGetUrl
+  NavNewsletterSubscribers -> Just dashboardNewsletterSubscribersGetUrl
   NavStoreProducts -> Just dashboardStoreProductsGetUrl
   NavStoreOrders -> Just dashboardStoreOrdersGetUrl
   NavStoreSettings -> Just dashboardStoreSettingsGetUrl
@@ -399,6 +408,7 @@ navUrl nav mShow =
         NavMissingEpisodes -> Just dashboardMissingEpisodesGetUrl
         NavAnalytics -> Just dashboardAnalyticsGetUrl
         NavInvitations -> Just dashboardInvitationsGetUrl
+        NavNewsletterSubscribers -> Just dashboardNewsletterSubscribersGetUrl
         NavStoreProducts -> Just dashboardStoreProductsGetUrl
         NavStoreOrders -> Just dashboardStoreOrdersGetUrl
         NavStoreSettings -> Just dashboardStoreSettingsGetUrl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,6 +84,7 @@ just tf-validate
 | DigitalOcean firewalls (prod + staging) | digitalocean | `digitalocean.tf` |
 | DigitalOcean SSH keys                | digitalocean | `digitalocean.tf` |
 | DigitalOcean Spaces buckets (prod + staging) | digitalocean | `digitalocean.tf` |
+| DigitalOcean project (`kpbj-fm`)     | digitalocean | `digitalocean.tf` |
 | Cloudflare DNS records               | cloudflare   | `cloudflare.tf`   |
 | Cloudflare proxy settings            | cloudflare   | `cloudflare.tf`   |
 | GCP Admin SDK API enablement         | google       | `google.tf`       |

--- a/terraform/digitalocean.tf
+++ b/terraform/digitalocean.tf
@@ -143,6 +143,30 @@ resource "digitalocean_firewall" "stream_prod" {
   }
 }
 
+# ──────────────────────────────────────────────────────────────
+# Project — groups KPBJ resources in the DO control panel
+# ──────────────────────────────────────────────────────────────
+#
+# Project assignment is metadata-only on DO's side: assigning a
+# resource here moves it out of whatever project currently owns
+# it (including the account default project) without touching
+# the resource itself — no reboot, no IP change, no downtime.
+# Firewalls and SSH keys are not project-assignable.
+
+resource "digitalocean_project" "kpbj" {
+  name        = "kpbj-fm"
+  description = "KPBJ 95.9FM community radio — streaming VPS, web app, object storage"
+  purpose     = "Web Application"
+
+  resources = [
+    digitalocean_droplet.stream_prod.urn,
+    digitalocean_droplet.staging.urn,
+    digitalocean_spaces_bucket.prod_storage.urn,
+    digitalocean_spaces_bucket.staging_storage.urn,
+    digitalocean_spaces_bucket.pgbackrest.urn,
+  ]
+}
+
 resource "digitalocean_firewall" "staging" {
   name        = "kpbj-staging-fw"
   droplet_ids = [digitalocean_droplet.staging.id]


### PR DESCRIPTION
## Summary

Dashboard CRUD for managing the `newsletter_subscribers` table, gated by `requireStaffNotSuspended`.

**New routes** (under `/dashboard/newsletter-subscribers`, all staff-only):

- `GET  /dashboard/newsletter-subscribers` — paginated list with email search
- `GET  /dashboard/newsletter-subscribers/bulk` — bulk-add form
- `POST /dashboard/newsletter-subscribers/bulk` — accepts comma- or newline-separated emails; reports added / duplicate / invalid counts in a flash banner
- `DELETE /dashboard/newsletter-subscribers/:id` — per-row delete (Pattern C)

**Table module** (`Effects.Database.Tables.NewsletterSubscribers`) gains `getPaginated`, `countAll`, `getById`, and `deleteById`. Bulk-add reuses the existing insert with per-row `ON CONFLICT DO NOTHING`, so duplicates and successes are reported separately without aborting the batch.

**Sidebar:** new NEWSLETTER entry under ADMIN (`Component.DashboardFrame`).

## Docs

Also corrects `CLAUDE.md`'s "HTMX Response Patterns" section, which still referenced the pre-`ffa546c4` (refactor: Simplify redirect implementations) helpers `BannerParams` and `redirectWithBanner`. Pattern A now documents the real `handleRedirectErrors` + `FlashMessage` + `flashCookie` shape used across the codebase.

## Test plan

- [x] List view loads, paginates, and search filters by email
- [x] Bulk-add accepts comma- and newline-separated input; banner reports added / duplicate / invalid counts
- [x] Delete removes the row inline (Pattern C, no full-page reload)
- [x] All routes 403 for non-staff users