### PR TITLE
feat: Add Membership link to main nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Membership link in main nav** — Added a dedicated "Membership" entry (linking to the pools.events listener-membership signup) to both the desktop navbar and the mobile hamburger menu, placed immediately after "Donate". Rendered as a plain external anchor (`target="_blank"`, `rel="noopener noreferrer"`) rather than an HTMX-swapped internal link, since the destination is cross-origin. The existing membership link in the donate-page content is unchanged.
+
 ### Changed
 - **Shipping carriers managed in EasyPost** — Removed the backend carrier whitelist (`filterRates`) from the checkout and label-purchase flows. Every rate EasyPost returns is now offered (sorted by price); which carriers appear is controlled entirely by the carrier accounts configured in the EasyPost dashboard.
 - **Helpful shipping-address errors at checkout** — When EasyPost rejects a shipping address, the checkout now surfaces the specific problem (e.g. "House number is missing") instead of a generic "check your address" banner. The `easypost-http` client parses EasyPost's structured `{"error": {...}}` payloads (`EasyPostError`/`EasyPostFieldError`), and the customer shipping-rate lookup now proactively requests delivery-address verification, showing a targeted message when the address can't be verified before quoting rates. The same parsed-error copy is reused across the create-session and label-purchase failure paths.

--- a/services/web/src/Component/Frame.hs
+++ b/services/web/src/Component/Frame.hs
@@ -836,6 +836,14 @@ mobileNavLinks mUser =
     mobileNavLink "Shows" showsGetUrl
     mobileNavLink "Schedule" scheduleGetUrl
     mobileNavLink "Donate" donateGetUrl
+    Lucid.a_
+      [ Lucid.href_ "https://pools.events/o/kpbjfm/join",
+        Lucid.target_ "_blank",
+        Lucid.rel_ "noopener noreferrer",
+        xOnClick_ "menuOpen = false",
+        class_ $ base [Tokens.textXl, Tokens.fontBold, Tokens.fgPrimary, "hover:opacity-70"]
+      ]
+      "Membership"
     mobileNavLink "Events" eventsGetUrl
     mobileNavLink "Store" storeGetUrl
     -- mobileNavLink "Blog" blogGetUrl
@@ -892,6 +900,7 @@ navigation =
     Lucid.a_ [Lucid.id_ "nav-shows", Lucid.href_ [i|/#{showsGetUrl}|], hxGet_ [i|/#{showsGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Shows"
     Lucid.a_ [Lucid.id_ "nav-schedule", Lucid.href_ [i|/#{scheduleGetUrl}|], hxGet_ [i|/#{scheduleGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Schedule"
     Lucid.a_ [Lucid.id_ "nav-donate", Lucid.href_ [i|/#{donateGetUrl}|], hxGet_ [i|/#{donateGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Donate"
+    Lucid.a_ [Lucid.id_ "nav-membership", Lucid.href_ "https://pools.events/o/kpbjfm/join", Lucid.target_ "_blank", Lucid.rel_ "noopener noreferrer", Lucid.class_ navLinkDark] "Membership"
     Lucid.a_ [Lucid.id_ "nav-events", Lucid.href_ [i|/#{eventsGetUrl}|], hxGet_ [i|/#{eventsGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Events"
     Lucid.a_ [Lucid.id_ "nav-store", Lucid.href_ [i|/#{storeGetUrl}|], hxGet_ [i|/#{storeGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Store"
     -- Lucid.a_ [Lucid.id_ "nav-blog", Lucid.href_ [i|/#{blogGetUrl}|], hxGet_ [i|/#{blogGetUrl}|], hxTarget_ "#main-content", hxPushUrl_ "true", Lucid.class_ navLinkDark] "Blog"


### PR DESCRIPTION
## Summary

Surfaces the pools.events listener-membership signup (`https://pools.events/o/kpbjfm/join`) more prominently by adding a dedicated **Membership** entry to the site's main navigation. Previously the link only lived in the donate-page content.

- **Desktop navbar** (`navigation`): new `nav-membership` anchor immediately after `Donate`.
- **Mobile hamburger** (`mobileNavLinks`): matching inline anchor after the Donate entry.
- Both are plain external anchors (`target="_blank"`, `rel="noopener noreferrer"`, no HTMX) since the destination is cross-origin — mirroring the existing `Contact` mailto pattern. Internal HTMX swaps into `#main-content` would break for an off-site URL.
- Styled identically to the other nav links (no special CTA treatment).
- The existing membership link in the donate-page markdown is unchanged.

## Testing

- `just build` passes.
- Visual check recommended: "Membership" appears after "Donate" in both the desktop navbar and mobile hamburger, and opens pools.events in a new tab.