### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.12.1] - 2026-05-21
+
 ### Added
 - **Mailchimp Graceful Disable** — Web service and inbound webhook now log a loud `MAILCHIMP DISABLED` banner (`LogAttention`) at boot when `MAILCHIMP_API_KEY` / `MAILCHIMP_AUDIENCE_ID` / `MAILCHIMP_WEBHOOK_SECRET` are absent, so a missed prod rotation does not go silent. New `kpbj.web.mailchimp.enable` NixOS option (default `true`) gates the three sops secret declarations, the `MAILCHIMP_*` env template lines, and the reconcile env template. Staging points at a separate Mailchimp audience with its own sopsified credentials (Mailchimp does not offer sandbox accounts), so end-to-end signup/webhook round-trips can be exercised without touching the prod audience.
 - **Host Invitation Recipient Email + Readable Token** — Invitations now require a recipient email and automatically send a plain-text invite link to that address on creation. Existing-user collisions are blocked. The dashboard list shows the recipient per row. Pending invitations can be edited inline (HTMX row swap) or resent without minting a new token. Invitations use a human-readable `INV-XXXX-XXXX` code (Crockford-style base32, 0/1/O/I/L excluded for visual disambiguation) instead of UUID hex; the new format is enforced by a CHECK constraint at the DB level. Migration `add_recipient_email_to_host_invitations` wipes legacy rows — the new server-side email-equality check on claim renders legacy invitations (with no bound recipient) unclaimable, and claimed-row history is independently in `shows` / `show_hosts`.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.12.0
+version:            0.12.1
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.12.1

This PR releases version 0.12.1

### What's Changed


### Added
- **Mailchimp Graceful Disable** — Web service and inbound webhook now log a loud `MAILCHIMP DISABLED` banner (`LogAttention`) at boot when `MAILCHIMP_API_KEY` / `MAILCHIMP_AUDIENCE_ID` / `MAILCHIMP_WEBHOOK_SECRET` are absent, so a missed prod rotation does not go silent. New `kpbj.web.mailchimp.enable` NixOS option (default `true`) gates the three sops secret declarations, the `MAILCHIMP_*` env template lines, and the reconcile env template. Staging points at a separate Mailchimp audience with its own sopsified credentials (Mailchimp does not offer sandbox accounts), so end-to-end signup/webhook round-trips can be exercised without touching the prod audience.
- **Host Invitation Recipient Email + Readable Token** — Invitations now require a recipient email and automatically send a plain-text invite link to that address on creation. Existing-user collisions are blocked. The dashboard list shows the recipient per row. Pending invitations can be edited inline (HTMX row swap) or resent without minting a new token. Invitations use a human-readable `INV-XXXX-XXXX` code (Crockford-style base32, 0/1/O/I/L excluded for visual disambiguation) instead of UUID hex; the new format is enforced by a CHECK constraint at the DB level. Migration `add_recipient_email_to_host_invitations` wipes legacy rows — the new server-side email-equality check on claim renders legacy invitations (with no bound recipient) unclaimable, and claimed-row history is independently in `shows` / `show_hosts`.
- **Newsletter Subscribers Admin CRUD** — Admin dashboard CRUD for newsletter subscribers — list with search/pagination, bulk insert (comma or newline-separated), and per-row delete. New routes under `/dashboard/newsletter-subscribers`, gated by `requireStaffNotSuspended`. Backed by new `getPaginated`, `countAll`, `getById`, and `deleteById` queries on the existing `newsletter_subscribers` table.
- **Mailchimp Sync** — Bidirectional sync between the in-app `newsletter_subscribers` table and the Mailchimp audience. Outbound: signups, registration newsletter opt-ins, and admin bulk-add push to MC asynchronously via `Effects.Mailchimp.Sync` (fire-and-forget, 30s timeout, `mailchimp_status` flips between `pending`/`subscribed`/`error`). Admin-side deletes archive the MC member. Inbound: `POST /api/webhooks/mailchimp` receives `subscribe`/`unsubscribe`/`cleaned`/`upemail` events (auth via `?key=<secret>` query param, constant-time compare) and reconciles them locally — `unsubscribe` deletes the local row, `cleaned` (hard bounce) tombstones the row at status `cleaned` and surfaces a friendly "previously bounced — contact us to resubscribe" message if the user retries the homepage form, `upemail` updates the email and re-pushes. Daily systemd timer `kpbj-mailchimp-reconcile.timer` (02:30 UTC) catches any drift the webhooks miss. Run `sudo systemctl start kpbj-mailchimp-reconcile-bootstrap` once after first deploy to import existing MC subscribers. New `lib/mailchimp-http` package wraps the Marketing API v3 + webhook parser; `jobs/mailchimp-reconcile` is the new daily job. Doc-verified contracts: HTTP Basic auth, `status_if_new` (not `status`) on upsert to avoid CAN-SPAM-violating resubscribes, MD5(lowercase(email)) subscriber hash.

### Changed
- **Dedicated `kpbj-fm` DigitalOcean Project** — Added a `digitalocean_project` resource (`terraform/digitalocean.tf`) that groups both droplets (`stream_prod`, `staging`) and all three Spaces buckets (`production-kpbj-storage`, `staging-kpbj-storage`, `kpbj-pgbackrest`) under a dedicated `kpbj-fm` project in the DO control panel. Project assignment is metadata-only on DO's side, so the move is non-destructive — no reboot, no IP change, no downtime. Firewalls and SSH keys are not project-assignable, so they remain unaffiliated.

---

When merged, a git tag v0.12.1 will be automatically created, which triggers the production deployment.
