### PR TITLE
refactor: Remove backend shipping carrier gating (manage in EasyPost)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+- **Shipping carriers managed in EasyPost** — Removed the backend carrier whitelist (`filterRates`) from the checkout and label-purchase flows. Every rate EasyPost returns is now offered (sorted by price); which carriers appear is controlled entirely by the carrier accounts configured in the EasyPost dashboard.
 
 ---
 

--- a/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
@@ -49,7 +49,7 @@ import Effects.Database.Tables.StoreSettings qualified as StoreSettings
 import Log qualified
 import Lucid qualified
 import Network.HTTP.Client (Manager)
-import Store.Checkout.Logic (filterRates, sortRatesByPrice)
+import Store.Checkout.Logic (sortRatesByPrice)
 import Utils (fromMaybeM)
 
 --------------------------------------------------------------------------------
@@ -97,7 +97,7 @@ createShipmentAndShowRates order = do
       lift $ Log.logInfo "EasyPost createShipment failed" (show err)
       pure $ renderBanner Error "Shipping Error" "Could not create shipment. Please try again."
     Right shipment ->
-      pure $ Templates.ratesTemplate shipment (sortRatesByPrice (filterRates shipment.rates)) order.oId
+      pure $ Templates.ratesTemplate shipment (sortRatesByPrice shipment.rates) order.oId
 
 -- | Step 2: buy the selected rate, persist tracking info, return success HTML.
 buyLabelAndUpdate ::

--- a/services/web/src/API/Store/ShippingRates/Post/Handler.hs
+++ b/services/web/src/API/Store/ShippingRates/Post/Handler.hs
@@ -39,7 +39,7 @@ import Effects.Database.Tables.StoreSettings qualified as StoreSettings
 import Log qualified
 import Lucid qualified
 import Network.HTTP.Client (Manager)
-import Store.Checkout.Logic (computeSubtotal, filterRates, sortRatesByPrice)
+import Store.Checkout.Logic (computeSubtotal, sortRatesByPrice)
 
 --------------------------------------------------------------------------------
 
@@ -80,10 +80,10 @@ handler req = do
                       let subtotal =
                             computeSubtotal
                               [ (ri.riUnitPrice, fromIntegral ri.riQuantity)
-                                | ri <- resolvedItems
+                              | ri <- resolvedItems
                               ]
                           taxRate = settings.ssTaxRate
-                          sortedRates = sortRatesByPrice (filterRates shipment.rates)
+                          sortedRates = sortRatesByPrice shipment.rates
                       pure $ Templates.template shipment sortedRates subtotal taxRate
 
 --------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ buildShipmentCreate req settings resolvedItems =
       fromIntegral $
         sum
           [ ri.riWeightOz * fromIntegral ri.riQuantity
-            | ri <- resolvedItems
+          | ri <- resolvedItems
           ]
 
 --------------------------------------------------------------------------------

--- a/services/web/src/Store/Checkout/Logic.hs
+++ b/services/web/src/Store/Checkout/Logic.hs
@@ -5,7 +5,6 @@ module Store.Checkout.Logic
     maskEmail,
     formatOrderNumber,
     easypostRateToCents,
-    filterRates,
     sortRatesByPrice,
   )
 where
@@ -74,10 +73,6 @@ easypostRateToCents rateText =
   case reads (Text.unpack rateText) :: [(Double, String)] of
     [(d, "")] -> Just $ Cents $ round (d * 100)
     _ -> Nothing
-
--- | Filter rates to USPS and UPS only.
-filterRates :: [Rate] -> [Rate]
-filterRates = filter (\r -> r.carrier == "USPS" || r.carrier == "UPS")
 
 -- | Sort EasyPost rates by their parsed cent value (cheapest first).
 --


### PR DESCRIPTION
Removes the backend shipping carrier whitelist so carrier availability is managed entirely in EasyPost.

- Drops `filterRates` (the hardcoded USPS/UPS filter) from `Store.Checkout.Logic`.
- Checkout and the dashboard label-purchase flow now offer every rate EasyPost returns, sorted by price.
- Which carriers appear is governed by the carrier accounts configured in the EasyPost dashboard — no code or migration needed to add/remove one.

_(Supersedes the earlier carrier-toggles approach on this branch; that added per-store config, but the real gating already lives in EasyPost, so the whitelist was redundant.)_
