### PR TITLE
feat: Surface EasyPost address errors and verify delivery at checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ### Changed
 - **Shipping carriers managed in EasyPost** — Removed the backend carrier whitelist (`filterRates`) from the checkout and label-purchase flows. Every rate EasyPost returns is now offered (sorted by price); which carriers appear is controlled entirely by the carrier accounts configured in the EasyPost dashboard.
+- **Helpful shipping-address errors at checkout** — When EasyPost rejects a shipping address, the checkout now surfaces the specific problem (e.g. "House number is missing") instead of a generic "check your address" banner. The `easypost-http` client parses EasyPost's structured `{"error": {...}}` payloads (`EasyPostError`/`EasyPostFieldError`), and the customer shipping-rate lookup now proactively requests delivery-address verification, showing a targeted message when the address can't be verified before quoting rates. The same parsed-error copy is reused across the create-session and label-purchase failure paths.
 
 ---
 

--- a/lib/easypost-http/easypost-http.cabal
+++ b/lib/easypost-http/easypost-http.cabal
@@ -53,10 +53,14 @@ test-suite easypost-http-test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Main.hs
-  other-modules:    EasyPost.IntegrationSpec
+  other-modules:
+    EasyPost.IntegrationSpec
+    EasyPost.TypesSpec
   default-language: Haskell2010
   build-depends:
-      base
+      aeson
+    , base
+    , bytestring
     , easypost-http
     , hspec
     , http-client

--- a/lib/easypost-http/src/EasyPost/Client.hs
+++ b/lib/easypost-http/src/EasyPost/Client.hs
@@ -10,6 +10,7 @@
 module EasyPost.Client
   ( -- * Error Type
     EasyPostClientError (..),
+    easyPostErrorDetails,
 
     -- * Client Functions
     createShipment,
@@ -18,6 +19,7 @@ module EasyPost.Client
   )
 where
 
+import Data.Aeson qualified as Aeson
 import Data.ByteString.Base64 qualified as Base64
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
@@ -25,6 +27,7 @@ import Data.Text.Encoding qualified as Text
 import EasyPost.API (EasyPostAPI)
 import EasyPost.Types
   ( EasyPostApiKey (..),
+    EasyPostError,
     Shipment,
     ShipmentBuy,
     ShipmentCreate,
@@ -37,6 +40,25 @@ import Servant.Client qualified as Client
 -- | An error from an EasyPost API call, wrapping the underlying 'Client.ClientError'.
 newtype EasyPostClientError = EasyPostClientError {unEasyPostClientError :: Client.ClientError}
   deriving stock (Show)
+
+
+-- | Extract EasyPost's structured error body from a client error, when present.
+--
+-- EasyPost returns a JSON @{"error": {...}}@ body on 4xx/5xx responses. This
+-- pulls the raw response body out of the wrapped 'Client.ClientError' and
+-- attempts to decode it into an 'EasyPostError'. Returns 'Nothing' for
+-- connection-level failures (which carry no response body) and when the body
+-- cannot be decoded.
+easyPostErrorDetails :: EasyPostClientError -> Maybe EasyPostError
+easyPostErrorDetails (EasyPostClientError clientError) =
+  case clientError of
+    Client.FailureResponse _ resp -> decodeBody resp
+    Client.DecodeFailure _ resp -> decodeBody resp
+    Client.UnsupportedContentType _ resp -> decodeBody resp
+    Client.InvalidContentTypeHeader resp -> decodeBody resp
+    Client.ConnectionError _ -> Nothing
+  where
+    decodeBody = Aeson.decode . Client.responseBody
 
 
 -- | Base URL for the EasyPost API.

--- a/lib/easypost-http/src/EasyPost/Types.hs
+++ b/lib/easypost-http/src/EasyPost/Types.hs
@@ -25,11 +25,19 @@ module EasyPost.Types
 
     -- * Label
     Label (..),
+
+    -- * Errors
+    EasyPostError (..),
+    EasyPostFieldError (..),
+
+    -- * Verification
+    Verification (..),
   )
 where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -125,20 +133,35 @@ data ShipmentCreate = ShipmentCreate
     -- | Destination address.
     toAddress :: Address,
     -- | Package dimensions and weight.
-    parcel :: Parcel
+    parcel :: Parcel,
+    -- | Address verifications to request (e.g. @["delivery"]@).
+    --
+    -- When empty, no @verify@ key is emitted so the request body is
+    -- byte-identical to callers that don't request verification.
+    verify :: [Text]
   }
   deriving stock (Show, Eq, Generic)
 
 instance ToJSON ShipmentCreate where
   toJSON sc =
     Aeson.object
-      [ "shipment"
-          Aeson..= Aeson.object
-            [ "from_address" Aeson..= sc.fromAddress,
-              "to_address" Aeson..= sc.toAddress,
-              "parcel" Aeson..= sc.parcel
-            ]
-      ]
+      ( [ "shipment"
+            Aeson..= Aeson.object
+              [ "from_address" Aeson..= sc.fromAddress,
+                "to_address" Aeson..= sc.toAddress,
+                "parcel" Aeson..= sc.parcel
+              ]
+        ]
+          <> verifyField
+      )
+    where
+      -- EasyPost expects @verify@ at the ROOT of the request body, as a sibling
+      -- of the @shipment@ object (same pattern as the Address API's
+      -- @{"address": {...}, "verify": ...}@) — NOT nested inside @shipment@.
+      -- Emitted only when non-empty so non-verifying callers are unaffected.
+      verifyField
+        | null sc.verify = []
+        | otherwise = ["verify" Aeson..= sc.verify]
 
 --------------------------------------------------------------------------------
 -- Label
@@ -218,7 +241,13 @@ data Shipment = Shipment
     -- | Tracking code, present after purchase.
     trackingCode :: Maybe Text,
     -- | Postage label, present after purchase.
-    postageLabel :: Maybe Label
+    postageLabel :: Maybe Label,
+    -- | Delivery verification result for the to-address, when EasyPost
+    -- was asked to verify the shipment and returned a verification block.
+    --
+    -- Parsed from @to_address.verifications.delivery@; 'Nothing' when any
+    -- of those keys are absent.
+    toAddressDeliveryVerification :: Maybe Verification
   }
   deriving stock (Show, Eq, Generic)
 
@@ -232,12 +261,96 @@ instance ToJSON Shipment where
         <> maybe [] (\pl -> ["postage_label" Aeson..= pl]) s.postageLabel
 
 instance FromJSON Shipment where
-  parseJSON = Aeson.withObject "Shipment" $ \o ->
-    Shipment
-      <$> o Aeson..: "id"
-      <*> o Aeson..:? "rates" Aeson..!= []
-      <*> o Aeson..:? "tracking_code"
-      <*> o Aeson..:? "postage_label"
+  parseJSON = Aeson.withObject "Shipment" $ \o -> do
+    shipmentId <- o Aeson..: "id"
+    rates <- o Aeson..:? "rates" Aeson..!= []
+    trackingCode <- o Aeson..:? "tracking_code"
+    postageLabel <- o Aeson..:? "postage_label"
+    -- Dig through @to_address.verifications.delivery@ defensively: any
+    -- missing intermediate key yields 'Nothing' rather than a parse error.
+    mToAddress <- o Aeson..:? "to_address" :: Aeson.Parser (Maybe Aeson.Object)
+    deliveryVerification <- case mToAddress of
+      Nothing -> pure Nothing
+      Just toAddr -> do
+        mVerifications <- toAddr Aeson..:? "verifications" :: Aeson.Parser (Maybe Aeson.Object)
+        case mVerifications of
+          Nothing -> pure Nothing
+          Just verifications -> verifications Aeson..:? "delivery"
+    pure
+      Shipment
+        { id = shipmentId,
+          rates = rates,
+          trackingCode = trackingCode,
+          postageLabel = postageLabel,
+          toAddressDeliveryVerification = deliveryVerification
+        }
+
+--------------------------------------------------------------------------------
+-- Errors
+
+-- | A single field-level error reported by EasyPost.
+--
+-- EasyPost returns @errors@ array items as either an object with
+-- @field@/@message@/@suggestion@ keys, or a bare JSON string. Both shapes
+-- decode here; a bare string populates 'message' with the other fields empty.
+data EasyPostFieldError = EasyPostFieldError
+  { -- | The offending request field, when identified.
+    field :: Maybe Text,
+    -- | Human-readable description of the problem.
+    message :: Text,
+    -- | Suggested correction, when EasyPost offers one.
+    suggestion :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON EasyPostFieldError where
+  parseJSON = \case
+    Aeson.String s -> pure (EasyPostFieldError Nothing s Nothing)
+    v ->
+      flip (Aeson.withObject "EasyPostFieldError") v $ \o ->
+        EasyPostFieldError
+          <$> o Aeson..:? "field"
+          <*> o Aeson..: "message"
+          <*> o Aeson..:? "suggestion"
+
+-- | A structured EasyPost API error, unwrapped from the @{"error": {...}}@ envelope.
+data EasyPostError = EasyPostError
+  { -- | Machine-readable error code (e.g. @"ADDRESS.VERIFY.FAILURE"@).
+    code :: Text,
+    -- | Top-level human-readable message.
+    message :: Text,
+    -- | Field-level errors, when present.
+    errors :: [EasyPostFieldError]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON EasyPostError where
+  parseJSON = Aeson.withObject "EasyPostError" $ \envelope -> do
+    o <- envelope Aeson..: "error"
+    EasyPostError
+      <$> o Aeson..: "code"
+      <*> o Aeson..: "message"
+      <*> o Aeson..:? "errors" Aeson..!= []
+
+--------------------------------------------------------------------------------
+-- Verification
+
+-- | An EasyPost address verification result.
+--
+-- Parsed from a shipment's @to_address.verifications.delivery@ block.
+data Verification = Verification
+  { -- | Whether the address passed verification.
+    success :: Bool,
+    -- | Verification errors, when the address failed.
+    errors :: [EasyPostFieldError]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON Verification where
+  parseJSON = Aeson.withObject "Verification" $ \o ->
+    Verification
+      <$> o Aeson..: "success"
+      <*> o Aeson..:? "errors" Aeson..!= []
 
 --------------------------------------------------------------------------------
 -- Shipment Buy

--- a/lib/easypost-http/test/EasyPost/IntegrationSpec.hs
+++ b/lib/easypost-http/test/EasyPost/IntegrationSpec.hs
@@ -56,7 +56,8 @@ spec = describe "EasyPost Integration (live test API)" $ do
           ShipmentCreate
             { fromAddress = fromAddress,
               toAddress = toAddress,
-              parcel = Parcel {weight = 16.0}
+              parcel = Parcel {weight = 16.0},
+              verify = []
             }
 
     createResult <- createShipment mgr key sc
@@ -79,7 +80,8 @@ spec = describe "EasyPost Integration (live test API)" $ do
           ShipmentCreate
             { fromAddress = fromAddress,
               toAddress = toAddress,
-              parcel = Parcel {weight = 8.0}
+              parcel = Parcel {weight = 8.0},
+              verify = []
             }
 
     createResult <- createShipment mgr key sc
@@ -97,7 +99,8 @@ spec = describe "EasyPost Integration (live test API)" $ do
           ShipmentCreate
             { fromAddress = fromAddress,
               toAddress = toAddress,
-              parcel = Parcel {weight = 10.0}
+              parcel = Parcel {weight = 10.0},
+              verify = []
             }
 
     createResult <- createShipment mgr key sc

--- a/lib/easypost-http/test/EasyPost/TypesSpec.hs
+++ b/lib/easypost-http/test/EasyPost/TypesSpec.hs
@@ -1,0 +1,97 @@
+-- | Pure JSON decoding tests for EasyPost error and verification types.
+module EasyPost.TypesSpec where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy (ByteString)
+import EasyPost.Types
+  ( EasyPostError (..),
+    EasyPostFieldError (..),
+    Shipment (..),
+    Verification (..),
+  )
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "EasyPostError FromJSON" $ do
+    it "decodes a PARAMETER.INVALID_TYPE (weight) error and unwraps the envelope" $ do
+      let body :: ByteString
+          body =
+            "{\"error\":{\"code\":\"PARAMETER.INVALID_TYPE\",\"message\":\"Wrong parameter type.\",\"errors\":[{\"field\":\"shipment.parcel.weight\",\"message\":\"must be greater than 0\"}]}}"
+      Aeson.decode body
+        `shouldBe` Just
+          EasyPostError
+            { code = "PARAMETER.INVALID_TYPE",
+              message = "Wrong parameter type.",
+              errors =
+                [ EasyPostFieldError
+                    { field = Just "shipment.parcel.weight",
+                      message = "must be greater than 0",
+                      suggestion = Nothing
+                    }
+                ]
+            }
+
+    it "decodes an ADDRESS.VERIFY.FAILURE error with a null suggestion" $ do
+      let body :: ByteString
+          body =
+            "{\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\",\"errors\":[{\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}]}}"
+      Aeson.decode body
+        `shouldBe` Just
+          EasyPostError
+            { code = "ADDRESS.VERIFY.FAILURE",
+              message = "Unable to verify address.",
+              errors =
+                [ EasyPostFieldError
+                    { field = Just "street1",
+                      message = "House number is missing",
+                      suggestion = Nothing
+                    }
+                ]
+            }
+
+    it "tolerates a bare-string errors[] item" $ do
+      let body :: ByteString
+          body =
+            "{\"error\":{\"code\":\"UNKNOWN\",\"message\":\"Something went wrong.\",\"errors\":[\"a bare string error\"]}}"
+      Aeson.decode body
+        `shouldBe` Just
+          EasyPostError
+            { code = "UNKNOWN",
+              message = "Something went wrong.",
+              errors =
+                [ EasyPostFieldError
+                    { field = Nothing,
+                      message = "a bare string error",
+                      suggestion = Nothing
+                    }
+                ]
+            }
+
+  describe "Shipment FromJSON delivery verification" $ do
+    it "decodes a failed to_address delivery verification" $ do
+      let body :: ByteString
+          body =
+            "{\"id\":\"shp_1\",\"rates\":[],\"to_address\":{\"verifications\":{\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null}}}}"
+          mShipment = Aeson.decode body :: Maybe Shipment
+      fmap (.toAddressDeliveryVerification) mShipment
+        `shouldBe` Just
+          ( Just
+              Verification
+                { success = False,
+                  errors =
+                    [ EasyPostFieldError
+                        { field = Just "address",
+                          message = "Address not found",
+                          suggestion = Nothing
+                        }
+                    ]
+                }
+          )
+
+    it "yields Nothing when verifications are absent" $ do
+      let body :: ByteString
+          body = "{\"id\":\"shp_2\",\"rates\":[]}"
+          mShipment = Aeson.decode body :: Maybe Shipment
+      fmap (.toAddressDeliveryVerification) mShipment
+        `shouldBe` Just Nothing

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -485,6 +485,7 @@ library
     API.Store.Types
     Store.Checkout.Emails
     Store.Checkout.Logic
+    Store.Checkout.ShippingErrors
     API.TermsOfService.Get.Handler
     API.TermsOfService.Get.Route
     API.TermsOfService.Get.Templates
@@ -627,6 +628,7 @@ test-suite kpbj-api-test
                     , web-server-core
                     , bytestring
                     , containers
+                    , easypost-http
                     , exceptions
                     , data-has
                     , hasql
@@ -655,6 +657,7 @@ test-suite kpbj-api-test
                     , postgres-options
                     , rel8
                     , scientific
+                    , servant-client-core
                     , string-interpolate
                     , text
                     , text-display
@@ -754,6 +757,7 @@ test-suite kpbj-api-test
        API.Store.Products.Slug.Get.HandlerSpec
        Store.Checkout.EmailsSpec
        Store.Checkout.LogicSpec
+       Store.Checkout.ShippingErrorsSpec
        API.Newsletter.Subscribe.Post.HandlerSpec
        API.User.ForgotPassword.Post.HandlerSpec
        API.User.Login.Post.HandlerSpec

--- a/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
@@ -50,6 +50,7 @@ import Log qualified
 import Lucid qualified
 import Network.HTTP.Client (Manager)
 import Store.Checkout.Logic (sortRatesByPrice)
+import Store.Checkout.ShippingErrors (easyPostFailureMessage)
 import Utils (fromMaybeM)
 
 --------------------------------------------------------------------------------
@@ -95,7 +96,7 @@ createShipmentAndShowRates order = do
   case result of
     Left (EasyPostClientError err) -> do
       lift $ Log.logInfo "EasyPost createShipment failed" (show err)
-      pure $ renderBanner Error "Shipping Error" "Could not create shipment. Please try again."
+      pure $ renderBanner Error "Shipping Error" (easyPostFailureMessage (EasyPostClientError err))
     Right shipment ->
       pure $ Templates.ratesTemplate shipment (sortRatesByPrice shipment.rates) order.oId
 
@@ -119,7 +120,7 @@ buyLabelAndUpdate orderId form = do
   case result of
     Left (EasyPostClientError err) -> do
       lift $ Log.logInfo "EasyPost buyShipment failed" (show err)
-      pure $ renderBanner Error "Label Error" "Could not purchase label. Please try again."
+      pure $ renderBanner Error "Label Error" (easyPostFailureMessage (EasyPostClientError err))
     Right shipment -> do
       let trackingNumber = fromMaybe "" shipment.trackingCode
           mLabelUrl = fmap (\(Label url) -> url) shipment.postageLabel
@@ -175,7 +176,8 @@ buildShipmentCreate order settings totalWeightOz =
   ShipmentCreate
     { fromAddress = fromAddr,
       toAddress = toAddr,
-      parcel = Parcel {weight = totalWeightOz}
+      parcel = Parcel {weight = totalWeightOz},
+      verify = []
     }
   where
     fromAddr =

--- a/services/web/src/API/Store/Checkout/CreateSession/Post/Handler.hs
+++ b/services/web/src/API/Store/Checkout/CreateSession/Post/Handler.hs
@@ -58,6 +58,7 @@ import Log qualified
 import Network.HTTP.Client (Manager)
 import Servant.Server qualified as Servant
 import Store.Checkout.Logic (computeSubtotal, computeTax, computeTotal, easypostRateToCents)
+import Store.Checkout.ShippingErrors (easyPostFailureMessage)
 import Stripe.Client (StripeClientError (..), createCheckoutSession)
 import Stripe.Types
   ( CheckoutSession (..),
@@ -116,7 +117,7 @@ handler req = do
   shipment <- case shipmentResult of
     Left (EasyPostClientError err) -> do
       Log.logAttention "EasyPost getShipment failed during checkout" (show err)
-      throwServerError "Could not verify shipping rate. Please go back and try again."
+      throwServerError (easyPostFailureMessage (EasyPostClientError err))
     Right s -> pure s
 
   let mMatchedRate = find (\r -> r.id == req.csrShippingRateId) shipment.rates
@@ -133,7 +134,7 @@ handler req = do
   -- 4. Compute totals
   let priceQtyPairs =
         [ (ri.riUnitPrice, fromIntegral ri.riQuantity)
-          | ri <- resolvedItems
+        | ri <- resolvedItems
         ]
       subtotal = computeSubtotal priceQtyPairs
       tax = computeTax subtotal settings.ssTaxRate
@@ -220,7 +221,7 @@ handler req = do
                   },
               quantity = item.riQuantity
             }
-          | item <- resolvedItems
+        | item <- resolvedItems
         ]
 
       taxLineItem =

--- a/services/web/src/API/Store/ShippingRates/Post/Handler.hs
+++ b/services/web/src/API/Store/ShippingRates/Post/Handler.hs
@@ -40,6 +40,7 @@ import Log qualified
 import Lucid qualified
 import Network.HTTP.Client (Manager)
 import Store.Checkout.Logic (computeSubtotal, sortRatesByPrice)
+import Store.Checkout.ShippingErrors (deliveryVerificationError, easyPostFailureMessage)
 
 --------------------------------------------------------------------------------
 
@@ -75,16 +76,19 @@ handler req = do
                   case result of
                     Left (EasyPostClientError err) -> do
                       Log.logInfo "EasyPost createShipment failed" (show err)
-                      pure $ renderBanner Error "Shipping Error" "Could not retrieve shipping rates. Please check your address and try again."
-                    Right shipment -> do
-                      let subtotal =
-                            computeSubtotal
-                              [ (ri.riUnitPrice, fromIntegral ri.riQuantity)
-                              | ri <- resolvedItems
-                              ]
-                          taxRate = settings.ssTaxRate
-                          sortedRates = sortRatesByPrice shipment.rates
-                      pure $ Templates.template shipment sortedRates subtotal taxRate
+                      pure $ renderBanner Error "Address Problem" (easyPostFailureMessage (EasyPostClientError err))
+                    Right shipment ->
+                      case deliveryVerificationError shipment of
+                        Just msg -> pure $ renderBanner Error "Address Problem" msg
+                        Nothing -> do
+                          let subtotal =
+                                computeSubtotal
+                                  [ (ri.riUnitPrice, fromIntegral ri.riQuantity)
+                                  | ri <- resolvedItems
+                                  ]
+                              taxRate = settings.ssTaxRate
+                              sortedRates = sortRatesByPrice shipment.rates
+                          pure $ Templates.template shipment sortedRates subtotal taxRate
 
 --------------------------------------------------------------------------------
 
@@ -184,7 +188,8 @@ buildShipmentCreate req settings resolvedItems =
   ShipmentCreate
     { fromAddress = fromAddr,
       toAddress = toAddr,
-      parcel = Parcel {weight = totalWeightOz}
+      parcel = Parcel {weight = totalWeightOz},
+      verify = ["delivery"]
     }
   where
     fromAddr =

--- a/services/web/src/Store/Checkout/ShippingErrors.hs
+++ b/services/web/src/Store/Checkout/ShippingErrors.hs
@@ -1,0 +1,85 @@
+-- | Human-readable messages for EasyPost shipping failures.
+--
+-- Turns the two ways EasyPost signals a bad address into user-facing copy:
+--
+--   * A failed API call (non-2xx) whose body carries a structured
+--     @{"error": {...}}@ payload — see 'easyPostFailureMessage'.
+--   * A successful shipment whose to-address delivery verification came back
+--     unsuccessful — see 'deliveryVerificationError'.
+--
+-- Both paths fall back to a safe generic message and never return empty text.
+module Store.Checkout.ShippingErrors
+  ( easyPostFailureMessage,
+    deliveryVerificationError,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import EasyPost.Client (EasyPostClientError, easyPostErrorDetails)
+import EasyPost.Types
+  ( EasyPostError (..),
+    EasyPostFieldError (..),
+    Shipment (..),
+    Verification (..),
+  )
+
+--------------------------------------------------------------------------------
+
+-- | Safe fallback used whenever we can't produce anything more specific.
+genericFallback :: Text
+genericFallback = "We couldn't process your shipping address. Please check it and try again."
+
+-- | Build a user-facing message from an EasyPost client error.
+--
+-- Prefers the structured field errors, then the top-level message, then a
+-- generic fallback. Always returns non-empty text.
+easyPostFailureMessage :: EasyPostClientError -> Text
+easyPostFailureMessage err =
+  maybe genericFallback formatEasyPostError (easyPostErrorDetails err)
+
+-- | Format a decoded 'EasyPostError' into user-facing copy.
+formatEasyPostError :: EasyPostError -> Text
+formatEasyPostError easyPostError =
+  case formatFieldErrors easyPostError.errors of
+    Just msg -> msg
+    Nothing ->
+      if Text.null (Text.strip easyPostError.message)
+        then genericFallback
+        else easyPostError.message
+
+-- | Produce a message from a delivery verification, when it failed.
+--
+-- Returns 'Nothing' when the shipment has no verification block or the
+-- delivery verification succeeded.
+deliveryVerificationError :: Shipment -> Maybe Text
+deliveryVerificationError shipment =
+  case shipment.toAddressDeliveryVerification of
+    Just verification
+      | not verification.success ->
+          Just (fromMaybe genericFallback (formatFieldErrors verification.errors))
+    _ -> Nothing
+
+--------------------------------------------------------------------------------
+
+-- | Join the field errors into a single sentence, or 'Nothing' if there are
+-- none with usable text.
+formatFieldErrors :: [EasyPostFieldError] -> Maybe Text
+formatFieldErrors fieldErrors =
+  case filter (not . Text.null) (map formatFieldError fieldErrors) of
+    [] -> Nothing
+    msgs -> Just (Text.intercalate "; " msgs)
+
+-- | Format a single field error, appending the suggestion when present.
+formatFieldError :: EasyPostFieldError -> Text
+formatFieldError fieldError =
+  case fieldError.suggestion of
+    Just suggestion
+      | not (Text.null (Text.strip suggestion)) ->
+          base <> " (suggestion: " <> suggestion <> ")"
+    _ -> base
+  where
+    base = Text.strip fieldError.message

--- a/services/web/test/Main.hs
+++ b/services/web/test/Main.hs
@@ -99,6 +99,7 @@ import Effects.StagedUploadsSpec qualified as StagedUploadsEffects
 import Middleware.ValidateEncodingSpec qualified as ValidateEncoding
 import Store.Checkout.EmailsSpec qualified as StoreCheckoutEmails
 import Store.Checkout.LogicSpec qualified as StoreCheckoutLogic
+import Store.Checkout.ShippingErrorsSpec qualified as StoreCheckoutShippingErrors
 import System.Environment (lookupEnv)
 import Test.Database.Setup (withTmpPG)
 import Test.Hspec
@@ -134,6 +135,7 @@ main = do
     StagedUploadsEffects.spec
     StoreCheckoutEmails.spec
     StoreCheckoutLogic.spec
+    StoreCheckoutShippingErrors.spec
     ValidateEncoding.spec
 
   -- Handler Integration Tests (database-dependent)

--- a/services/web/test/Store/Checkout/ShippingErrorsSpec.hs
+++ b/services/web/test/Store/Checkout/ShippingErrorsSpec.hs
@@ -1,0 +1,101 @@
+module Store.Checkout.ShippingErrorsSpec (spec) where
+
+--------------------------------------------------------------------------------
+
+import Control.Exception (ErrorCall (..), toException)
+import Data.ByteString.Lazy (ByteString)
+import Data.Text (Text)
+import EasyPost.Client (EasyPostClientError (..))
+import EasyPost.Types
+  ( EasyPostFieldError (..),
+    Shipment (..),
+    Verification (..),
+  )
+import Network.HTTP.Types (http11, status422)
+import Servant.Client.Core qualified as Client
+import Store.Checkout.ShippingErrors (deliveryVerificationError, easyPostFailureMessage)
+import Test.Hspec
+
+--------------------------------------------------------------------------------
+
+-- | Wrap a JSON body in a 'Client.DecodeFailure', the simplest 'Client.ClientError'
+-- carrying a response body.
+mkClientError :: ByteString -> EasyPostClientError
+mkClientError body =
+  EasyPostClientError $
+    Client.DecodeFailure "test" $
+      Client.Response status422 mempty http11 body
+
+-- | A connection-level error, which carries no response body.
+connectionError :: EasyPostClientError
+connectionError =
+  EasyPostClientError (Client.ConnectionError (toException (ErrorCall "boom")))
+
+genericFallback :: Text
+genericFallback = "We couldn't process your shipping address. Please check it and try again."
+
+-- | Build a shipment carrying only a delivery verification result.
+mkShipment :: Maybe Verification -> Shipment
+mkShipment verification =
+  Shipment
+    { id = "shp_test",
+      rates = [],
+      trackingCode = Nothing,
+      postageLabel = Nothing,
+      toAddressDeliveryVerification = verification
+    }
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+  describe "easyPostFailureMessage" $ do
+    it "formats a field error with its suggestion" $ do
+      let body =
+            "{\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\",\"errors\":[{\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":\"123 Main St\"}]}}"
+      easyPostFailureMessage (mkClientError body)
+        `shouldBe` "House number is missing (suggestion: 123 Main St)"
+
+    it "joins multiple field errors" $ do
+      let body =
+            "{\"error\":{\"code\":\"X\",\"message\":\"top\",\"errors\":[{\"field\":\"a\",\"message\":\"first problem\",\"suggestion\":null},{\"field\":\"b\",\"message\":\"second problem\",\"suggestion\":null}]}}"
+      easyPostFailureMessage (mkClientError body)
+        `shouldBe` "first problem; second problem"
+
+    it "falls back to the top-level message when there are no field errors" $ do
+      let body =
+            "{\"error\":{\"code\":\"X\",\"message\":\"Top level message.\",\"errors\":[]}}"
+      easyPostFailureMessage (mkClientError body)
+        `shouldBe` "Top level message."
+
+    it "uses the generic fallback for an unparseable body" $ do
+      easyPostFailureMessage (mkClientError "not json at all")
+        `shouldBe` genericFallback
+
+    it "uses the generic fallback for a connection error" $ do
+      easyPostFailureMessage connectionError
+        `shouldBe` genericFallback
+
+  describe "deliveryVerificationError" $ do
+    it "formats errors from a failed delivery verification" $ do
+      let verification =
+            Verification
+              { success = False,
+                errors =
+                  [ EasyPostFieldError
+                      { field = Just "address",
+                        message = "Address not found",
+                        suggestion = Nothing
+                      }
+                  ]
+              }
+      deliveryVerificationError (mkShipment (Just verification))
+        `shouldBe` Just "Address not found"
+
+    it "returns Nothing for a successful verification" $ do
+      let verification = Verification {success = True, errors = []}
+      deliveryVerificationError (mkShipment (Just verification))
+        `shouldBe` Nothing
+
+    it "returns Nothing when there is no verification block" $
+      deliveryVerificationError (mkShipment Nothing) `shouldBe` Nothing


### PR DESCRIPTION
Surfaces EasyPost's actual reason for a bad shipping address at checkout instead of a generic banner, and proactively requests delivery-address verification.

## What changed
- **easypost-http**: parse EasyPost's `{"error": {...}}` envelope into `EasyPostError`/`EasyPostFieldError` (tolerating object- or bare-string `errors[]` items); add `easyPostErrorDetails` to recover it from a `ClientError`. Add a `verify` field to `ShipmentCreate` (emitted at the request root, sibling of `shipment`, only when non-empty) and decode `to_address.verifications.delivery` on the `Shipment` response.
- **Store.Checkout.ShippingErrors** (new): shared helpers turning an EasyPost error or a failed delivery verification into user-facing copy.
- **Shipping-rates handler**: requests delivery verification and shows a specific "Address Problem" message (blocking rates) on failure. The checkout-session and label-purchase failure paths reuse the parsed-error copy.

## Tests
- `easypost-http`: decode tests for the error envelope (weight + `ADDRESS.VERIFY.FAILURE` samples, incl. bare-string `errors[]`) and for a failed `to_address.verifications.delivery`.
- app: `ShippingErrors` unit tests (field-error, message-only, fallback, failed/absent verification).

`just build` clean; new specs pass; ormolu + hlint clean.

## ⚠️ Known limitation — verify not yet validated end-to-end
EasyPost **test mode only verifies its documented fixture addresses**, so with a test key arbitrary bad addresses return `verifications: {}` and no block is triggered. The request now correctly sends `verify:["delivery"]` at the root (matching EasyPost's Address API), but the placement should be **confirmed against a live key on staging** (submit a bad address, confirm `to_address.verifications.delivery.success=false` comes back). The error-message **parsing** is unit-tested and works regardless of verification.

## Note on base
Stacked on `feat/store-carrier-toggles` (#67) since it shares handler files — this PR's diff is just the address-error commit. Retarget to `main` once #67 lands (or if #67 is dropped).
