### PR TITLE
Split easypost-http request/response types; fix zero-rate USPS shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to KPBJ 95.9FM are documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+- **easypost-http: split request/response types and model all documented fields** — The EasyPost domain types are now split into request types (`AddressParams`, `ParcelParams`, `ShipmentParams`) and response types (`Address`, `Parcel`, `Shipment`, `Rate`, `PostageLabel`), each modeling every documented field. Request types have hand-written `ToJSON` (nesting + omit-when-empty); response types derive `FromJSON` from a shared snake_case options value (with hand-written instances where lists need defaulting). Address verification is now expressed via `verify`/`verify_strict`/`verify_carrier` on `AddressParams` (previously a root-level shipment key). Added `Verifications`/`VerificationDetails`; `PostageLabel` replaces the old `Label` type; `ShipmentParams` replaces `ShipmentCreate`. Field-level errors (`EasyPostFieldError`) gained a `code` field. Not-yet-modeled nested objects (customs info, tracker, options, forms, fees, etc.) are retained as raw JSON.
+- **Store checkout/label handlers updated to the split easypost-http types** — The shipping-rate and label-purchase handlers now build `ShipmentParams`/`AddressParams`/`ParcelParams` requests and parse the new `Shipment`/`Address`/`PostageLabel` responses. Delivery-address verification is read from `toAddress.verifications.delivery` instead of the old bespoke `toAddressDeliveryVerification` field. Both builders now ship in the larger 14.5×19 mailer (hardcoded parcel dimensions) — USPS requires all three parcel dimensions or it returns zero rates.
 
 ---
 

--- a/lib/easypost-http/easypost-http.cabal
+++ b/lib/easypost-http/easypost-http.cabal
@@ -38,6 +38,7 @@ library
     , servant
     , servant-client
     , text
+    , time
   exposed-modules:
     EasyPost.API
     EasyPost.Client

--- a/lib/easypost-http/src/EasyPost/API.hs
+++ b/lib/easypost-http/src/EasyPost/API.hs
@@ -28,7 +28,7 @@ import Servant.API
     (:<|>),
     (:>),
   )
-import EasyPost.Types (Shipment, ShipmentBuy, ShipmentCreate)
+import EasyPost.Types (Shipment, ShipmentBuy, ShipmentParams)
 
 
 -- | @POST /v2/shipments@
@@ -39,7 +39,7 @@ type CreateShipmentAPI =
   "v2"
     :> "shipments"
     :> Header' '[Required, Strict] "Authorization" Text
-    :> ReqBody '[JSON] ShipmentCreate
+    :> ReqBody '[JSON] ShipmentParams
     :> PostCreated '[JSON] Shipment
 
 

--- a/lib/easypost-http/src/EasyPost/Client.hs
+++ b/lib/easypost-http/src/EasyPost/Client.hs
@@ -30,7 +30,7 @@ import EasyPost.Types
     EasyPostError,
     Shipment,
     ShipmentBuy,
-    ShipmentCreate,
+    ShipmentParams,
   )
 import Network.HTTP.Client (Manager)
 import Servant.API ((:<|>) (..))
@@ -73,7 +73,7 @@ easyPostBaseUrl =
 
 
 -- | Derive client functions from the 'EasyPostAPI' type.
-createShipmentClient :: Text -> ShipmentCreate -> Client.ClientM Shipment
+createShipmentClient :: Text -> ShipmentParams -> Client.ClientM Shipment
 getShipmentClient :: Text -> Text -> Client.ClientM Shipment
 buyShipmentClient :: Text -> Text -> ShipmentBuy -> Client.ClientM Shipment
 createShipmentClient :<|> getShipmentClient :<|> buyShipmentClient = Client.client (Proxy :: Proxy EasyPostAPI)
@@ -98,7 +98,7 @@ createShipment ::
   -- | API key
   EasyPostApiKey ->
   -- | Shipment parameters
-  ShipmentCreate ->
+  ShipmentParams ->
   IO (Either EasyPostClientError Shipment)
 createShipment manager apiKey params = do
   let env = Client.mkClientEnv manager easyPostBaseUrl

--- a/lib/easypost-http/src/EasyPost/Types.hs
+++ b/lib/easypost-http/src/EasyPost/Types.hs
@@ -1,46 +1,69 @@
 -- | Core EasyPost domain types.
 --
--- All types in this module model EasyPost API objects and use EasyPost's
--- snake_case JSON encoding. The 'EasyPostApiKey' newtype has a censored
--- 'Show' instance so credentials never appear in logs.
+-- Types are split into two families:
+--
+-- * __Request types__ — @*Params@ records and 'ShipmentBuy'. These are what
+--   you send to EasyPost; they have hand-written 'ToJSON' instances that
+--   control nesting and omit optional keys when empty.
+-- * __Response types__ — 'Address', 'Parcel', 'Shipment', 'Rate',
+--   'PostageLabel', etc. These model the full documented shape of EasyPost's
+--   API objects and only have 'FromJSON' instances.
+--
+-- All JSON encoding follows EasyPost's snake_case convention. The
+-- 'EasyPostApiKey' newtype has a censored 'Show' instance so credentials never
+-- appear in logs.
 module EasyPost.Types
   ( -- * API Credentials
     EasyPostApiKey (..),
 
     -- * Address
     Address (..),
+    AddressParams (..),
 
     -- * Parcel
     Parcel (..),
+    ParcelParams (..),
 
     -- * Shipment
-    ShipmentCreate (..),
     Shipment (..),
+    ShipmentParams (..),
+    ShipmentBuy (..),
 
     -- * Rate
     Rate (..),
 
-    -- * Purchase
-    ShipmentBuy (..),
+    -- * Postage Label
+    PostageLabel (..),
 
-    -- * Label
-    Label (..),
+    -- * Verification
+    Verifications (..),
+    Verification (..),
+    VerificationDetails (..),
 
     -- * Errors
     EasyPostError (..),
     EasyPostFieldError (..),
-
-    -- * Verification
-    Verification (..),
   )
 where
 
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..), Value)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+import Data.Time (UTCTime)
 import GHC.Generics (Generic)
+
+--------------------------------------------------------------------------------
+-- JSON Options
+
+-- | Shared aeson options mapping camelCase Haskell fields to EasyPost's
+-- snake_case JSON keys (e.g. @createdAt@ ↔ @created_at@).
+jsonOptions :: Aeson.Options
+jsonOptions =
+  Aeson.defaultOptions
+    { Aeson.fieldLabelModifier = Aeson.camelTo2 '_'
+    }
 
 --------------------------------------------------------------------------------
 -- API Credentials
@@ -55,12 +78,72 @@ instance Show EasyPostApiKey where
   show _ = "EasyPostApiKey \"<redacted>\""
 
 --------------------------------------------------------------------------------
--- Address
+-- Address (response)
 
--- | A shipping address in EasyPost's format.
+-- | A shipping address as returned by EasyPost.
+--
+-- Only @id@, @object@, @mode@, @createdAt@, and @updatedAt@ are guaranteed
+-- present; all descriptive fields are optional and may be @null@.
 data Address = Address
+  { -- | Unique address identifier (e.g. @"adr_abc123"@).
+    id :: Text,
+    -- | Object type, always @"Address"@.
+    object :: Text,
+    -- | Environment mode, @"test"@ or @"production"@.
+    mode :: Text,
+    -- | Creation timestamp.
+    createdAt :: UTCTime,
+    -- | Last-update timestamp.
+    updatedAt :: UTCTime,
+    -- | Primary street line.
+    street1 :: Maybe Text,
+    -- | Secondary street line (apt, suite, etc.).
+    street2 :: Maybe Text,
+    -- | City name.
+    city :: Maybe Text,
+    -- | State or province code (e.g. @"CA"@).
+    state :: Maybe Text,
+    -- | ZIP or postal code.
+    zip :: Maybe Text,
+    -- | Two-letter country code (e.g. @"US"@).
+    country :: Maybe Text,
+    -- | Full name of the recipient or sender.
+    name :: Maybe Text,
+    -- | Company name.
+    company :: Maybe Text,
+    -- | Phone number.
+    phone :: Maybe Text,
+    -- | Email address.
+    email :: Maybe Text,
+    -- | Federal tax identifier.
+    federalTaxId :: Maybe Text,
+    -- | State tax identifier.
+    stateTaxId :: Maybe Text,
+    -- | Whether the address is residential.
+    residential :: Maybe Bool,
+    -- | Carrier facility hint.
+    carrierFacility :: Maybe Text,
+    -- | Verification results, present when verification was requested.
+    verifications :: Maybe Verifications
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON Address where
+  parseJSON = Aeson.genericParseJSON jsonOptions
+
+--------------------------------------------------------------------------------
+-- Address (request)
+
+-- | Parameters for creating an address.
+--
+-- The required address lines are always emitted; optional fields are emitted
+-- only when 'Just'. The three @verify*@ lists request server-side address
+-- verification and are omitted when empty.
+data AddressParams = AddressParams
   { -- | Full name of the recipient or sender.
-    name :: Text,
+    name :: Maybe Text,
+    -- | Company name.
+    company :: Maybe Text,
     -- | Primary street line.
     street1 :: Text,
     -- | Secondary street line (apt, suite, etc.).
@@ -72,218 +155,455 @@ data Address = Address
     -- | ZIP or postal code.
     zip :: Text,
     -- | Two-letter country code (e.g. @"US"@).
-    country :: Text
+    country :: Text,
+    -- | Phone number.
+    phone :: Maybe Text,
+    -- | Email address.
+    email :: Maybe Text,
+    -- | Federal tax identifier.
+    federalTaxId :: Maybe Text,
+    -- | State tax identifier.
+    stateTaxId :: Maybe Text,
+    -- | Whether the address is residential.
+    residential :: Maybe Bool,
+    -- | Carrier facility hint.
+    carrierFacility :: Maybe Text,
+    -- | Verifications to request (e.g. @["delivery"]@); emitted only when
+    -- non-empty.
+    verify :: [Text],
+    -- | Strict verifications to request; emitted only when non-empty.
+    verifyStrict :: [Text],
+    -- | Carrier verifications to request; emitted only when non-empty.
+    verifyCarrier :: [Text]
   }
   deriving stock (Show, Eq, Generic)
 
-instance ToJSON Address where
+instance ToJSON AddressParams where
   toJSON addr =
     Aeson.object $
-      [ "name" Aeson..= addr.name,
-        "street1" Aeson..= addr.street1,
+      [ "street1" Aeson..= addr.street1,
         "city" Aeson..= addr.city,
         "state" Aeson..= addr.state,
         "zip" Aeson..= addr.zip,
         "country" Aeson..= addr.country
       ]
-        <> maybe [] (\s2 -> ["street2" Aeson..= s2]) addr.street2
-
-instance FromJSON Address where
-  parseJSON = Aeson.withObject "Address" $ \o ->
-    Address
-      <$> o Aeson..: "name"
-      <*> o Aeson..: "street1"
-      <*> o Aeson..:? "street2"
-      <*> o Aeson..: "city"
-      <*> o Aeson..: "state"
-      <*> o Aeson..: "zip"
-      <*> o Aeson..: "country"
+        <> optional "name" addr.name
+        <> optional "company" addr.company
+        <> optional "street2" addr.street2
+        <> optional "phone" addr.phone
+        <> optional "email" addr.email
+        <> optional "federal_tax_id" addr.federalTaxId
+        <> optional "state_tax_id" addr.stateTaxId
+        <> optional "residential" addr.residential
+        <> optional "carrier_facility" addr.carrierFacility
+        <> optionalList "verify" addr.verify
+        <> optionalList "verify_strict" addr.verifyStrict
+        <> optionalList "verify_carrier" addr.verifyCarrier
 
 --------------------------------------------------------------------------------
--- Parcel
+-- Verification (response)
 
--- | A parcel description for shipment rating.
-newtype Parcel = Parcel
-  { -- | Weight in ounces.
-    weight :: Double
+-- | The verification results attached to an address, keyed by verification
+-- kind.
+data Verifications = Verifications
+  { -- | Deliverability verification.
+    delivery :: Maybe Verification,
+    -- | ZIP+4 verification.
+    zip4 :: Maybe Verification
   }
   deriving stock (Show, Eq, Generic)
 
-instance ToJSON Parcel where
-  toJSON p =
-    Aeson.object
-      [ "weight" Aeson..= p.weight
-      ]
+instance FromJSON Verifications where
+  parseJSON = Aeson.genericParseJSON jsonOptions
+
+-- | A single EasyPost address verification result.
+data Verification = Verification
+  { -- | Whether the address passed verification.
+    success :: Bool,
+    -- | Verification errors, when the address failed.
+    errors :: [EasyPostFieldError],
+    -- | Additional geocoding details, when available.
+    details :: Maybe VerificationDetails
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON Verification where
+  parseJSON = Aeson.withObject "Verification" $ \o ->
+    Verification
+      <$> o Aeson..: "success"
+      <*> o Aeson..:? "errors" Aeson..!= []
+      <*> o Aeson..:? "details"
+
+-- | Geocoding details attached to a 'Verification'.
+data VerificationDetails = VerificationDetails
+  { -- | Latitude of the verified address.
+    latitude :: Maybe Double,
+    -- | Longitude of the verified address.
+    longitude :: Maybe Double,
+    -- | Time zone of the verified address.
+    timeZone :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON VerificationDetails where
+  parseJSON = Aeson.genericParseJSON jsonOptions
+
+--------------------------------------------------------------------------------
+-- Parcel (response)
+
+-- | A parcel as returned by EasyPost.
+data Parcel = Parcel
+  { -- | Unique parcel identifier (e.g. @"prcl_abc123"@).
+    id :: Text,
+    -- | Object type, always @"Parcel"@.
+    object :: Text,
+    -- | Environment mode, @"test"@ or @"production"@.
+    mode :: Text,
+    -- | Creation timestamp.
+    createdAt :: UTCTime,
+    -- | Last-update timestamp.
+    updatedAt :: UTCTime,
+    -- | Length in inches.
+    length :: Maybe Double,
+    -- | Width in inches.
+    width :: Maybe Double,
+    -- | Height in inches.
+    height :: Maybe Double,
+    -- | Weight in ounces.
+    weight :: Double,
+    -- | Predefined package type, when used.
+    predefinedPackage :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
 
 instance FromJSON Parcel where
-  parseJSON = Aeson.withObject "Parcel" $ \o ->
-    Parcel
-      <$> o Aeson..: "weight"
+  parseJSON = Aeson.genericParseJSON jsonOptions
 
 --------------------------------------------------------------------------------
--- Shipment Create
+-- Parcel (request)
 
--- | Parameters for creating a new EasyPost shipment.
+-- | Parameters for creating a parcel.
 --
--- Serializes as @{"shipment": {"from_address": ..., "to_address": ..., "parcel": ...}}@
--- to match the EasyPost API's expected request body.
-data ShipmentCreate = ShipmentCreate
-  { -- | Origin address.
-    fromAddress :: Address,
-    -- | Destination address.
-    toAddress :: Address,
-    -- | Package dimensions and weight.
-    parcel :: Parcel,
-    -- | Address verifications to request (e.g. @["delivery"]@).
-    --
-    -- When empty, no @verify@ key is emitted so the request body is
-    -- byte-identical to callers that don't request verification.
-    verify :: [Text]
+-- @weight@ is always emitted; the dimensional fields and predefined package
+-- are emitted only when 'Just'.
+data ParcelParams = ParcelParams
+  { -- | Length in inches.
+    length :: Maybe Double,
+    -- | Width in inches.
+    width :: Maybe Double,
+    -- | Height in inches.
+    height :: Maybe Double,
+    -- | Weight in ounces.
+    weight :: Double,
+    -- | Predefined package type (e.g. @"FlatRateEnvelope"@).
+    predefinedPackage :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
 
-instance ToJSON ShipmentCreate where
-  toJSON sc =
-    Aeson.object
-      ( [ "shipment"
-            Aeson..= Aeson.object
-              [ "from_address" Aeson..= sc.fromAddress,
-                "to_address" Aeson..= sc.toAddress,
-                "parcel" Aeson..= sc.parcel
-              ]
-        ]
-          <> verifyField
-      )
-    where
-      -- EasyPost expects @verify@ at the ROOT of the request body, as a sibling
-      -- of the @shipment@ object (same pattern as the Address API's
-      -- @{"address": {...}, "verify": ...}@) — NOT nested inside @shipment@.
-      -- Emitted only when non-empty so non-verifying callers are unaffected.
-      verifyField
-        | null sc.verify = []
-        | otherwise = ["verify" Aeson..= sc.verify]
-
---------------------------------------------------------------------------------
--- Label
-
--- | A postage label returned by EasyPost after purchasing a shipment.
-newtype Label = Label
-  { -- | URL to download the label PDF or PNG.
-    labelUrl :: Text
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance ToJSON Label where
-  toJSON l =
-    Aeson.object
-      [ "label_url" Aeson..= l.labelUrl
+instance ToJSON ParcelParams where
+  toJSON p =
+    Aeson.object $
+      [ "weight" Aeson..= p.weight
       ]
-
-instance FromJSON Label where
-  parseJSON = Aeson.withObject "Label" $ \o ->
-    Label
-      <$> o Aeson..: "label_url"
+        <> optional "length" p.length
+        <> optional "width" p.width
+        <> optional "height" p.height
+        <> optional "predefined_package" p.predefinedPackage
 
 --------------------------------------------------------------------------------
--- Rate
+-- Rate (response)
 
 -- | A shipping rate option returned by EasyPost.
 data Rate = Rate
   { -- | Unique rate identifier (e.g. @"rate_abc123"@).
     id :: Text,
-    -- | Carrier name (e.g. @"USPS"@, @"UPS"@).
-    carrier :: Text,
+    -- | Object type, always @"Rate"@.
+    object :: Text,
+    -- | Environment mode, @"test"@ or @"production"@.
+    mode :: Text,
     -- | Service level (e.g. @"Priority"@, @"Express"@).
     service :: Text,
+    -- | Carrier name (e.g. @"USPS"@, @"UPS"@).
+    carrier :: Text,
+    -- | Carrier account identifier, when a carrier account was used.
+    carrierAccountId :: Maybe Text,
+    -- | Identifier of the shipment this rate belongs to.
+    shipmentId :: Text,
     -- | Rate amount as a string (e.g. @"7.58"@).
     rate :: Text,
-    -- | Three-letter currency code (e.g. @"USD"@).
+    -- | Three-letter currency code for 'rate' (e.g. @"USD"@).
     currency :: Text,
+    -- | Retail rate amount as a string.
+    retailRate :: Maybe Text,
+    -- | Currency for 'retailRate'.
+    retailCurrency :: Maybe Text,
+    -- | List rate amount as a string.
+    listRate :: Maybe Text,
+    -- | Currency for 'listRate'.
+    listCurrency :: Maybe Text,
     -- | Estimated delivery days, if available.
-    deliveryDays :: Maybe Int
+    deliveryDays :: Maybe Int,
+    -- | Estimated delivery date, if available.
+    deliveryDate :: Maybe UTCTime,
+    -- | Whether the delivery date is guaranteed.
+    deliveryDateGuaranteed :: Bool,
+    -- | Estimated delivery days (carrier estimate).
+    estDeliveryDays :: Maybe Int,
+    -- | Billing type for this rate.
+    billingType :: Maybe Text,
+    -- | Creation timestamp.
+    createdAt :: UTCTime,
+    -- | Last-update timestamp.
+    updatedAt :: UTCTime
   }
   deriving stock (Show, Eq, Generic)
 
-instance ToJSON Rate where
-  toJSON r =
-    Aeson.object $
-      [ "id" Aeson..= r.id,
-        "carrier" Aeson..= r.carrier,
-        "service" Aeson..= r.service,
-        "rate" Aeson..= r.rate,
-        "currency" Aeson..= r.currency
-      ]
-        <> maybe [] (\d -> ["delivery_days" Aeson..= d]) r.deliveryDays
-
 instance FromJSON Rate where
-  parseJSON = Aeson.withObject "Rate" $ \o ->
-    Rate
-      <$> o Aeson..: "id"
-      <*> o Aeson..: "carrier"
-      <*> o Aeson..: "service"
-      <*> o Aeson..: "rate"
-      <*> o Aeson..: "currency"
-      <*> o Aeson..:? "delivery_days"
+  parseJSON = Aeson.genericParseJSON jsonOptions
 
 --------------------------------------------------------------------------------
--- Shipment
+-- Postage Label (response)
+
+-- | A postage label returned by EasyPost after purchasing a shipment.
+--
+-- Only 'labelUrl' is guaranteed present when a label exists; the format-,
+-- resolution-, and alternate-URL fields are optional.
+data PostageLabel = PostageLabel
+  { -- | Unique label identifier (e.g. @"pl_abc123"@).
+    id :: Text,
+    -- | Object type, always @"PostageLabel"@.
+    object :: Text,
+    -- | Creation timestamp.
+    createdAt :: UTCTime,
+    -- | Last-update timestamp.
+    updatedAt :: UTCTime,
+    -- | Number of days the label date was advanced.
+    dateAdvance :: Maybe Int,
+    -- | Integrated form type, when present.
+    integratedForm :: Maybe Text,
+    -- | The label date.
+    labelDate :: Maybe UTCTime,
+    -- | URL to the EPL2-format label.
+    labelEpl2Url :: Maybe Text,
+    -- | Label file type (e.g. @"image/png"@).
+    labelFileType :: Maybe Text,
+    -- | URL to the PDF-format label.
+    labelPdfUrl :: Maybe Text,
+    -- | Label resolution in DPI.
+    labelResolution :: Maybe Int,
+    -- | Label size (e.g. @"4x6"@).
+    labelSize :: Maybe Text,
+    -- | Label type.
+    labelType :: Maybe Text,
+    -- | URL to download the label; always present when a label exists.
+    labelUrl :: Text,
+    -- | URL to the ZPL-format label.
+    labelZplUrl :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON PostageLabel where
+  parseJSON = Aeson.genericParseJSON jsonOptions
+
+--------------------------------------------------------------------------------
+-- Shipment (response)
 
 -- | An EasyPost shipment object.
 --
 -- Returned from both the create and buy endpoints. After creation, 'rates'
 -- will be populated. After purchasing, 'trackingCode' and 'postageLabel'
 -- will be present.
+--
+-- Several nested objects are not yet modeled as dedicated types and are
+-- retained as raw JSON 'Value's.
 data Shipment = Shipment
   { -- | Unique shipment identifier (e.g. @"shp_abc123"@).
     id :: Text,
+    -- | Object type, always @"Shipment"@.
+    object :: Text,
+    -- | Environment mode, @"test"@ or @"production"@.
+    mode :: Text,
+    -- | Creation timestamp.
+    createdAt :: UTCTime,
+    -- | Last-update timestamp.
+    updatedAt :: UTCTime,
+    -- | Caller-supplied reference.
+    reference :: Maybe Text,
+    -- | Destination address.
+    toAddress :: Address,
+    -- | Origin address.
+    fromAddress :: Address,
+    -- | Return address, when distinct.
+    returnAddress :: Maybe Address,
+    -- | Buyer address, when distinct.
+    buyerAddress :: Maybe Address,
+    -- | Package dimensions and weight.
+    parcel :: Parcel,
+    -- | Customs information. Not yet modeled as a dedicated type; retained as
+    -- raw JSON.
+    customsInfo :: Maybe Value,
     -- | Available shipping rates.
     rates :: [Rate],
+    -- | The purchased rate, present after buying.
+    selectedRate :: Maybe Rate,
+    -- | Postage label, present after purchase.
+    postageLabel :: Maybe PostageLabel,
     -- | Tracking code, present after purchase.
     trackingCode :: Maybe Text,
-    -- | Postage label, present after purchase.
-    postageLabel :: Maybe Label,
-    -- | Delivery verification result for the to-address, when EasyPost
-    -- was asked to verify the shipment and returned a verification block.
-    --
-    -- Parsed from @to_address.verifications.delivery@; 'Nothing' when any
-    -- of those keys are absent.
-    toAddressDeliveryVerification :: Maybe Verification
+    -- | Tracker object. Not yet modeled as a dedicated type; retained as raw
+    -- JSON.
+    tracker :: Maybe Value,
+    -- | Shipment options. Not yet modeled as a dedicated type; retained as raw
+    -- JSON.
+    options :: Maybe Value,
+    -- | Carrier messages. Not yet modeled as dedicated types; retained as raw
+    -- JSON.
+    messages :: [Value],
+    -- | Current status.
+    status :: Maybe Text,
+    -- | Refund status, when a refund was requested.
+    refundStatus :: Maybe Text,
+    -- | Whether this is a return shipment.
+    isReturn :: Bool,
+    -- | Insurance amount as a string.
+    insurance :: Maybe Text,
+    -- | USPS zone, when applicable.
+    uspsZone :: Maybe Int,
+    -- | Identifier of the batch this shipment belongs to.
+    batchId :: Maybe Text,
+    -- | Batch status.
+    batchStatus :: Maybe Text,
+    -- | Batch message.
+    batchMessage :: Maybe Text,
+    -- | Customs/compliance forms. Not yet modeled as dedicated types; retained
+    -- as raw JSON.
+    forms :: [Value],
+    -- | Fees applied to the shipment. Not yet modeled as dedicated types;
+    -- retained as raw JSON.
+    fees :: [Value],
+    -- | Identifier of the order this shipment belongs to.
+    orderId :: Maybe Text,
+    -- | Scan form object. Not yet modeled as a dedicated type; retained as raw
+    -- JSON.
+    scanForm :: Maybe Value,
+    -- | Line items. Not yet modeled as a dedicated type; retained as raw JSON.
+    lineItems :: Maybe Value
   }
   deriving stock (Show, Eq, Generic)
 
-instance ToJSON Shipment where
-  toJSON s =
-    Aeson.object $
-      [ "id" Aeson..= s.id,
-        "rates" Aeson..= s.rates
-      ]
-        <> maybe [] (\tc -> ["tracking_code" Aeson..= tc]) s.trackingCode
-        <> maybe [] (\pl -> ["postage_label" Aeson..= pl]) s.postageLabel
-
 instance FromJSON Shipment where
-  parseJSON = Aeson.withObject "Shipment" $ \o -> do
-    shipmentId <- o Aeson..: "id"
-    rates <- o Aeson..:? "rates" Aeson..!= []
-    trackingCode <- o Aeson..:? "tracking_code"
-    postageLabel <- o Aeson..:? "postage_label"
-    -- Dig through @to_address.verifications.delivery@ defensively: any
-    -- missing intermediate key yields 'Nothing' rather than a parse error.
-    mToAddress <- o Aeson..:? "to_address" :: Aeson.Parser (Maybe Aeson.Object)
-    deliveryVerification <- case mToAddress of
-      Nothing -> pure Nothing
-      Just toAddr -> do
-        mVerifications <- toAddr Aeson..:? "verifications" :: Aeson.Parser (Maybe Aeson.Object)
-        case mVerifications of
-          Nothing -> pure Nothing
-          Just verifications -> verifications Aeson..:? "delivery"
-    pure
-      Shipment
-        { id = shipmentId,
-          rates = rates,
-          trackingCode = trackingCode,
-          postageLabel = postageLabel,
-          toAddressDeliveryVerification = deliveryVerification
-        }
+  parseJSON = Aeson.withObject "Shipment" $ \o ->
+    Shipment
+      <$> o Aeson..: "id"
+      <*> o Aeson..: "object"
+      <*> o Aeson..: "mode"
+      <*> o Aeson..: "created_at"
+      <*> o Aeson..: "updated_at"
+      <*> o Aeson..:? "reference"
+      <*> o Aeson..: "to_address"
+      <*> o Aeson..: "from_address"
+      <*> o Aeson..:? "return_address"
+      <*> o Aeson..:? "buyer_address"
+      <*> o Aeson..: "parcel"
+      <*> o Aeson..:? "customs_info"
+      <*> o Aeson..:? "rates" Aeson..!= []
+      <*> o Aeson..:? "selected_rate"
+      <*> o Aeson..:? "postage_label"
+      <*> o Aeson..:? "tracking_code"
+      <*> o Aeson..:? "tracker"
+      <*> o Aeson..:? "options"
+      <*> o Aeson..:? "messages" Aeson..!= []
+      <*> o Aeson..:? "status"
+      <*> o Aeson..:? "refund_status"
+      <*> o Aeson..:? "is_return" Aeson..!= False
+      <*> o Aeson..:? "insurance"
+      <*> o Aeson..:? "usps_zone"
+      <*> o Aeson..:? "batch_id"
+      <*> o Aeson..:? "batch_status"
+      <*> o Aeson..:? "batch_message"
+      <*> o Aeson..:? "forms" Aeson..!= []
+      <*> o Aeson..:? "fees" Aeson..!= []
+      <*> o Aeson..:? "order_id"
+      <*> o Aeson..:? "scan_form"
+      <*> o Aeson..:? "line_items"
+
+--------------------------------------------------------------------------------
+-- Shipment (request)
+
+-- | Parameters for creating a new EasyPost shipment.
+--
+-- Serializes with everything nested under a top-level @shipment@ object:
+-- @{"shipment": {"from_address": ..., "to_address": ..., "parcel": ...}}@.
+--
+-- Address verification is expressed via the @verify@\/@verify_strict@\/
+-- @verify_carrier@ fields on the 'AddressParams' — there is no shipment-level
+-- verify key.
+data ShipmentParams = ShipmentParams
+  { -- | Origin address.
+    fromAddress :: AddressParams,
+    -- | Destination address.
+    toAddress :: AddressParams,
+    -- | Package dimensions and weight.
+    parcel :: ParcelParams,
+    -- | Carrier account identifiers to rate against; emitted only when
+    -- non-empty.
+    carrierAccounts :: [Text],
+    -- | Requested service level.
+    service :: Maybe Text,
+    -- | Caller-supplied reference.
+    reference :: Maybe Text,
+    -- | Customs information. Not yet modeled as a dedicated type; passed
+    -- through as raw JSON.
+    customsInfo :: Maybe Value,
+    -- | Shipment options. Not yet modeled as a dedicated type; passed through
+    -- as raw JSON.
+    options :: Maybe Value,
+    -- | Whether this is a return shipment.
+    isReturn :: Maybe Bool
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON ShipmentParams where
+  toJSON sc =
+    Aeson.object
+      [ "shipment" Aeson..= Aeson.object shipmentFields
+      ]
+    where
+      shipmentFields =
+        [ "from_address" Aeson..= sc.fromAddress,
+          "to_address" Aeson..= sc.toAddress,
+          "parcel" Aeson..= sc.parcel
+        ]
+          <> optionalList "carrier_accounts" sc.carrierAccounts
+          <> optional "service" sc.service
+          <> optional "reference" sc.reference
+          <> optional "customs_info" sc.customsInfo
+          <> optional "options" sc.options
+          <> optional "is_return" sc.isReturn
+
+--------------------------------------------------------------------------------
+-- Shipment Buy (request)
+
+-- | Parameters for purchasing a shipment at a specific rate.
+--
+-- Serializes as @{"rate": {"id": ...}}@, plus @insurance@ when requested.
+data ShipmentBuy = ShipmentBuy
+  { -- | The rate identifier to purchase.
+    rateId :: Text,
+    -- | Insurance amount to purchase, as a string.
+    insurance :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON ShipmentBuy where
+  toJSON sb =
+    Aeson.object $
+      [ "rate"
+          Aeson..= Aeson.object
+            [ "id" Aeson..= sb.rateId
+            ]
+      ]
+        <> optional "insurance" sb.insurance
 
 --------------------------------------------------------------------------------
 -- Errors
@@ -291,29 +611,34 @@ instance FromJSON Shipment where
 -- | A single field-level error reported by EasyPost.
 --
 -- EasyPost returns @errors@ array items as either an object with
--- @field@/@message@/@suggestion@ keys, or a bare JSON string. Both shapes
--- decode here; a bare string populates 'message' with the other fields empty.
+-- @field@\/@message@\/@suggestion@\/@code@ keys, or a bare JSON string. Both
+-- shapes decode here; a bare string populates 'message' with the other fields
+-- empty.
 data EasyPostFieldError = EasyPostFieldError
   { -- | The offending request field, when identified.
     field :: Maybe Text,
     -- | Human-readable description of the problem.
     message :: Text,
     -- | Suggested correction, when EasyPost offers one.
-    suggestion :: Maybe Text
+    suggestion :: Maybe Text,
+    -- | Machine-readable field-level code (e.g. @"E.ADDRESS.NOT_FOUND"@).
+    code :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON EasyPostFieldError where
   parseJSON = \case
-    Aeson.String s -> pure (EasyPostFieldError Nothing s Nothing)
+    Aeson.String s -> pure (EasyPostFieldError Nothing s Nothing Nothing)
     v ->
       flip (Aeson.withObject "EasyPostFieldError") v $ \o ->
         EasyPostFieldError
           <$> o Aeson..:? "field"
           <*> o Aeson..: "message"
           <*> o Aeson..:? "suggestion"
+          <*> o Aeson..:? "code"
 
--- | A structured EasyPost API error, unwrapped from the @{"error": {...}}@ envelope.
+-- | A structured EasyPost API error, unwrapped from the @{"error": {...}}@
+-- envelope.
 data EasyPostError = EasyPostError
   { -- | Machine-readable error code (e.g. @"ADDRESS.VERIFY.FAILURE"@).
     code :: Text,
@@ -333,43 +658,13 @@ instance FromJSON EasyPostError where
       <*> o Aeson..:? "errors" Aeson..!= []
 
 --------------------------------------------------------------------------------
--- Verification
+-- Encoding helpers
 
--- | An EasyPost address verification result.
---
--- Parsed from a shipment's @to_address.verifications.delivery@ block.
-data Verification = Verification
-  { -- | Whether the address passed verification.
-    success :: Bool,
-    -- | Verification errors, when the address failed.
-    errors :: [EasyPostFieldError]
-  }
-  deriving stock (Show, Eq, Generic)
+-- | Emit a JSON key/value pair only when the value is 'Just'.
+optional :: (ToJSON a) => Aeson.Key -> Maybe a -> [Aeson.Pair]
+optional key = maybe [] (\v -> [key Aeson..= v])
 
-instance FromJSON Verification where
-  parseJSON = Aeson.withObject "Verification" $ \o ->
-    Verification
-      <$> o Aeson..: "success"
-      <*> o Aeson..:? "errors" Aeson..!= []
-
---------------------------------------------------------------------------------
--- Shipment Buy
-
--- | Parameters for purchasing a shipment at a specific rate.
---
--- Serializes as @{"rate": {"id": ...}}@ to match the EasyPost API's
--- expected request body.
-newtype ShipmentBuy = ShipmentBuy
-  { -- | The rate identifier to purchase.
-    rateId :: Text
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance ToJSON ShipmentBuy where
-  toJSON sb =
-    Aeson.object
-      [ "rate"
-          Aeson..= Aeson.object
-            [ "id" Aeson..= sb.rateId
-            ]
-      ]
+-- | Emit a JSON key/list pair only when the list is non-empty.
+optionalList :: (ToJSON a) => Aeson.Key -> [a] -> [Aeson.Pair]
+optionalList _ [] = []
+optionalList key xs = [key Aeson..= xs]

--- a/lib/easypost-http/test/EasyPost/IntegrationSpec.hs
+++ b/lib/easypost-http/test/EasyPost/IntegrationSpec.hs
@@ -25,40 +25,80 @@ withEasyPost action = do
       action key mgr
 
 -- | Test addresses using EasyPost's recommended test values.
-fromAddress :: Address
+fromAddress :: AddressParams
 fromAddress =
-  Address
-    { name = "KPBJ 95.9FM",
+  AddressParams
+    { name = Just "KPBJ 95.9FM",
+      company = Nothing,
       street1 = "417 Montgomery Street",
       street2 = Just "Floor 5",
       city = "San Francisco",
       state = "CA",
       zip = "94104",
-      country = "US"
+      country = "US",
+      phone = Nothing,
+      email = Nothing,
+      federalTaxId = Nothing,
+      stateTaxId = Nothing,
+      residential = Nothing,
+      carrierFacility = Nothing,
+      verify = [],
+      verifyStrict = [],
+      verifyCarrier = []
     }
 
-toAddress :: Address
+toAddress :: AddressParams
 toAddress =
-  Address
-    { name = "Jane Doe",
+  AddressParams
+    { name = Just "Jane Doe",
+      company = Nothing,
       street1 = "388 Townsend St",
       street2 = Just "Apt 20",
       city = "San Francisco",
       state = "CA",
       zip = "94107",
-      country = "US"
+      country = "US",
+      phone = Nothing,
+      email = Nothing,
+      federalTaxId = Nothing,
+      stateTaxId = Nothing,
+      residential = Nothing,
+      carrierFacility = Nothing,
+      verify = [],
+      verifyStrict = [],
+      verifyCarrier = []
+    }
+
+-- | Build a shipment create request with the test addresses and a parcel of
+-- the given weight (in ounces).
+mkShipmentParams :: Double -> ShipmentParams
+mkShipmentParams weight =
+  ShipmentParams
+    { fromAddress = fromAddress,
+      toAddress = toAddress,
+      parcel =
+        -- EasyPost create-validation requires all three dimensions once any is
+        -- present, and USPS refuses to rate a dimensionless parcel — so we send
+        -- a representative poly-mailer size (inches) alongside the weight.
+        ParcelParams
+          { weight = weight,
+            length = Just 13,
+            width = Just 10,
+            height = Just 1,
+            predefinedPackage = Nothing
+          },
+      carrierAccounts = [],
+      service = Nothing,
+      reference = Nothing,
+      customsInfo = Nothing,
+      options = Nothing,
+      isReturn = Nothing
     }
 
 spec :: Spec
 spec = describe "EasyPost Integration (live test API)" $ do
   it "creates a shipment and gets rates" $ withEasyPost $ \key mgr -> do
-    let sc =
-          ShipmentCreate
-            { fromAddress = fromAddress,
-              toAddress = toAddress,
-              parcel = Parcel {weight = 16.0},
-              verify = []
-            }
+    let sc = mkShipmentParams 16.0
 
     createResult <- createShipment mgr key sc
     case createResult of
@@ -76,13 +116,7 @@ spec = describe "EasyPost Integration (live test API)" $ do
           ) shipment.rates
 
   it "retrieves a shipment by ID" $ withEasyPost $ \key mgr -> do
-    let sc =
-          ShipmentCreate
-            { fromAddress = fromAddress,
-              toAddress = toAddress,
-              parcel = Parcel {weight = 8.0},
-              verify = []
-            }
+    let sc = mkShipmentParams 8.0
 
     createResult <- createShipment mgr key sc
     case createResult of
@@ -95,13 +129,7 @@ spec = describe "EasyPost Integration (live test API)" $ do
             shipment'.id `shouldBe` shipment.id
 
   it "buys a shipment and gets tracking + label" $ withEasyPost $ \key mgr -> do
-    let sc =
-          ShipmentCreate
-            { fromAddress = fromAddress,
-              toAddress = toAddress,
-              parcel = Parcel {weight = 10.0},
-              verify = []
-            }
+    let sc = mkShipmentParams 10.0
 
     createResult <- createShipment mgr key sc
     case createResult of
@@ -111,7 +139,7 @@ spec = describe "EasyPost Integration (live test API)" $ do
         case shipment.rates of
           [] -> fail "No rates returned"
           (cheapest : _) -> do
-            let buy = ShipmentBuy {rateId = cheapest.id}
+            let buy = ShipmentBuy {rateId = cheapest.id, insurance = Nothing}
             buyResult <- buyShipment mgr key shipment.id buy
             case buyResult of
               Left err -> fail $ "Failed to buy shipment: " <> show err

--- a/lib/easypost-http/test/EasyPost/TypesSpec.hs
+++ b/lib/easypost-http/test/EasyPost/TypesSpec.hs
@@ -4,10 +4,12 @@ module EasyPost.TypesSpec where
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy (ByteString)
 import EasyPost.Types
-  ( EasyPostError (..),
+  ( Address (..),
+    EasyPostError (..),
     EasyPostFieldError (..),
     Shipment (..),
     Verification (..),
+    Verifications (..),
   )
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -27,7 +29,8 @@ spec = do
                 [ EasyPostFieldError
                     { field = Just "shipment.parcel.weight",
                       message = "must be greater than 0",
-                      suggestion = Nothing
+                      suggestion = Nothing,
+                      code = Nothing
                     }
                 ]
             }
@@ -35,7 +38,7 @@ spec = do
     it "decodes an ADDRESS.VERIFY.FAILURE error with a null suggestion" $ do
       let body :: ByteString
           body =
-            "{\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\",\"errors\":[{\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}]}}"
+            "{\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\",\"errors\":[{\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null,\"code\":\"E.ADDRESS.NOT_FOUND\"}]}}"
       Aeson.decode body
         `shouldBe` Just
           EasyPostError
@@ -45,7 +48,8 @@ spec = do
                 [ EasyPostFieldError
                     { field = Just "street1",
                       message = "House number is missing",
-                      suggestion = Nothing
+                      suggestion = Nothing,
+                      code = Just "E.ADDRESS.NOT_FOUND"
                     }
                 ]
             }
@@ -63,7 +67,8 @@ spec = do
                 [ EasyPostFieldError
                     { field = Nothing,
                       message = "a bare string error",
-                      suggestion = Nothing
+                      suggestion = Nothing,
+                      code = Nothing
                     }
                 ]
             }
@@ -72,9 +77,9 @@ spec = do
     it "decodes a failed to_address delivery verification" $ do
       let body :: ByteString
           body =
-            "{\"id\":\"shp_1\",\"rates\":[],\"to_address\":{\"verifications\":{\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null}}}}"
+            "{\"id\":\"shp_1\",\"object\":\"Shipment\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\",\"rates\":[],\"parcel\":{\"id\":\"prcl_1\",\"object\":\"Parcel\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\",\"weight\":16.0},\"from_address\":{\"id\":\"adr_from\",\"object\":\"Address\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\"},\"to_address\":{\"id\":\"adr_to\",\"object\":\"Address\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\",\"verifications\":{\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null}}}}"
           mShipment = Aeson.decode body :: Maybe Shipment
-      fmap (.toAddressDeliveryVerification) mShipment
+      fmap (\s -> s.toAddress.verifications >>= (.delivery)) mShipment
         `shouldBe` Just
           ( Just
               Verification
@@ -83,15 +88,18 @@ spec = do
                     [ EasyPostFieldError
                         { field = Just "address",
                           message = "Address not found",
-                          suggestion = Nothing
+                          suggestion = Nothing,
+                          code = Just "E.ADDRESS.NOT_FOUND"
                         }
-                    ]
+                    ],
+                  details = Nothing
                 }
           )
 
     it "yields Nothing when verifications are absent" $ do
       let body :: ByteString
-          body = "{\"id\":\"shp_2\",\"rates\":[]}"
+          body =
+            "{\"id\":\"shp_2\",\"object\":\"Shipment\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\",\"rates\":[],\"parcel\":{\"id\":\"prcl_2\",\"object\":\"Parcel\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\",\"weight\":8.0},\"from_address\":{\"id\":\"adr_from\",\"object\":\"Address\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\"},\"to_address\":{\"id\":\"adr_to\",\"object\":\"Address\",\"mode\":\"test\",\"created_at\":\"2025-05-09T20:37:54Z\",\"updated_at\":\"2025-05-09T20:37:54Z\"}}"
           mShipment = Aeson.decode body :: Maybe Shipment
-      fmap (.toAddressDeliveryVerification) mShipment
+      fmap (\s -> s.toAddress.verifications) mShipment
         `shouldBe` Just Nothing

--- a/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
+++ b/services/web/src/API/Dashboard/Store/Orders/Id/Label/Post/Handler.hs
@@ -32,13 +32,13 @@ import Data.Text qualified as Text
 import Domain.Types.Cookie (Cookie)
 import EasyPost.Client (EasyPostClientError (..), buyShipment, createShipment)
 import EasyPost.Types
-  ( Address (..),
+  ( AddressParams (..),
     EasyPostApiKey,
-    Label (..),
-    Parcel (..),
+    ParcelParams (..),
+    PostageLabel (..),
     Shipment (..),
     ShipmentBuy (..),
-    ShipmentCreate (..),
+    ShipmentParams (..),
   )
 import Effects.Database.Execute (execQueryThrow)
 import Effects.Database.Tables.OrderItems qualified as OrderItems
@@ -115,7 +115,7 @@ buyLabelAndUpdate orderId form = do
   let shipmentId = lfShipmentId form
       rateId = lfRateId form
 
-  result <- liftIO $ buyShipment manager apiKey shipmentId (ShipmentBuy rateId)
+  result <- liftIO $ buyShipment manager apiKey shipmentId (ShipmentBuy {rateId = rateId, insurance = Nothing})
 
   case result of
     Left (EasyPostClientError err) -> do
@@ -123,7 +123,7 @@ buyLabelAndUpdate orderId form = do
       pure $ renderBanner Error "Label Error" (easyPostFailureMessage (EasyPostClientError err))
     Right shipment -> do
       let trackingNumber = fromMaybe "" shipment.trackingCode
-          mLabelUrl = fmap (\(Label url) -> url) shipment.postageLabel
+          mLabelUrl = fmap (.labelUrl) shipment.postageLabel
       lift $
         void $
           execQueryThrow
@@ -166,33 +166,59 @@ itemWeight item = do
 
   pure (effectiveWeight * item.oiQuantity)
 
--- | Build an EasyPost ShipmentCreate from the order and store settings.
+-- | Build an EasyPost ShipmentParams from the order and store settings.
+--
+-- Ships in the larger 14.5×19 mailer (hardcoded parcel dimensions) — USPS
+-- requires all three dimensions or it returns zero rates.
 buildShipmentCreate ::
   Orders.Model ->
   StoreSettings.Model ->
   Double ->
-  ShipmentCreate
+  ShipmentParams
 buildShipmentCreate order settings totalWeightOz =
-  ShipmentCreate
+  ShipmentParams
     { fromAddress = fromAddr,
       toAddress = toAddr,
-      parcel = Parcel {weight = totalWeightOz},
-      verify = []
+      parcel =
+        ParcelParams
+          { weight = totalWeightOz,
+            length = Just 19,
+            width = Just 14.5,
+            height = Just 1,
+            predefinedPackage = Nothing
+          },
+      carrierAccounts = [],
+      service = Nothing,
+      reference = Nothing,
+      customsInfo = Nothing,
+      options = Nothing,
+      isReturn = Nothing
     }
   where
     fromAddr =
-      Address
-        { name = settings.ssShipFromName,
+      AddressParams
+        { name = Just settings.ssShipFromName,
+          company = Nothing,
           street1 = settings.ssShipFromAddressLine1,
           street2 = Nothing,
           city = settings.ssShipFromCity,
           state = settings.ssShipFromState,
           zip = settings.ssShipFromZip,
-          country = settings.ssShipFromCountry
+          country = settings.ssShipFromCountry,
+          phone = Nothing,
+          email = Nothing,
+          federalTaxId = Nothing,
+          stateTaxId = Nothing,
+          residential = Nothing,
+          carrierFacility = Nothing,
+          verify = [],
+          verifyStrict = [],
+          verifyCarrier = []
         }
     toAddr =
-      Address
-        { name = order.oShippingFirstName <> " " <> order.oShippingLastName,
+      AddressParams
+        { name = Just (order.oShippingFirstName <> " " <> order.oShippingLastName),
+          company = Nothing,
           street1 = order.oShippingAddressLine1,
           street2 =
             if Text.null order.oShippingAddressLine2
@@ -201,5 +227,14 @@ buildShipmentCreate order settings totalWeightOz =
           city = order.oShippingCity,
           state = order.oShippingState,
           zip = order.oShippingZip,
-          country = order.oShippingCountry
+          country = order.oShippingCountry,
+          phone = Nothing,
+          email = Nothing,
+          federalTaxId = Nothing,
+          stateTaxId = Nothing,
+          residential = Nothing,
+          carrierFacility = Nothing,
+          verify = [],
+          verifyStrict = [],
+          verifyCarrier = []
         }

--- a/services/web/src/API/Store/ShippingRates/Post/Handler.hs
+++ b/services/web/src/API/Store/ShippingRates/Post/Handler.hs
@@ -26,11 +26,11 @@ import Data.Text qualified as Text
 import Domain.Types.Cents (Cents (..))
 import EasyPost.Client (EasyPostClientError (..), createShipment)
 import EasyPost.Types
-  ( Address (..),
+  ( AddressParams (..),
     EasyPostApiKey,
-    Parcel (..),
+    ParcelParams (..),
     Shipment (..),
-    ShipmentCreate (..),
+    ShipmentParams (..),
   )
 import Effects.Database.Execute (execQueryThrow)
 import Effects.Database.Tables.ProductVariants qualified as ProductVariants
@@ -178,39 +178,74 @@ resolveVariant product' variantId qty = do
 
 --------------------------------------------------------------------------------
 
--- | Build the EasyPost ShipmentCreate from request and resolved items.
+-- | Build the EasyPost ShipmentParams from request and resolved items.
+--
+-- Ships in the larger 14.5×19 mailer (hardcoded parcel dimensions) — USPS
+-- requires all three dimensions or it returns zero rates.
 buildShipmentCreate ::
   ShippingRateRequest ->
   StoreSettings.Model ->
   [ResolvedItem] ->
-  ShipmentCreate
+  ShipmentParams
 buildShipmentCreate req settings resolvedItems =
-  ShipmentCreate
+  ShipmentParams
     { fromAddress = fromAddr,
       toAddress = toAddr,
-      parcel = Parcel {weight = totalWeightOz},
-      verify = ["delivery"]
+      parcel =
+        ParcelParams
+          { weight = totalWeightOz,
+            length = Just 19,
+            width = Just 14.5,
+            height = Just 1,
+            predefinedPackage = Nothing
+          },
+      carrierAccounts = [],
+      service = Nothing,
+      reference = Nothing,
+      customsInfo = Nothing,
+      options = Nothing,
+      isReturn = Nothing
     }
   where
     fromAddr =
-      Address
-        { name = settings.ssShipFromName,
+      AddressParams
+        { name = Just settings.ssShipFromName,
+          company = Nothing,
           street1 = settings.ssShipFromAddressLine1,
           street2 = Nothing,
           city = settings.ssShipFromCity,
           state = settings.ssShipFromState,
           zip = settings.ssShipFromZip,
-          country = settings.ssShipFromCountry
+          country = settings.ssShipFromCountry,
+          phone = Nothing,
+          email = Nothing,
+          federalTaxId = Nothing,
+          stateTaxId = Nothing,
+          residential = Nothing,
+          carrierFacility = Nothing,
+          verify = [],
+          verifyStrict = [],
+          verifyCarrier = []
         }
     toAddr =
-      Address
-        { name = req.srrFirstName <> " " <> req.srrLastName,
+      AddressParams
+        { name = Just (req.srrFirstName <> " " <> req.srrLastName),
+          company = Nothing,
           street1 = req.srrAddressLine1,
           street2 = if Text.null req.srrAddressLine2 then Nothing else Just req.srrAddressLine2,
           city = req.srrCity,
           state = req.srrState,
           zip = req.srrZip,
-          country = "US"
+          country = "US",
+          phone = Nothing,
+          email = Nothing,
+          federalTaxId = Nothing,
+          stateTaxId = Nothing,
+          residential = Nothing,
+          carrierFacility = Nothing,
+          verify = ["delivery"],
+          verifyStrict = [],
+          verifyCarrier = []
         }
     totalWeightOz :: Double
     totalWeightOz =

--- a/services/web/src/Store/Checkout/ShippingErrors.hs
+++ b/services/web/src/Store/Checkout/ShippingErrors.hs
@@ -21,10 +21,12 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import EasyPost.Client (EasyPostClientError, easyPostErrorDetails)
 import EasyPost.Types
-  ( EasyPostError (..),
+  ( Address (..),
+    EasyPostError (..),
     EasyPostFieldError (..),
     Shipment (..),
     Verification (..),
+    Verifications (..),
   )
 
 --------------------------------------------------------------------------------
@@ -57,7 +59,7 @@ formatEasyPostError easyPostError =
 -- delivery verification succeeded.
 deliveryVerificationError :: Shipment -> Maybe Text
 deliveryVerificationError shipment =
-  case shipment.toAddressDeliveryVerification of
+  case shipment.toAddress.verifications >>= (.delivery) of
     Just verification
       | not verification.success ->
           Just (fromMaybe genericFallback (formatFieldErrors verification.errors))

--- a/services/web/test/Store/Checkout/ShippingErrorsSpec.hs
+++ b/services/web/test/Store/Checkout/ShippingErrorsSpec.hs
@@ -5,11 +5,15 @@ module Store.Checkout.ShippingErrorsSpec (spec) where
 import Control.Exception (ErrorCall (..), toException)
 import Data.ByteString.Lazy (ByteString)
 import Data.Text (Text)
+import Data.Time (UTCTime)
 import EasyPost.Client (EasyPostClientError (..))
 import EasyPost.Types
-  ( EasyPostFieldError (..),
+  ( Address (..),
+    EasyPostFieldError (..),
+    Parcel (..),
     Shipment (..),
     Verification (..),
+    Verifications (..),
   )
 import Network.HTTP.Types (http11, status422)
 import Servant.Client.Core qualified as Client
@@ -34,15 +38,94 @@ connectionError =
 genericFallback :: Text
 genericFallback = "We couldn't process your shipping address. Please check it and try again."
 
+t0 :: UTCTime
+t0 = read "2025-01-01 00:00:00 UTC"
+
+baseAddress :: Address
+baseAddress =
+  Address
+    { id = "adr_test",
+      object = "Address",
+      mode = "test",
+      createdAt = t0,
+      updatedAt = t0,
+      street1 = Just "388 Townsend St",
+      street2 = Nothing,
+      city = Just "San Francisco",
+      state = Just "CA",
+      zip = Just "94107",
+      country = Just "US",
+      name = Just "Jane Doe",
+      company = Nothing,
+      phone = Nothing,
+      email = Nothing,
+      federalTaxId = Nothing,
+      stateTaxId = Nothing,
+      residential = Nothing,
+      carrierFacility = Nothing,
+      verifications = Nothing
+    }
+
+baseParcel :: Parcel
+baseParcel =
+  Parcel
+    { id = "prcl_test",
+      object = "Parcel",
+      mode = "test",
+      createdAt = t0,
+      updatedAt = t0,
+      length = Nothing,
+      width = Nothing,
+      height = Nothing,
+      weight = 16,
+      predefinedPackage = Nothing
+    }
+
+baseShipment :: Shipment
+baseShipment =
+  Shipment
+    { id = "shp_test",
+      object = "Shipment",
+      mode = "test",
+      createdAt = t0,
+      updatedAt = t0,
+      reference = Nothing,
+      toAddress = baseAddress,
+      fromAddress = baseAddress,
+      returnAddress = Nothing,
+      buyerAddress = Nothing,
+      parcel = baseParcel,
+      customsInfo = Nothing,
+      rates = [],
+      selectedRate = Nothing,
+      postageLabel = Nothing,
+      trackingCode = Nothing,
+      tracker = Nothing,
+      options = Nothing,
+      messages = [],
+      status = Nothing,
+      refundStatus = Nothing,
+      isReturn = False,
+      insurance = Nothing,
+      uspsZone = Nothing,
+      batchId = Nothing,
+      batchStatus = Nothing,
+      batchMessage = Nothing,
+      forms = [],
+      fees = [],
+      orderId = Nothing,
+      scanForm = Nothing,
+      lineItems = Nothing
+    }
+
 -- | Build a shipment carrying only a delivery verification result.
 mkShipment :: Maybe Verification -> Shipment
 mkShipment verification =
-  Shipment
-    { id = "shp_test",
-      rates = [],
-      trackingCode = Nothing,
-      postageLabel = Nothing,
-      toAddressDeliveryVerification = verification
+  baseShipment
+    { toAddress =
+        baseAddress
+          { verifications = Just Verifications {delivery = verification, zip4 = Nothing}
+          }
     }
 
 --------------------------------------------------------------------------------
@@ -85,15 +168,17 @@ spec = do
                   [ EasyPostFieldError
                       { field = Just "address",
                         message = "Address not found",
-                        suggestion = Nothing
+                        suggestion = Nothing,
+                        code = Nothing
                       }
-                  ]
+                  ],
+                details = Nothing
               }
       deliveryVerificationError (mkShipment (Just verification))
         `shouldBe` Just "Address not found"
 
     it "returns Nothing for a successful verification" $ do
-      let verification = Verification {success = True, errors = []}
+      let verification = Verification {success = True, errors = [], details = Nothing}
       deliveryVerificationError (mkShipment (Just verification))
         `shouldBe` Nothing
 


### PR DESCRIPTION
## Summary

Splits the `easypost-http` library's domain types into separate **request** and **response** types with all documented EasyPost fields, and wires the store's checkout/label handlers to the new API. Fixes the store returning **zero USPS shipping rates**.

## Why

EasyPost/USPS returns no rates for a weight-only parcel — it requires all three parcel dimensions, and EasyPost's create-validation is all-or-nothing (any dimension present → all three required). The old `ShipmentCreate` sent weight only, so the shipping-rate endpoint came back empty.

Verified against the live EasyPost test API: with dimensions present, USPS GroundAdvantage/Priority/Express rates return. Rates are **weight-driven** for soft mailers (mailer size and thickness don't move the price), so we ship in a fixed **14.5×19 poly mailer** (`19×14.5×1`) plus the summed item weight.

## Library (`lib/easypost-http`)

- **Request types** (`ToJSON`): `AddressParams`, `ParcelParams`, `ShipmentParams`, `ShipmentBuy`.
- **Response types** (`FromJSON`): `Address`, `Parcel`, `Shipment`, `Rate`, `PostageLabel`, `Verifications`, `VerificationDetails` — all documented fields modeled.
- Address verification (`verify` / `verify_strict` / `verify_carrier`) now rides on the address params, per EasyPost docs (previously a shipment-level key).
- `ShipmentBuy` gained `insurance`; `EasyPostFieldError` gained `code`.

## App (`services/web`)

- Both `buildShipmentCreate` builders use the new types and the hardcoded 14.5×19 mailer dimensions.
- Label URL now read via `.labelUrl` on `PostageLabel`; delivery verification via `shipment.toAddress.verifications >>= (.delivery)`.

## Test plan

- `easypost-http`: **8/8 pass**, including live integration (create → rate → buy) against the EasyPost test API.
- `kpbj-api`: builds clean under `-Wall -Werror`; pure store-checkout specs pass (`ShippingErrors` 8/8, `Store.Checkout.*` 61/61).
- DB-backed integration specs not exercised (tmp-postgres unavailable in the sandbox); none are touched by this change.

## Deferred follow-ups

- Poster shipping (rigid — needs a tube, not a soft mailer).
- Staff mailer-picker UI (mailer choice is price-irrelevant, so v1 hardcodes the larger mailer).
- Optionally populate address `email` / `phone` (email enables EasyPost tracking notifications; phone is needed before UPS/international).

No version bump — release is separate.
