### PR TITLE
Release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.12.3] - 2026-07-13
+
 ### Fixed
 - **Host email sync no longer removes group managers** — The `sync-host-emails` job previously removed any Google Group member whose email was not in the host set, including accounts manually promoted to `MANAGER`/`OWNER` in Google Admin. The reconciliation now excludes `MANAGER`/`OWNER` members from removal (protect-only; the job still never assigns the manager role, and still adds hosts as plain `MEMBER`). Dry-run output gains a `PROTECTED (skipped)` section and the run log a `protected` count. Reconciliation is now a pure, unit-tested `computeSyncPlan` (`jobs/sync-host-emails/src/Sync.hs`), and the package was split into a library + executable + hspec test-suite to support it.
 

--- a/services/web/kpbj-api.cabal
+++ b/services/web/kpbj-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kpbj-api
-version:            0.12.2
+version:            0.12.3
 license:            Apache-2.0
 license-file:       LICENSE_HASKELL
 author:             Solomon Bothwell


### PR DESCRIPTION
## Release v0.12.3

This PR releases version 0.12.3

### What's Changed


### Fixed
- **Host email sync no longer removes group managers** — The `sync-host-emails` job previously removed any Google Group member whose email was not in the host set, including accounts manually promoted to `MANAGER`/`OWNER` in Google Admin. The reconciliation now excludes `MANAGER`/`OWNER` members from removal (protect-only; the job still never assigns the manager role, and still adds hosts as plain `MEMBER`). Dry-run output gains a `PROTECTED (skipped)` section and the run log a `protected` count. Reconciliation is now a pure, unit-tested `computeSyncPlan` (`jobs/sync-host-emails/src/Sync.hs`), and the package was split into a library + executable + hspec test-suite to support it.

---

When merged, a git tag v0.12.3 will be automatically created, which triggers the production deployment.
