### PR TITLE
Restore soft-deleted shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Restore soft-deleted shows** — Admins can restore soft-deleted shows from a new "Deleted only" toggle on the dashboard shows list (`/dashboard/shows?deleted`). The deleted view lists shows most-recently-deleted first with a "Deleted" badge and a per-row Restore action (`POST /dashboard/shows/:slug/restore`), which clears `deleted_at` and swaps the row out. Backed by three new idempotent `shows` queries (`restoreShow`, `getDeletedShowBySlug`, `getDeletedShowsWithHostInfo`). The delete-confirm copy now notes the show can be restored later.
 - **Membership link in main nav** — Added a dedicated "Membership" entry (linking to the pools.events listener-membership signup) to both the desktop navbar and the mobile hamburger menu, placed immediately after "Donate". Rendered as a plain external anchor (`target="_blank"`, `rel="noopener noreferrer"`) rather than an HTMX-swapped internal link, since the destination is cross-origin. The existing membership link in the donate-page content is unchanged.
 
 ### Changed

--- a/lib/kpbj-database/src/Effects/Database/Tables/Shows.hs
+++ b/lib/kpbj-database/src/Effects/Database/Tables/Shows.hs
@@ -27,6 +27,7 @@ module Effects.Database.Tables.Shows
 
     -- * Queries
     getShowBySlug,
+    getDeletedShowBySlug,
     getShowById,
     getShowsFiltered,
     insertShow,
@@ -39,10 +40,12 @@ module Effects.Database.Tables.Shows
 
     -- * Soft Delete
     softDeleteShow,
+    restoreShow,
 
     -- * Admin Queries
     ShowWithHostInfo (..),
     getAllShowsWithHostInfo,
+    getDeletedShowsWithHostInfo,
     getShowsByStatusWithHostInfo,
     searchShowsWithHostInfo,
 
@@ -264,6 +267,17 @@ getShowBySlug showSlug = fmap listToMaybe $ run $ select do
   where_ $ isNull (deletedAt s)
   pure s
 
+-- | Get a soft-deleted show by slug (only returns rows with a non-NULL deleted_at).
+--
+-- Needed by the restore flow because 'getShowBySlug' hides deleted rows, so it
+-- cannot resolve a slug to an id for a show that is currently soft-deleted.
+getDeletedShowBySlug :: Slug -> Hasql.Statement () (Maybe Model)
+getDeletedShowBySlug showSlug = fmap listToMaybe $ run $ select do
+  s <- each showSchema
+  where_ $ slug s ==. lit showSlug
+  where_ $ not_ (isNull (deletedAt s))
+  pure s
+
 -- | Get show by ID (excludes soft-deleted shows).
 getShowById :: Id -> Hasql.Statement () (Maybe Model)
 getShowById showId = fmap listToMaybe $ run $ select do
@@ -385,6 +399,29 @@ softDeleteShow showId =
             returning = Returning id
           }
 
+-- | Restore a soft-deleted show by clearing its deleted_at timestamp.
+--
+-- Returns the show ID if successfully restored, Nothing if the show was not
+-- currently deleted (or does not exist). Idempotent: only affects rows whose
+-- deleted_at is non-NULL.
+restoreShow :: Id -> Hasql.Statement () (Maybe Id)
+restoreShow showId =
+  fmap listToMaybe $
+    run $
+      update
+        Rel8.Update
+          { target = showSchema,
+            from = pure (),
+            set = \_ showRec ->
+              showRec
+                { deletedAt = Rel8.null
+                },
+            updateWhere = \_ showRec ->
+              id showRec ==. lit showId {- HLINT ignore "Redundant id" -}
+                &&. not_ (isNull (deletedAt showRec)),
+            returning = Returning id
+          }
+
 --------------------------------------------------------------------------------
 -- Show Host Queries
 
@@ -481,6 +518,29 @@ getAllShowsWithHostInfo (Limit lim) (Offset off) =
     WHERE s.deleted_at IS NULL
     GROUP BY s.id
     ORDER BY s.created_at DESC
+    LIMIT #{lim} OFFSET #{off}
+  |]
+
+-- | Get soft-deleted shows with host info for admin listing.
+--
+-- Returns only shows whose deleted_at is non-NULL, most recently deleted first.
+-- Only counts active hosts (where left_at IS NULL).
+getDeletedShowsWithHostInfo :: Limit -> Offset -> Hasql.Statement () [ShowWithHostInfo]
+getDeletedShowsWithHostInfo (Limit lim) (Offset off) =
+  interp
+    False
+    [sql|
+    SELECT
+      s.id, s.title, s.slug, s.description, s.logo_url,
+      s.status, s.created_at, s.updated_at,
+      COUNT(DISTINCT sh.user_id) FILTER (WHERE sh.left_at IS NULL)::bigint as host_count,
+      STRING_AGG(DISTINCT um.display_name, ', ' ORDER BY um.display_name) FILTER (WHERE sh.left_at IS NULL) as host_names
+    FROM shows s
+    LEFT JOIN show_hosts sh ON s.id = sh.show_id
+    LEFT JOIN user_metadata um ON sh.user_id = um.user_id
+    WHERE s.deleted_at IS NOT NULL
+    GROUP BY s.id
+    ORDER BY s.deleted_at DESC
     LIMIT #{lim} OFFSET #{off}
   |]
 

--- a/lib/kpbj-database/test/Effects/Database/Tables/ShowsSpec.hs
+++ b/lib/kpbj-database/test/Effects/Database/Tables/ShowsSpec.hs
@@ -57,6 +57,10 @@ spec =
           hedgehog . prop_softDeleteShow
         runs 10 . it "softDeleteShow: second delete is no-op" $
           hedgehog . prop_softDeleteShow_idempotent
+        runs 10 . it "restoreShow: clears deleted_at, getById returns the show again" $
+          hedgehog . prop_restoreShow
+        runs 10 . it "restoreShow: restoring a non-deleted show is a no-op" $
+          hedgehog . prop_restoreShow_noop
 
       describe "Constraints" $ do
         runs 10 . it "rejects duplicate slug on insert" $ hedgehog . prop_insertDuplicateSlug
@@ -393,6 +397,55 @@ prop_softDeleteShow_idempotent cfg = do
         deletedId <- assertJust firstDelete
         deletedId === showId
         assertNothing secondDelete
+        pure ()
+
+-- | restoreShow: clears deleted_at, getById returns the show again.
+prop_restoreShow :: TestDBConfig -> PropertyT IO ()
+prop_restoreShow cfg = do
+  arrange (bracketConn cfg) $ do
+    showInsert <- forAllT showInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        showId <- unwrapInsert (UUT.insertShow showInsert)
+
+        _ <- TRX.statement () (UUT.softDeleteShow showId)
+        afterDelete <- TRX.statement () (UUT.getShowById showId)
+
+        restoreResult <- TRX.statement () (UUT.restoreShow showId)
+        afterRestore <- TRX.statement () (UUT.getShowById showId)
+        TRX.condemn
+        pure (showId, afterDelete, restoreResult, afterRestore)
+
+      assert $ do
+        (showId, afterDelete, restoreResult, afterRestore) <- assertRight result
+        assertNothing afterDelete
+        restoredId <- assertJust restoreResult
+        restoredId === showId
+        restored <- assertJust afterRestore
+        UUT.id restored === showId
+        pure ()
+
+-- | restoreShow: restoring a show that is not deleted returns Nothing (no-op).
+prop_restoreShow_noop :: TestDBConfig -> PropertyT IO ()
+prop_restoreShow_noop cfg = do
+  arrange (bracketConn cfg) $ do
+    showInsert <- forAllT showInsertGen
+
+    act $ do
+      result <- runDB $ TRX.transaction TRX.ReadCommitted TRX.Write $ do
+        showId <- unwrapInsert (UUT.insertShow showInsert)
+
+        restoreResult <- TRX.statement () (UUT.restoreShow showId)
+        stillPresent <- TRX.statement () (UUT.getShowById showId)
+        TRX.condemn
+        pure (showId, restoreResult, stillPresent)
+
+      assert $ do
+        (showId, restoreResult, stillPresent) <- assertRight result
+        assertNothing restoreResult
+        present <- assertJust stillPresent
+        UUT.id present === showId
         pure ()
 
 --------------------------------------------------------------------------------

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -395,6 +395,8 @@ library
     API.Dashboard.Shows.Slug.Edit.Post.Route
     API.Dashboard.Shows.Slug.Delete.Handler
     API.Dashboard.Shows.Slug.Delete.Route
+    API.Dashboard.Shows.Slug.Restore.Post.Handler
+    API.Dashboard.Shows.Slug.Restore.Post.Route
     API.Dashboard.Shows.Slug.Episode.New.Get.Handler
     API.Dashboard.Shows.Slug.Episode.New.Get.Route
     API.Dashboard.Shows.Slug.Episode.New.Get.Templates.Form

--- a/services/web/src/API.hs
+++ b/services/web/src/API.hs
@@ -109,6 +109,7 @@ import API.Dashboard.Shows.Slug.Edit.Post.Handler qualified as Dashboard.Shows.S
 import API.Dashboard.Shows.Slug.Episode.New.Get.Handler qualified as Dashboard.Shows.Slug.Episode.New.Get
 import API.Dashboard.Shows.Slug.Episode.New.Post.Handler qualified as Dashboard.Shows.Slug.Episode.New.Post
 import API.Dashboard.Shows.Slug.Get.Handler qualified as Dashboard.Shows.Slug.Get
+import API.Dashboard.Shows.Slug.Restore.Post.Handler qualified as Dashboard.Shows.Slug.Restore.Post
 import API.Dashboard.SitePages.Get.Handler qualified as Dashboard.SitePages.Get
 import API.Dashboard.SitePages.Slug.Edit.Get.Handler qualified as Dashboard.SitePages.Slug.Edit.Get
 import API.Dashboard.SitePages.Slug.Edit.Post.Handler qualified as Dashboard.SitePages.Slug.Edit.Post
@@ -528,6 +529,7 @@ server =
           editGet = Dashboard.Shows.Slug.Edit.Get.handler,
           editPost = Dashboard.Shows.Slug.Edit.Post.handler,
           delete = Dashboard.Shows.Slug.Delete.handler,
+          restorePost = Dashboard.Shows.Slug.Restore.Post.handler,
           episodeNewGet = Dashboard.Shows.Slug.Episode.New.Get.handler,
           episodeNewPost = Dashboard.Shows.Slug.Episode.New.Post.handler
         }

--- a/services/web/src/API/Dashboard/Shows/Get/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/Get/Handler.hs
@@ -48,6 +48,7 @@ data ShowListViewData = ShowListViewData
     slvHasMore :: Bool,
     slvQueryFilter :: Maybe Text,
     slvStatusFilter :: Maybe Shows.Status,
+    slvDeletedView :: Bool,
     slvIsAdmin :: Bool,
     slvIsAppendRequest :: Bool
   }
@@ -59,9 +60,10 @@ action ::
   Maybe Int64 ->
   Maybe (Filter Text) ->
   Maybe (Filter Shows.Status) ->
+  Bool ->
   HxRequest ->
   ExceptT HandlerError AppM ShowListViewData
-action user userMetadata maybePage queryFilterParam statusFilterParam hxRequest = do
+action user userMetadata maybePage queryFilterParam statusFilterParam deletedView hxRequest = do
   -- 1. Set up pagination and filters
   let page = fromMaybe 1 maybePage
       limit = 20 :: Limit
@@ -79,7 +81,7 @@ action user userMetadata maybePage queryFilterParam statusFilterParam hxRequest 
   let selectedShow = listToMaybe sidebarShows
 
   -- 4. Fetch shows for main content
-  allShowsResult <- getShowResults limit offset queryFilter statusFilter
+  allShowsResult <- getShowResults limit offset queryFilter statusFilter deletedView
 
   -- 5. Compute pagination
   let theShows = take (fromIntegral limit) allShowsResult
@@ -95,6 +97,7 @@ action user userMetadata maybePage queryFilterParam statusFilterParam hxRequest 
         slvHasMore = hasMore,
         slvQueryFilter = queryFilter,
         slvStatusFilter = statusFilter,
+        slvDeletedView = deletedView,
         slvIsAdmin = isAdmin,
         slvIsAppendRequest = isAppendRequest
       }
@@ -103,20 +106,21 @@ handler ::
   Maybe Int64 ->
   Maybe (Filter Text) ->
   Maybe (Filter Shows.Status) ->
+  Bool ->
   Maybe Cookie ->
   Maybe HxRequest ->
   AppM (Lucid.Html ())
-handler maybePage queryFilterParam statusFilterParam cookie (foldHxReq -> hxRequest) =
+handler maybePage queryFilterParam statusFilterParam deletedView cookie (foldHxReq -> hxRequest) =
   handleHtmlErrors "Shows list" apiLinks.rootGet $ do
     -- 1. Require authentication and staff role
     (user, userMetadata) <- requireAuth cookie
     requireStaffNotSuspended "You do not have permission to access this page." userMetadata
-    vd <- action user userMetadata maybePage queryFilterParam statusFilterParam hxRequest
+    vd <- action user userMetadata maybePage queryFilterParam statusFilterParam deletedView hxRequest
     if vd.slvIsAppendRequest
-      then pure $ renderItemsFragment vd.slvIsAdmin vd.slvShows vd.slvPage vd.slvHasMore vd.slvQueryFilter vd.slvStatusFilter
+      then pure $ renderItemsFragment vd.slvIsAdmin vd.slvDeletedView vd.slvShows vd.slvPage vd.slvHasMore vd.slvQueryFilter vd.slvStatusFilter
       else do
-        let showsTemplate = template vd.slvIsAdmin vd.slvShows vd.slvPage vd.slvHasMore vd.slvQueryFilter vd.slvStatusFilter
-            filtersContent = Just $ filtersUI vd.slvQueryFilter vd.slvStatusFilter
+        let showsTemplate = template vd.slvIsAdmin vd.slvDeletedView vd.slvShows vd.slvPage vd.slvHasMore vd.slvQueryFilter vd.slvStatusFilter
+            filtersContent = Just $ filtersUI vd.slvQueryFilter vd.slvStatusFilter vd.slvDeletedView
         lift $ renderDashboardTemplate hxRequest vd.slvUserMetadata vd.slvSidebarShows vd.slvSelectedShow NavShows filtersContent newShowButton showsTemplate
   where
     newShowButton :: Maybe (Lucid.Html ())
@@ -143,9 +147,9 @@ fetchSidebarShows isAdmin user =
     else fromRight [] <$> execQuery (Shows.getShowsForUser (User.mId user))
 
 -- | Filter UI for top bar
-filtersUI :: Maybe Text -> Maybe Shows.Status -> Lucid.Html ()
-filtersUI queryFilter statusFilter = do
-  let dashboardShowsGetUrl = rootLink $ dashboardShowsLinks.list Nothing Nothing Nothing
+filtersUI :: Maybe Text -> Maybe Shows.Status -> Bool -> Lucid.Html ()
+filtersUI queryFilter statusFilter deletedView = do
+  let dashboardShowsGetUrl = rootLink $ dashboardShowsLinks.list Nothing Nothing Nothing False
   Lucid.form_
     [ hxGet_ dashboardShowsGetUrl,
       hxTarget_ "#main-content",
@@ -170,6 +174,18 @@ filtersUI queryFilter statusFilter = do
           Lucid.option_ ([Lucid.value_ ""] <> selectedWhen (isNothing statusFilter)) "All Statuses"
           Lucid.option_ ([Lucid.value_ "active"] <> selectedWhen (statusFilter == Just Shows.Active)) "Active"
           Lucid.option_ ([Lucid.value_ "inactive"] <> selectedWhen (statusFilter == Just Shows.Inactive)) "Inactive"
+      -- Deleted-only toggle
+      Lucid.label_
+        [class_ $ base ["flex", "items-center", "gap-1", Tokens.textSm, Tokens.fgPrimary]]
+        $ do
+          Lucid.input_
+            ( [ Lucid.type_ "checkbox",
+                Lucid.name_ "deleted",
+                Lucid.value_ "true"
+              ]
+                <> checkedWhen deletedView
+            )
+          "Deleted only"
       -- Submit button
       Lucid.button_
         [ Lucid.type_ "submit",
@@ -178,19 +194,23 @@ filtersUI queryFilter statusFilter = do
         "Filter"
   where
     selectedWhen cond = [Lucid.selected_ "selected" | cond]
+    checkedWhen cond = [Lucid.checked_ | cond]
 
 getShowResults ::
   Limit ->
   Offset ->
   Maybe Text ->
   Maybe Shows.Status ->
+  Bool ->
   ExceptT HandlerError AppM [Shows.ShowWithHostInfo]
-getShowResults limit offset queryFilter statusFilter =
+getShowResults limit offset queryFilter statusFilter deletedView =
   fromRightM throwDatabaseError $
-    case (queryFilter, statusFilter) of
-      (Just query, _) ->
-        execQuery (Shows.searchShowsWithHostInfo (Search query) (limit + 1) offset)
-      (Nothing, Just status) ->
-        execQuery (Shows.getShowsByStatusWithHostInfo status (limit + 1) offset)
-      (Nothing, Nothing) ->
-        execQuery (Shows.getAllShowsWithHostInfo (limit + 1) offset)
+    if deletedView
+      then execQuery (Shows.getDeletedShowsWithHostInfo (limit + 1) offset)
+      else case (queryFilter, statusFilter) of
+        (Just query, _) ->
+          execQuery (Shows.searchShowsWithHostInfo (Search query) (limit + 1) offset)
+        (Nothing, Just status) ->
+          execQuery (Shows.getShowsByStatusWithHostInfo status (limit + 1) offset)
+        (Nothing, Nothing) ->
+          execQuery (Shows.getAllShowsWithHostInfo (limit + 1) offset)

--- a/services/web/src/API/Dashboard/Shows/Get/Route.hs
+++ b/services/web/src/API/Dashboard/Shows/Get/Route.hs
@@ -22,6 +22,7 @@ type Route =
     :> Servant.QueryParam "page" Int64
     :> Servant.QueryParam "q" (Filter Text)
     :> Servant.QueryParam "status" (Filter Shows.Status)
+    :> Servant.QueryFlag "deleted"
     :> Servant.Header "Cookie" Cookie
     :> Servant.Header "HX-Request" HxRequest
     :> Servant.Get '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Dashboard/Shows/Get/Templates/ItemsFragment.hs
+++ b/services/web/src/API/Dashboard/Shows/Get/Templates/ItemsFragment.hs
@@ -32,18 +32,19 @@ import Servant.Links qualified as Links
 -- to the existing table body.
 renderItemsFragment ::
   IsAdmin ->
+  Bool ->
   [Shows.ShowWithHostInfo] ->
   Int64 ->
   Bool ->
   Maybe Text ->
   Maybe Shows.Status ->
   Lucid.Html ()
-renderItemsFragment isAdmin theShows currentPage hasMore maybeQuery maybeStatusFilter =
+renderItemsFragment isAdmin deletedView theShows currentPage hasMore maybeQuery maybeStatusFilter =
   renderTableFragment
     4 -- Number of columns (was incorrectly 5 before)
     "#shows-table-body"
     (if hasMore then Just [i|/#{nextPageUrl}|] else Nothing)
-    (mapM_ (renderShowRow isAdmin) theShows)
+    (mapM_ (renderShowRow isAdmin deletedView) theShows)
   where
     nextPageUrl :: Links.URI
-    nextPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage + 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter))
+    nextPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage + 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter)) deletedView

--- a/services/web/src/API/Dashboard/Shows/Get/Templates/Page.hs
+++ b/services/web/src/API/Dashboard/Shows/Get/Templates/Page.hs
@@ -44,17 +44,18 @@ type IsAdmin = Bool
 -- | Shows list template (filters are now in the top bar)
 template ::
   IsAdmin ->
+  Bool ->
   [Shows.ShowWithHostInfo] ->
   Int64 ->
   Bool ->
   Maybe Text ->
   Maybe Shows.Status ->
   Lucid.Html ()
-template isAdmin theShowList currentPage hasMore maybeQuery maybeStatusFilter = do
+template isAdmin deletedView theShowList currentPage hasMore maybeQuery maybeStatusFilter = do
   -- Shows table or empty state
   Lucid.section_ [class_ $ base [Tokens.bgMain, "rounded", "overflow-hidden", Tokens.mb8]] $
     if null theShowList
-      then renderEmptyState maybeQuery
+      then renderEmptyState deletedView maybeQuery
       else
         renderIndexTable
           IndexTableConfig
@@ -74,21 +75,23 @@ template isAdmin theShowList currentPage hasMore maybeQuery maybeStatusFilter = 
                       pcCurrentPage = currentPage
                     }
             }
-          (mapM_ (renderShowRow isAdmin) theShowList)
+          (mapM_ (renderShowRow isAdmin deletedView) theShowList)
   where
     nextPageUrl :: Links.URI
-    nextPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage + 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter))
+    nextPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage + 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter)) deletedView
     prevPageUrl :: Links.URI
-    prevPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage - 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter))
+    prevPageUrl = Links.linkURI $ dashboardShowsLinks.list (Just (currentPage - 1)) (Just (Filter maybeQuery)) (Just (Filter maybeStatusFilter)) deletedView
 
-renderShowRow :: IsAdmin -> Shows.ShowWithHostInfo -> Lucid.Html ()
-renderShowRow isAdmin showInfo =
+renderShowRow :: IsAdmin -> Bool -> Shows.ShowWithHostInfo -> Lucid.Html ()
+renderShowRow isAdmin deletedView showInfo =
   let showSlug = showInfo.swhiSlug
       showTitle = showInfo.swhiTitle
       showDetailUri = Links.linkURI $ dashboardShowsLinks.detail showInfo.swhiId showSlug Nothing
       showDetailUrl = [i|/#{showDetailUri}|]
       showEditUrl = Links.linkURI $ dashboardShowsLinks.editGet showSlug
       showDeleteUrl = [i|/dashboard/shows/#{display showSlug}|]
+      showRestoreUri = Links.linkURI $ dashboardShowsLinks.restorePost showSlug
+      showRestoreUrl = [i|/#{showRestoreUri}|] :: Text
    in do
         Lucid.tr_
           [class_ $ base ["border-b-2", Tokens.borderMuted, Tokens.hoverBg]]
@@ -98,7 +101,9 @@ renderShowRow isAdmin showInfo =
                 Lucid.toHtml showInfo.swhiTitle
 
             Lucid.td_ (clickableCellAttrs showDetailUrl) $
-              renderStatusBadge showInfo.swhiStatus
+              if deletedView
+                then renderDeletedBadge
+                else renderStatusBadge showInfo.swhiStatus
 
             Lucid.td_ (clickableCellAttrs showDetailUrl) $ do
               case showInfo.swhiHostNames of
@@ -110,52 +115,66 @@ renderShowRow isAdmin showInfo =
                       "(" <> show showInfo.swhiHostCount <> ")"
 
             Lucid.td_ [class_ $ base [Tokens.p4, "text-center"]] $
-              Lucid.div_ [xData_ "{}"] $
-                do
-                  -- Hidden link for Edit - HTMX handles history properly
-                  Lucid.a_
-                    [ Lucid.href_ [i|/#{showEditUrl}|],
-                      hxGet_ [i|/#{showEditUrl}|],
-                      hxTarget_ "#main-content",
-                      hxPushUrl_ "true",
-                      xRef_ "editLink",
-                      Lucid.class_ "hidden"
-                    ]
-                    ""
-                  -- Hidden button for Delete (admin only) - HTMX handles the request
+              if deletedView
+                then
+                  -- Restore action (admin only)
                   if isAdmin
                     then
                       Lucid.button_
-                        [ hxDelete_ showDeleteUrl,
+                        [ hxPost_ showRestoreUrl,
                           hxTarget_ "closest tr",
                           hxSwap_ "outerHTML swap:1s",
-                          hxConfirm_ [i|Are you sure you want to delete "#{showTitle}"? This action cannot be undone.|],
-                          xRef_ "deleteBtn",
-                          Lucid.class_ "hidden"
+                          xOnClick_ "event.stopPropagation()",
+                          class_ $ base ["p-2", "border", Tokens.borderMuted, "text-xs", Tokens.bgMain, Tokens.fgPrimary, "hover:opacity-80"]
                         ]
-                        ""
+                        "Restore"
                     else mempty
-                  -- Visible dropdown
-                  Lucid.select_
-                    [ class_ $ base ["p-2", "border", Tokens.borderMuted, "text-xs", Tokens.bgMain, Tokens.fgPrimary],
-                      xOnChange_
-                        [i|
-                      const action = $el.value;
-                      $el.value = '';
-                      if (action === 'edit') {
-                        $refs.editLink.click();
-                      } else if (action === 'delete') {
-                        $refs.deleteBtn.click();
-                      }
-                    |],
-                      xOnClick_ "event.stopPropagation()"
-                    ]
-                    $ do
-                      Lucid.option_ [Lucid.value_ ""] "Actions..."
-                      Lucid.option_ [Lucid.value_ "edit"] "Edit"
-                      if isAdmin
-                        then Lucid.option_ [Lucid.value_ "delete"] "Delete"
-                        else mempty
+                else Lucid.div_ [xData_ "{}"] $
+                  do
+                    -- Hidden link for Edit - HTMX handles history properly
+                    Lucid.a_
+                      [ Lucid.href_ [i|/#{showEditUrl}|],
+                        hxGet_ [i|/#{showEditUrl}|],
+                        hxTarget_ "#main-content",
+                        hxPushUrl_ "true",
+                        xRef_ "editLink",
+                        Lucid.class_ "hidden"
+                      ]
+                      ""
+                    -- Hidden button for Delete (admin only) - HTMX handles the request
+                    if isAdmin
+                      then
+                        Lucid.button_
+                          [ hxDelete_ showDeleteUrl,
+                            hxTarget_ "closest tr",
+                            hxSwap_ "outerHTML swap:1s",
+                            hxConfirm_ [i|Are you sure you want to delete "#{showTitle}"? You can restore it later from the Deleted view.|],
+                            xRef_ "deleteBtn",
+                            Lucid.class_ "hidden"
+                          ]
+                          ""
+                      else mempty
+                    -- Visible dropdown
+                    Lucid.select_
+                      [ class_ $ base ["p-2", "border", Tokens.borderMuted, "text-xs", Tokens.bgMain, Tokens.fgPrimary],
+                        xOnChange_
+                          [i|
+                          const action = $el.value;
+                          $el.value = '';
+                          if (action === 'edit') {
+                            $refs.editLink.click();
+                          } else if (action === 'delete') {
+                            $refs.deleteBtn.click();
+                          }
+                        |],
+                        xOnClick_ "event.stopPropagation()"
+                      ]
+                      $ do
+                        Lucid.option_ [Lucid.value_ ""] "Actions..."
+                        Lucid.option_ [Lucid.value_ "edit"] "Edit"
+                        if isAdmin
+                          then Lucid.option_ [Lucid.value_ "delete"] "Delete"
+                          else mempty
 
 renderStatusBadge :: Shows.Status -> Lucid.Html ()
 renderStatusBadge status = do
@@ -167,10 +186,18 @@ renderStatusBadge status = do
     [class_ $ base ["inline-block", Tokens.px3, "py-1", Tokens.textSm, Tokens.fontBold, "rounded", bgClass, textClass]]
     $ Lucid.toHtml statusText
 
-renderEmptyState :: Maybe Text -> Lucid.Html ()
-renderEmptyState maybeQuery = do
+renderDeletedBadge :: Lucid.Html ()
+renderDeletedBadge =
+  Lucid.span_
+    [class_ $ base ["inline-block", Tokens.px3, "py-1", Tokens.textSm, Tokens.fontBold, "rounded", Tokens.errorBg, Tokens.errorText]]
+    "Deleted"
+
+renderEmptyState :: Bool -> Maybe Text -> Lucid.Html ()
+renderEmptyState deletedView maybeQuery = do
   Lucid.div_ [class_ $ base [Tokens.bgAlt, Tokens.border2, Tokens.borderMuted, "p-12", "text-center"]] $ do
     Lucid.p_ [class_ $ base [Tokens.textXl, Tokens.fgMuted]] $
-      case maybeQuery of
-        Nothing -> "No shows found. Create your first show!"
-        Just query -> Lucid.toHtml $ "No shows found matching \"" <> query <> "\"."
+      if deletedView
+        then "No deleted shows."
+        else case maybeQuery of
+          Nothing -> "No shows found. Create your first show!"
+          Just query -> Lucid.toHtml $ "No shows found matching \"" <> query <> "\"."

--- a/services/web/src/API/Dashboard/Shows/New/Get/Templates/Page.hs
+++ b/services/web/src/API/Dashboard/Shows/New/Get/Templates/Page.hs
@@ -26,7 +26,7 @@ import Servant.Links qualified as Links
 --------------------------------------------------------------------------------
 
 dashboardShowsGetUrl :: Links.URI
-dashboardShowsGetUrl = Links.linkURI $ apiLinks.dashboard.admin.shows.list Nothing Nothing Nothing
+dashboardShowsGetUrl = Links.linkURI $ apiLinks.dashboard.admin.shows.list Nothing Nothing Nothing False
 
 dashboardShowsNewPostUrl :: Links.URI
 dashboardShowsNewPostUrl = Links.linkURI apiLinks.dashboard.admin.shows.newPost

--- a/services/web/src/API/Dashboard/Shows/Slug/Edit/Get/Templates/Form.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Edit/Get/Templates/Form.hs
@@ -37,7 +37,7 @@ import Servant.Links qualified as Links
 --------------------------------------------------------------------------------
 
 dashboardShowsGetUrl :: Links.URI
-dashboardShowsGetUrl = Links.linkURI $ apiLinks.dashboard.admin.shows.list Nothing Nothing Nothing
+dashboardShowsGetUrl = Links.linkURI $ apiLinks.dashboard.admin.shows.list Nothing Nothing Nothing False
 
 showGetUrl :: Slug -> Links.URI
 showGetUrl slug = Links.linkURI $ apiLinks.shows.detail slug Nothing
@@ -186,7 +186,7 @@ renderSchedulePreview activeTemplates pendingTemplates pendingStartDate =
 
     -- Pending schedule with start date
     unless (null pendingTemplates) $ do
-      when (not (null activeTemplates)) $
+      unless (null activeTemplates) $
         Lucid.hr_ [class_ $ base [Tokens.borderMuted, "my-3"]]
       let header =
             if Text.null pendingStartDate

--- a/services/web/src/API/Dashboard/Shows/Slug/Restore/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Restore/Post/Handler.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module API.Dashboard.Shows.Slug.Restore.Post.Handler where
+
+--------------------------------------------------------------------------------
+
+import App.Handler.Combinators (requireAdminNotSuspended, requireAuth)
+import App.Handler.Error (HandlerError, handleBannerErrors, throwDatabaseError, throwNotFound)
+import App.Monad (AppM)
+import Component.Banner (BannerType (..), renderBanner)
+import Control.Monad (void)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Text.Display (display)
+import Domain.Types.Cookie (Cookie (..))
+import Domain.Types.Slug (Slug)
+import Effects.Database.Class (runDBTransaction)
+import Effects.Database.Tables.Shows qualified as Shows
+import Hasql.Transaction qualified as TRX
+import Log qualified
+import Lucid qualified
+
+--------------------------------------------------------------------------------
+
+handler ::
+  Slug ->
+  Maybe Cookie ->
+  AppM (Lucid.Html ())
+handler targetSlug cookie =
+  handleBannerErrors "Show restore" $ do
+    (_user, userMetadata) <- requireAuth cookie
+    requireAdminNotSuspended "Only admins can restore shows." userMetadata
+    (_, showTitle) <- action targetSlug
+    pure $ do
+      mempty
+      renderBanner Success "Show Restored" ("Show \"" <> showTitle <> "\" has been restored.")
+
+-- | Business logic: look up soft-deleted show, restore it.
+--
+-- Returns the restored show's ID and title on success.
+action ::
+  Slug ->
+  ExceptT HandlerError AppM (Shows.Id, Text)
+action targetSlug = do
+  result <- runDBTransaction $ runMaybeT $ do
+    showRec <- MaybeT $ TRX.statement () (Shows.getDeletedShowBySlug targetSlug)
+    void $ MaybeT $ TRX.statement () (Shows.restoreShow showRec.id)
+    pure (showRec.id, showRec.title)
+
+  case result of
+    Left err -> throwDatabaseError err
+    Right Nothing -> throwNotFound "Show"
+    Right (Just success) -> do
+      Log.logInfo "Show restored successfully" (Aeson.object ["showId" .= display (fst success)])
+      pure success

--- a/services/web/src/API/Dashboard/Shows/Slug/Restore/Post/Route.hs
+++ b/services/web/src/API/Dashboard/Shows/Slug/Restore/Post/Route.hs
@@ -1,0 +1,21 @@
+module API.Dashboard.Shows.Slug.Restore.Post.Route where
+
+--------------------------------------------------------------------------------
+
+import Domain.Types.Cookie (Cookie)
+import Domain.Types.Slug (Slug)
+import Lucid qualified
+import Servant ((:>))
+import Servant qualified
+import Text.HTML (HTML)
+
+--------------------------------------------------------------------------------
+
+-- | "POST /dashboard/shows/:slug/restore"
+type Route =
+  "dashboard"
+    :> "shows"
+    :> Servant.Capture "slug" Slug
+    :> "restore"
+    :> Servant.Header "Cookie" Cookie
+    :> Servant.Post '[HTML] (Lucid.Html ())

--- a/services/web/src/API/Types.hs
+++ b/services/web/src/API/Types.hs
@@ -106,6 +106,7 @@ import API.Dashboard.Shows.Slug.Edit.Post.Route qualified as Dashboard.Shows.Slu
 import API.Dashboard.Shows.Slug.Episode.New.Get.Route qualified as Dashboard.Shows.Slug.Episode.New.Get
 import API.Dashboard.Shows.Slug.Episode.New.Post.Route qualified as Dashboard.Shows.Slug.Episode.New.Post
 import API.Dashboard.Shows.Slug.Get.Route qualified as Dashboard.Shows.Slug.Get
+import API.Dashboard.Shows.Slug.Restore.Post.Route qualified as Dashboard.Shows.Slug.Restore.Post
 import API.Dashboard.SitePages.Get.Route qualified as Dashboard.SitePages.Get
 import API.Dashboard.SitePages.Slug.Edit.Get.Route qualified as Dashboard.SitePages.Slug.Edit.Get
 import API.Dashboard.SitePages.Slug.Edit.Post.Route qualified as Dashboard.SitePages.Slug.Edit.Post
@@ -530,6 +531,8 @@ data DashboardShowsRoutes mode = DashboardShowsRoutes
     editPost :: mode :- Dashboard.Shows.Slug.Edit.Post.Route,
     -- | @DELETE /dashboard/shows/:slug@ - Delete show (soft delete)
     delete :: mode :- Dashboard.Shows.Slug.Delete.Route,
+    -- | @POST /dashboard/shows/:slug/restore@ - Restore soft-deleted show
+    restorePost :: mode :- Dashboard.Shows.Slug.Restore.Post.Route,
     -- | @GET /dashboard/shows/:slug/episodes/new@ - New episode upload form
     episodeNewGet :: mode :- Dashboard.Shows.Slug.Episode.New.Get.Route,
     -- | @POST /dashboard/shows/:slug/episodes/new@ - Create new episode

--- a/services/web/src/Component/DashboardFrame.hs
+++ b/services/web/src/Component/DashboardFrame.hs
@@ -80,7 +80,7 @@ dashboardUsersGetUrl :: Links.URI
 dashboardUsersGetUrl = Links.linkURI $ dashboardUsersLinks.list Nothing Nothing Nothing Nothing
 
 dashboardShowsGetUrl :: Links.URI
-dashboardShowsGetUrl = Links.linkURI $ dashboardShowsLinks.list Nothing Nothing Nothing
+dashboardShowsGetUrl = Links.linkURI $ dashboardShowsLinks.list Nothing Nothing Nothing False
 
 dashboardStationBlogGetUrl :: Links.URI
 dashboardStationBlogGetUrl = Links.linkURI $ dashboardStationBlogLinks.list Nothing

--- a/services/web/test/API/Dashboard/Shows/Get/HandlerSpec.hs
+++ b/services/web/test/API/Dashboard/Shows/Get/HandlerSpec.hs
@@ -45,7 +45,7 @@ test_emptyDbReturnsNoShows cfg = do
           setupUserModels adminInsert
     (userModel, userMetaModel) <- expectSetupRight dbResult
 
-    result <- runExceptT $ action userModel userMetaModel Nothing Nothing Nothing IsNotHxRequest
+    result <- runExceptT $ action userModel userMetaModel Nothing Nothing Nothing False IsNotHxRequest
 
     liftIO $ case result of
       Left err -> expectationFailure $ "Expected Right but got Left: " <> show err
@@ -65,7 +65,7 @@ test_insertedShowAppears cfg = do
       pure (userModel, userMetaModel, showId)
     (userModel, userMetaModel, _showId) <- expectSetupRight dbResult
 
-    result <- runExceptT $ action userModel userMetaModel Nothing Nothing Nothing IsNotHxRequest
+    result <- runExceptT $ action userModel userMetaModel Nothing Nothing Nothing False IsNotHxRequest
 
     liftIO $ case result of
       Left err -> expectationFailure $ "Expected Right but got Left: " <> show err
@@ -89,10 +89,10 @@ test_statusFilterWorks cfg = do
 
     activeResult <-
       runExceptT $
-        action userModel userMetaModel Nothing Nothing (Just (Filter (Just Shows.Active))) IsNotHxRequest
+        action userModel userMetaModel Nothing Nothing (Just (Filter (Just Shows.Active))) False IsNotHxRequest
     inactiveResult <-
       runExceptT $
-        action userModel userMetaModel Nothing Nothing (Just (Filter (Just Shows.Inactive))) IsNotHxRequest
+        action userModel userMetaModel Nothing Nothing (Just (Filter (Just Shows.Inactive))) False IsNotHxRequest
 
     liftIO $ do
       case activeResult of


### PR DESCRIPTION
Adds a "Deleted only" view to the dashboard shows index and an admin-only restore action to un-soft-delete shows.

- `GET /dashboard/shows` gains a "Deleted only" toggle (defaults off)
- `POST /dashboard/shows/:slug/restore` clears `deleted_at` (admin only)
- Delete confirmation copy updated to mention restore
