### PR TITLE
Release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.12.2] - 2026-07-11
+
 ### Added
 - **Event photo galleries** — Events can now carry an optional gallery of photos, posted after the fact as a historical record. Staff (or the event's author) manage photos in a new "EVENT PHOTO GALLERY" section of the event edit form (`/dashboard/events/:id/:slug/edit`): drag to reorder, add a visible caption and alt text per photo, and remove photos. Unlike poster/product images, gallery photos are stored as-is with their original aspect ratio (no cropping), so mixed portrait/landscape phone photos are preserved. On the public event page the photos render as a responsive thumbnail grid with a click-to-enlarge Alpine.js lightbox (prev/next, Esc/backdrop to close); the section is hidden entirely when an event has no photos. Backed by a new `event_images` table (`Effects.Database.Tables.EventImages`), an `uploadEventGalleryImage` effect storing under `images/event-galleries/…`, and a prepare→transaction→cleanup save path mirroring product images. No new routes — the gallery piggybacks on the existing event edit POST and public detail GET.
 - **Restore soft-deleted shows** — Admins can restore soft-deleted shows from a new "Deleted only" toggle on the dashboard shows list (`/dashboard/shows?deleted`). The deleted view lists shows most-recently-deleted first with a "Deleted" badge and a per-row Restore action (`POST /dashboard/shows/:slug/restore`), which clears `deleted_at` and swaps the row out. Backed by three new idempotent `shows` queries (`restoreShow`, `getDeletedShowBySlug`, `getDeletedShowsWithHostInfo`). The delete-confirm copy now notes the show can be restored later.

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.12.1
+version:            0.12.2
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.12.2

This PR releases version 0.12.2

### What's Changed


### Added
- **Event photo galleries** — Events can now carry an optional gallery of photos, posted after the fact as a historical record. Staff (or the event's author) manage photos in a new "EVENT PHOTO GALLERY" section of the event edit form (`/dashboard/events/:id/:slug/edit`): drag to reorder, add a visible caption and alt text per photo, and remove photos. Unlike poster/product images, gallery photos are stored as-is with their original aspect ratio (no cropping), so mixed portrait/landscape phone photos are preserved. On the public event page the photos render as a responsive thumbnail grid with a click-to-enlarge Alpine.js lightbox (prev/next, Esc/backdrop to close); the section is hidden entirely when an event has no photos. Backed by a new `event_images` table (`Effects.Database.Tables.EventImages`), an `uploadEventGalleryImage` effect storing under `images/event-galleries/…`, and a prepare→transaction→cleanup save path mirroring product images. No new routes — the gallery piggybacks on the existing event edit POST and public detail GET.
- **Restore soft-deleted shows** — Admins can restore soft-deleted shows from a new "Deleted only" toggle on the dashboard shows list (`/dashboard/shows?deleted`). The deleted view lists shows most-recently-deleted first with a "Deleted" badge and a per-row Restore action (`POST /dashboard/shows/:slug/restore`), which clears `deleted_at` and swaps the row out. Backed by three new idempotent `shows` queries (`restoreShow`, `getDeletedShowBySlug`, `getDeletedShowsWithHostInfo`). The delete-confirm copy now notes the show can be restored later.
- **Membership link in main nav** — Added a dedicated "Membership" entry (linking to the pools.events listener-membership signup) to both the desktop navbar and the mobile hamburger menu, placed immediately after "Donate". Rendered as a plain external anchor (`target="_blank"`, `rel="noopener noreferrer"`) rather than an HTMX-swapped internal link, since the destination is cross-origin. The existing membership link in the donate-page content is unchanged.

### Changed
- **Shipping carriers managed in EasyPost** — Removed the backend carrier whitelist (`filterRates`) from the checkout and label-purchase flows. Every rate EasyPost returns is now offered (sorted by price); which carriers appear is controlled entirely by the carrier accounts configured in the EasyPost dashboard.
- **Helpful shipping-address errors at checkout** — When EasyPost rejects a shipping address, the checkout now surfaces the specific problem (e.g. "House number is missing") instead of a generic "check your address" banner. The `easypost-http` client parses EasyPost's structured `{"error": {...}}` payloads (`EasyPostError`/`EasyPostFieldError`), and the customer shipping-rate lookup now proactively requests delivery-address verification, showing a targeted message when the address can't be verified before quoting rates. The same parsed-error copy is reused across the create-session and label-purchase failure paths.
- **Consistent dev Justfile recipe names** — Aligned the local-development recipes with the `<env>-<thing>` convention already used by staging/prod. Renamed `dev-postgres-psql` → `dev-psql` (mirrors `prod-psql`/`staging-psql`), `dev-postgres-start`/`dev-postgres-stop` → `dev-db-start`/`dev-db-stop`, and the local streaming-VM recipes `stream-dev-{build,start,stop,ssh,logs}` → `dev-stream-{build,start,stop,ssh,logs}`. Hard rename with no aliases; updated README, CLAUDE.md, PROVISIONING.md, and the `prod-to-local` scripts. Internal Docker container and NixOS configuration names are unchanged.
- **Environment-prefixed NixOS recipes** — Renamed the NixOS streaming-VPS recipes to lead with the environment, matching the `<env>-*` convention: `nixos-deploy-{prod,staging}` → `{prod,staging}-nixos-deploy`, `nixos-deploy-{prod,staging}-dry` → `{prod,staging}-nixos-deploy-dry`, and `nixos-build-{prod,staging}` → `{prod,staging}-nixos-build`. `nixos-setup HOST ENV` is unchanged (environment is a runtime argument). Updated README, ARCHITECTURE.md, PROVISIONING.md, terraform docs, and `scripts/nixos-setup.sh`.
- **Staging pgBackRest disabled** — Turned off pgBackRest entirely on staging (`nixos/staging.nix`): no local or S3 backups, and no WAL archiving. Staging data is disposable (rebuilt from prod via `just prod-to-staging`), so there is nothing worth backing up. Production is unchanged and retains full pgBackRest (repo1 local + repo2 S3, `kpbj-pgbackrest/prod`).

---

When merged, a git tag v0.12.2 will be automatically created, which triggers the production deployment.
